### PR TITLE
added upload resources

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -20,6 +20,7 @@ import { JwtAuthGuard } from './auth/guards/jwtAuth.guard';
 import { RolesGuard } from './auth/guards/roles.guard';
 import { PassportModule } from '@nestjs/passport';
 import { LocationModule } from './location/location.module';
+import { FileUpload } from "./upload/entities/file-upload.entity"
 
 const ENV = process.env.NODE_ENV;
 
@@ -60,6 +61,7 @@ const ENV = process.env.NODE_ENV;
     MailModule,
     LoggingModule,
     PaginationModule,
+    FileUpload
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/upload/config/cloudinary.config.ts
+++ b/backend/src/upload/config/cloudinary.config.ts
@@ -1,0 +1,20 @@
+import type { ConfigService } from "@nestjs/config"
+import { v2 as cloudinary } from "cloudinary"
+import { CloudinaryStorage } from "multer-storage-cloudinary"
+
+export const cloudinaryConfig = (configService: ConfigService) => {
+  cloudinary.config({
+    cloud_name: configService.get("CLOUDINARY_CLOUD_NAME"),
+    api_key: configService.get("CLOUDINARY_API_KEY"),
+    api_secret: configService.get("CLOUDINARY_API_SECRET"),
+  })
+
+  return new CloudinaryStorage({
+    cloudinary: cloudinary,
+    params: {
+      folder: "uploads",
+      allowed_formats: ["jpg", "jpeg", "png", "pdf"],
+      transformation: [{ width: 1000, height: 1000, crop: "limit" }],
+    } as any,
+  })
+}

--- a/backend/src/upload/config/multer.config.ts
+++ b/backend/src/upload/config/multer.config.ts
@@ -1,0 +1,64 @@
+import type { MulterOptions } from "@nestjs/platform-express/multer/interfaces/multer-options.interface"
+import type { ConfigService } from "@nestjs/config"
+import { diskStorage } from "multer"
+import { extname, join } from "path"
+import { existsSync, mkdirSync } from "fs"
+import { BadRequestException } from "@nestjs/common"
+
+export const multerConfig = (configService: ConfigService): MulterOptions => {
+  const uploadPath = configService.get("UPLOAD_PATH", "./uploads")
+
+  // Ensure upload directory exists
+  if (!existsSync(uploadPath)) {
+    mkdirSync(uploadPath, { recursive: true })
+  }
+
+  return {
+    storage: diskStorage({
+      destination: (req, file, cb) => {
+        const { uploadType } = req.body
+        let subDir = "general"
+
+        switch (uploadType) {
+          case "proof":
+            subDir = "proofs"
+            break
+          case "kyc":
+            subDir = "kyc-documents"
+            break
+          case "shipment":
+            subDir = "shipment-photos"
+            break
+          case "id":
+            subDir = "id-documents"
+            break
+        }
+
+        const fullPath = join(uploadPath, subDir)
+        if (!existsSync(fullPath)) {
+          mkdirSync(fullPath, { recursive: true })
+        }
+
+        cb(null, fullPath)
+      },
+      filename: (req, file, cb) => {
+        const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9)
+        const ext = extname(file.originalname)
+        cb(null, `${file.fieldname}-${uniqueSuffix}${ext}`)
+      },
+    }),
+    fileFilter: (req, file, cb) => {
+      const allowedMimes = ["image/jpeg", "image/jpg", "image/png", "application/pdf"]
+
+      if (allowedMimes.includes(file.mimetype)) {
+        cb(null, true)
+      } else {
+        cb(new BadRequestException("Invalid file type. Only JPEG, PNG, and PDF files are allowed."), false)
+      }
+    },
+    limits: {
+      fileSize: 10 * 1024 * 1024, // 10MB limit
+      files: 5, // Maximum 5 files per request
+    },
+  }
+}

--- a/backend/src/upload/config/s3.config.ts
+++ b/backend/src/upload/config/s3.config.ts
@@ -1,0 +1,24 @@
+import type { ConfigService } from "@nestjs/config"
+import { S3Client } from "@aws-sdk/client-s3"
+import * as multerS3 from "multer-s3"
+
+export const s3Config = (configService: ConfigService) => {
+  const s3 = new S3Client({
+    region: configService.get("AWS_REGION"),
+    credentials: {
+      accessKeyId: configService.get("AWS_ACCESS_KEY_ID"),
+      secretAccessKey: configService.get("AWS_SECRET_ACCESS_KEY"),
+    },
+  })
+
+  return multerS3({
+    s3: s3,
+    bucket: configService.get("AWS_S3_BUCKET"),
+    acl: "private",
+    key: (req, file, cb) => {
+      const { uploadType } = req.body
+      const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9)
+      cb(null, `${uploadType}/${uniqueSuffix}-${file.originalname}`)
+    },
+  })
+}

--- a/backend/src/upload/dto/upload.dto.ts
+++ b/backend/src/upload/dto/upload.dto.ts
@@ -1,0 +1,68 @@
+import { IsEnum, IsOptional, IsString } from "class-validator"
+import { ApiProperty } from "@nestjs/swagger"
+
+export enum UploadType {
+  PROOF = "proof",
+  KYC = "kyc",
+  SHIPMENT = "shipment",
+  ID = "id",
+  GENERAL = "general",
+}
+
+export class UploadDto {
+  @ApiProperty({
+    enum: UploadType,
+    description: "Type of upload",
+    example: UploadType.PROOF,
+  })
+  @IsEnum(UploadType)
+  uploadType: UploadType
+
+  @ApiProperty({
+    description: "Optional description for the upload",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string
+
+  @ApiProperty({
+    description: "Reference ID (e.g., order ID, user ID)",
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  referenceId?: string
+}
+
+export class UploadResponseDto {
+  @ApiProperty()
+  id: string
+
+  @ApiProperty()
+  filename: string
+
+  @ApiProperty()
+  originalName: string
+
+  @ApiProperty()
+  mimetype: string
+
+  @ApiProperty()
+  size: number
+
+  @ApiProperty()
+  path: string
+
+  @ApiProperty()
+  uploadType: UploadType
+
+  @ApiProperty()
+  uploadedAt: Date
+
+  @ApiProperty({ required: false })
+  description?: string
+
+  @ApiProperty({ required: false })
+  referenceId?: string
+}

--- a/backend/src/upload/entities/file-upload.entity.ts
+++ b/backend/src/upload/entities/file-upload.entity.ts
@@ -1,0 +1,39 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from "typeorm"
+import { UploadType } from "../dto/upload.dto"
+
+@Entity("file_uploads")
+export class FileUpload {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column()
+  filename: string
+
+  @Column()
+  originalName: string
+
+  @Column()
+  mimetype: string
+
+  @Column()
+  size: number
+
+  @Column()
+  path: string
+
+  @Column({
+    type: "enum",
+    enum: UploadType,
+    default: UploadType.GENERAL,
+  })
+  uploadType: UploadType
+
+  @Column({ nullable: true })
+  description?: string
+
+  @Column({ nullable: true })
+  referenceId?: string
+
+  @CreateDateColumn()
+  uploadedAt: Date
+}

--- a/backend/src/upload/upload.controller.ts
+++ b/backend/src/upload/upload.controller.ts
@@ -1,0 +1,136 @@
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  UploadedFiles,
+  Body,
+  Get,
+  Param,
+  Delete,
+  Res,
+  BadRequestException,
+} from "@nestjs/common"
+import { FileInterceptor, FilesInterceptor } from "@nestjs/platform-express"
+import { ApiTags, ApiConsumes, ApiBody, ApiResponse } from "@nestjs/swagger"
+import type { Response } from "express"
+import type { UploadService } from "./upload.service"
+import { type UploadDto, UploadResponseDto } from "./dto/upload.dto"
+import type { Express } from "express"
+
+@ApiTags("Upload")
+@Controller("upload")
+export class UploadController {
+  constructor(private readonly uploadService: UploadService) {}
+
+  @Post("single")
+  @UseInterceptors(FileInterceptor("file"))
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        file: {
+          type: "string",
+          format: "binary",
+        },
+        uploadType: {
+          type: "string",
+          enum: ["proof", "kyc", "shipment", "id", "general"],
+        },
+        description: {
+          type: "string",
+        },
+        referenceId: {
+          type: "string",
+        },
+      },
+    },
+  })
+  @ApiResponse({ type: UploadResponseDto })
+  async uploadSingle(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() uploadDto: UploadDto,
+  ): Promise<UploadResponseDto> {
+    if (!file) {
+      throw new BadRequestException("No file uploaded")
+    }
+
+    return this.uploadService.saveFileRecord(file, uploadDto)
+  }
+
+  @Post("multiple")
+  @UseInterceptors(FilesInterceptor("files", 5))
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        files: {
+          type: "array",
+          items: {
+            type: "string",
+            format: "binary",
+          },
+        },
+        uploadType: {
+          type: "string",
+          enum: ["proof", "kyc", "shipment", "id", "general"],
+        },
+        description: {
+          type: "string",
+        },
+        referenceId: {
+          type: "string",
+        },
+      },
+    },
+  })
+  @ApiResponse({ type: [UploadResponseDto] })
+  async uploadMultiple(
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body() uploadDto: UploadDto,
+  ): Promise<UploadResponseDto[]> {
+    if (!files || files.length === 0) {
+      throw new BadRequestException("No files uploaded")
+    }
+
+    const results = []
+    for (const file of files) {
+      const result = await this.uploadService.saveFileRecord(file, uploadDto)
+      results.push(result)
+    }
+
+    return results
+  }
+
+  @Get(':id')
+  @ApiResponse({ type: UploadResponseDto })
+  async getFile(@Param('id') id: string): Promise<UploadResponseDto> {
+    return this.uploadService.getFileById(id);
+  }
+
+  @Get("download/:id")
+  async downloadFile(@Param('id') id: string, @Res() res: Response) {
+    const file = await this.uploadService.getFileById(id)
+    return res.download(file.path, file.originalName)
+  }
+
+  @Delete(':id')
+  async deleteFile(@Param('id') id: string): Promise<{ message: string }> {
+    await this.uploadService.deleteFile(id);
+    return { message: 'File deleted successfully' };
+  }
+
+  @Get('by-type/:uploadType')
+  @ApiResponse({ type: [UploadResponseDto] })
+  async getFilesByType(@Param('uploadType') uploadType: string): Promise<UploadResponseDto[]> {
+    return this.uploadService.getFilesByType(uploadType);
+  }
+
+  @Get('by-reference/:referenceId')
+  @ApiResponse({ type: [UploadResponseDto] })
+  async getFilesByReference(@Param('referenceId') referenceId: string): Promise<UploadResponseDto[]> {
+    return this.uploadService.getFilesByReference(referenceId);
+  }
+}

--- a/backend/src/upload/upload.module.ts
+++ b/backend/src/upload/upload.module.ts
@@ -1,0 +1,20 @@
+import { Module } from "@nestjs/common"
+import { MulterModule } from "@nestjs/platform-express"
+import { ConfigModule, ConfigService } from "@nestjs/config"
+import { UploadController } from "./upload.controller"
+import { UploadService } from "./upload.service"
+import { multerConfig } from "./config/multer.config"
+
+@Module({
+  imports: [
+    MulterModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => multerConfig(configService),
+      inject: [ConfigService],
+    }),
+  ],
+  controllers: [UploadController],
+  providers: [UploadService],
+  exports: [UploadService],
+})
+export class UploadModule {}

--- a/backend/src/upload/upload.service.ts
+++ b/backend/src/upload/upload.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import { InjectRepository } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { unlink } from "fs/promises"
+import type { UploadDto, UploadResponseDto } from "./dto/upload.dto"
+import { FileUpload } from "./entities/file-upload.entity"
+import type { Express } from "express"
+
+@Injectable()
+export class UploadService {
+  constructor(
+    @InjectRepository(FileUpload)
+    private readonly fileUploadRepository: Repository<FileUpload>,
+  ) {}
+
+  async saveFileRecord(file: Express.Multer.File, uploadDto: UploadDto): Promise<UploadResponseDto> {
+    const fileRecord = this.fileUploadRepository.create({
+      filename: file.filename,
+      originalName: file.originalname,
+      mimetype: file.mimetype,
+      size: file.size,
+      path: file.path,
+      uploadType: uploadDto.uploadType,
+      description: uploadDto.description,
+      referenceId: uploadDto.referenceId,
+    })
+
+    const savedFile = await this.fileUploadRepository.save(fileRecord)
+    return this.mapToResponseDto(savedFile)
+  }
+
+  async getFileById(id: string): Promise<UploadResponseDto> {
+    const file = await this.fileUploadRepository.findOne({ where: { id } })
+    if (!file) {
+      throw new NotFoundException("File not found")
+    }
+    return this.mapToResponseDto(file)
+  }
+
+  async getFilesByType(uploadType: string): Promise<UploadResponseDto[]> {
+    const files = await this.fileUploadRepository.find({
+      where: { uploadType },
+      order: { uploadedAt: "DESC" },
+    })
+    return files.map((file) => this.mapToResponseDto(file))
+  }
+
+  async getFilesByReference(referenceId: string): Promise<UploadResponseDto[]> {
+    const files = await this.fileUploadRepository.find({
+      where: { referenceId },
+      order: { uploadedAt: "DESC" },
+    })
+    return files.map((file) => this.mapToResponseDto(file))
+  }
+
+  async deleteFile(id: string): Promise<void> {
+    const file = await this.fileUploadRepository.findOne({ where: { id } })
+    if (!file) {
+      throw new NotFoundException("File not found")
+    }
+
+    try {
+      await unlink(file.path)
+    } catch (error) {
+      console.error("Error deleting physical file:", error)
+    }
+
+    await this.fileUploadRepository.remove(file)
+  }
+
+  private mapToResponseDto(file: FileUpload): UploadResponseDto {
+    return {
+      id: file.id,
+      filename: file.filename,
+      originalName: file.originalName,
+      mimetype: file.mimetype,
+      size: file.size,
+      path: file.path,
+      uploadType: file.uploadType,
+      uploadedAt: file.uploadedAt,
+      description: file.description,
+      referenceId: file.referenceId,
+    }
+  }
+}


### PR DESCRIPTION
## Setup File Upload Support

- Added file upload support using Multer.
- Accepts JPEG, PNG, and PDF formats.
- Handles uploads for delivery proofs, KYC IDs, and shipment photos.
- Files can be stored locally or in S3/Cloudinary.

closes #190 