### PR TITLE
feat: added endpoint to allow existing admins to create new admin users

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,13 +1,27 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { AuthService } from './providers/auth.service';
 import { AuthController } from './auth.controller';
+import { ConfigModule } from '@nestjs/config';
+import jwtConfig from './config/jwtConfig';
+import { JwtModule } from '@nestjs/jwt';
 import { UsersModule } from 'src/users/users.module';
+import { HashingProvider } from './providers/hashing.provider';
+import { BcryptProvider } from './providers/bcrypt.provider';
+import { LoginUserProvider } from './providers/loginuser.provider';
+import { GenerateTokensProvider } from './providers/generateTokens.provider';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { RefreshTokenEntity } from './entities/refreshToken.entity';
-import { ConfigModule } from '@nestjs/config';
-import { JwtModule } from '@nestjs/jwt';
+import { RefreshTokenRepositoryOperations } from './providers/RefreshTokenCrud.repository';
+import { ValidateUserProvider } from './providers/validateUser.provider';
 import { PassportModule } from '@nestjs/passport';
-import jwtConfig from './config/jwtConfig';
+import { LocalStrategy } from './strategies/local.strategy';
+import { JwtRefreshStrategy } from './strategies/jwtRefresh.strategy';
+import { RefreshTokensProvider } from './providers/refreshTokens.provider';
+import { FindOneRefreshTokenProvider } from './providers/findOneRefreshToken.provider';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { MailModule } from 'src/mail/mail.module';
+import { RolesGuard } from './guards/roles.guard';
+import { ConfigService } from '@nestjs/config';
 
 @Module({
   imports: [
@@ -21,8 +35,34 @@ import jwtConfig from './config/jwtConfig';
     }),
     forwardRef(() => UsersModule),
     TypeOrmModule.forFeature([RefreshTokenEntity]),
+    MailModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService],
+  providers: [
+    JwtStrategy,
+    LocalStrategy,
+    JwtRefreshStrategy,
+    AuthService,
+    {
+      provide: HashingProvider,
+      useClass: BcryptProvider,
+    },
+    LoginUserProvider,
+    GenerateTokensProvider,
+    RefreshTokenRepositoryOperations,
+    ValidateUserProvider,
+    RefreshTokensProvider,
+    FindOneRefreshTokenProvider,
+    RolesGuard,
+  ],
+  exports: [
+    AuthService,
+    HashingProvider,
+    PassportModule,
+    JwtModule,
+    LocalStrategy,
+    JwtStrategy,
+    JwtRefreshStrategy,
+  ],
 })
 export class AuthModule {}

--- a/backend/src/users/providers/createAdminUser.provider.ts
+++ b/backend/src/users/providers/createAdminUser.provider.ts
@@ -1,0 +1,88 @@
+import {
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+import { CreateAdminDto } from '../dtos/createAdmin.dto';
+import { UserRole } from 'src/auth/enums/roles.enum';
+import { FindOneUserByEmailProvider } from './findOneUserByEmail.provider';
+import { HashingProvider } from 'src/auth/providers/hashing.provider';
+import { InjectRepository } from '@nestjs/typeorm';
+import { User } from '../entities/users.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CreateAdminProvider {
+  constructor(
+    private readonly findOneUserByEmailProvider: FindOneUserByEmailProvider,
+
+    private readonly hashingProvider: HashingProvider,
+
+    @InjectRepository(User)
+    private readonly usersRepository: Repository<User>,
+  ) {}
+
+  public async createAdmin(
+    createAdminDto: CreateAdminDto,
+    creatorRole?: UserRole,
+  ) {
+    // check if the person that wants to create an admin is actually an admin
+    if (creatorRole !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'Only an admin is allowed to create another admin',
+      );
+    }
+
+    // check if the admin user we want to create exists before
+    const existingUser = await this.findOneUserByEmailProvider.findUserByEmail(
+      createAdminDto.email,
+    );
+
+    if (existingUser) {
+      throw new ConflictException('User already exists');
+    }
+
+    // hash the user password
+    let hashedPassword: string;
+
+    try {
+      hashedPassword = await this.hashingProvider.hashPassword(
+        createAdminDto.password,
+      );
+    } catch (error) {
+      throw new InternalServerErrorException(
+        'Error hashing admin user password',
+      );
+    }
+
+    let admin: User;
+
+    // create and save the admin user
+    admin = this.usersRepository.create({
+      ...createAdminDto,
+      password: hashedPassword,
+      role: UserRole.ADMIN,
+    });
+
+    try {
+      admin = await this.usersRepository.save(admin);
+    } catch (error) {
+      throw new InternalServerErrorException(
+        'Failed to save admin due to server error failure',
+      );
+    }
+
+    return {
+      status: true,
+      message: 'Admin user created successfully',
+      admin: {
+        id: admin.id,
+        firstName: admin.firstName,
+        email: admin.email,
+        role: admin.role,
+        createdAt: admin.createdAt,
+      },
+    };
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,13 +1,57 @@
 import { forwardRef, Module } from '@nestjs/common';
-import { UsersService } from './providers/users.service';
 import { UsersController } from './users.controller';
+import { UsersService } from './providers/users.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from './entities/users.entity';
 import { AuthModule } from 'src/auth/auth.module';
-import { User } from './entities/user.entity';
+import { CreateSinlgeUserProvider } from './providers/createsingleuser.provider';
+import { FindOneUserByEmailProvider } from './providers/findOneUserByEmail.provider';
+import { FindOneUserByIdProvider } from './providers/findOneUserById.provider';
+import { ChangePasswordProvider } from './providers/changeUserPassword.provider';
+import { PasswordResetTokenProvider } from './providers/setPasswordResetToken.provider';
+import { ResetPasswordProvider } from './providers/resetPassword.provider';
+import { GenerateRandomTokenProvider } from './providers/generateRandomToken.provider';
+import { EmailVerificationTokenProvider } from './providers/setEmailVerificationToken.provider';
+import { MailModule } from 'src/mail/mail.module';
+import { VerifyEmailProvider } from './providers/verifyEmail.provider';
+import { ResendEmailVerificationProvider } from './providers/resendEmailVerification.provider';
+import { FindAllUsersProvider } from './providers/findAllUsers.provider';
+import { UpdateOneUserProvider } from './providers/updateOneUser.provider';
+import { DeleteOneUserProvider } from './providers/deleteOneUser.provider';
+import { PaginationModule } from 'src/common/pagination/pagination.module';
+import { CreateManyUsersProvider } from './providers/createManyUsers.provider';
+import { DeleteManyUsersProvider } from './providers/deleteManyUsers.provider';
+import { GetUserProfileProvider } from './providers/getUserProfile.provider';
+import { CreateAdminProvider } from './providers/createAdminUser.provider';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => AuthModule)],
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    forwardRef(() => AuthModule),
+    MailModule,
+    PaginationModule,
+  ],
   controllers: [UsersController],
-  providers: [UsersService],
+  providers: [
+    UsersService,
+    CreateSinlgeUserProvider,
+    FindOneUserByEmailProvider,
+    FindOneUserByIdProvider,
+    ChangePasswordProvider,
+    PasswordResetTokenProvider,
+    ResetPasswordProvider,
+    GenerateRandomTokenProvider,
+    EmailVerificationTokenProvider,
+    VerifyEmailProvider,
+    ResendEmailVerificationProvider,
+    FindAllUsersProvider,
+    UpdateOneUserProvider,
+    DeleteOneUserProvider,
+    CreateManyUsersProvider,
+    DeleteManyUsersProvider,
+    GetUserProfileProvider,
+    CreateAdminProvider,
+  ],
+  exports: [UsersService],
 })
 export class UsersModule {}


### PR DESCRIPTION
-Implemented a secured RESTful endpoint for admin creation.
- Only authenticated users with admin privileges can access this route.
- Added role-based access control to return 403 Forbidden for non-admins.
- Performed basic input validation (e.g., valid email and username).
- Ensured proper responses:
   201 Created on success, 400 Bad Request for validation issues, 403 Forbidden for unauthorized users, 500 Internal Server Error for unexpected failures.
- Wrote unit tests to cover:
Successful admin creation by another admin, Forbidden access by regular users, Invalid input scenarios.