### PR TITLE
Create Notifications Module (In-App + Email)

### DIFF
--- a/backend/src/notifications/controllers/email-debug.controller.ts
+++ b/backend/src/notifications/controllers/email-debug.controller.ts
@@ -1,0 +1,32 @@
+import { Controller, Get, Delete, UseGuards } from "@nestjs/common"
+import type { EmailService } from "../services/email.service"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("email-debug")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class EmailDebugController {
+  constructor(private readonly emailService: EmailService) {}
+
+  @Get("queue")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getEmailQueue() {
+    return {
+      queue: this.emailService.getEmailQueue(),
+      queueSize: this.emailService.getQueueSize(),
+    }
+  }
+
+  @Delete("queue")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  clearEmailQueue() {
+    this.emailService.clearEmailQueue()
+    return { message: "Email queue cleared" }
+  }
+}

--- a/backend/src/notifications/controllers/in-app-notifications.controller.ts
+++ b/backend/src/notifications/controllers/in-app-notifications.controller.ts
@@ -1,0 +1,59 @@
+import { Controller, Get, Patch, Delete, Query, UseGuards, ParseIntPipe, DefaultValuePipe } from "@nestjs/common"
+import type { InAppNotificationService } from "../services/in-app-notification.service"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("in-app-notifications")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class InAppNotificationsController {
+  constructor(private readonly inAppService: InAppNotificationService) {}
+
+  @Get("user/:userId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getUserNotifications(userId: string, @Query("limit", new DefaultValuePipe(20), ParseIntPipe) limit: number) {
+    return this.inAppService.getUserNotifications(userId, limit)
+  }
+
+  @Get("user/:userId/unread-count")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getUnreadCount(userId: string) {
+    return this.inAppService.getUnreadCount(userId)
+  }
+
+  @Patch("user/:userId/notification/:notificationId/read")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  markAsRead(userId: string, notificationId: string) {
+    return this.inAppService.markAsRead(userId, notificationId)
+  }
+
+  @Patch("user/:userId/mark-all-read")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  markAllAsRead(userId: string) {
+    return this.inAppService.markAllAsRead(userId)
+  }
+
+  @Delete("user/:userId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  clearUserNotifications(userId: string) {
+    return this.inAppService.clearUserNotifications(userId)
+  }
+
+  @Get("queue/stats")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getQueueStats() {
+    return {
+      queueSize: this.inAppService.getQueueSize(),
+      totalUsers: this.inAppService.getAllQueuedNotifications().then((queue) => queue.size),
+    }
+  }
+}

--- a/backend/src/notifications/controllers/notification-preferences.controller.ts
+++ b/backend/src/notifications/controllers/notification-preferences.controller.ts
@@ -1,0 +1,81 @@
+import { Controller, Get, Post, Patch, Delete, UseGuards } from "@nestjs/common"
+import type { NotificationPreferenceService } from "../services/notification-preference.service"
+import type {
+  CreateNotificationPreferenceDto,
+  UpdateNotificationPreferenceDto,
+  BulkUpdatePreferencesDto,
+} from "../dto/notification-preference.dto"
+import type { NotificationType, NotificationChannel } from "../entities/notification.entity"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("notification-preferences")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class NotificationPreferencesController {
+  constructor(private readonly preferenceService: NotificationPreferenceService) {}
+
+  @Post()
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.USER })
+  create(createPreferenceDto: CreateNotificationPreferenceDto) {
+    return this.preferenceService.create(createPreferenceDto)
+  }
+
+  @Post("bulk-update")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.USER })
+  bulkUpdate(bulkUpdateDto: BulkUpdatePreferencesDto) {
+    return this.preferenceService.bulkUpdatePreferences(bulkUpdateDto)
+  }
+
+  @Post("defaults/:userId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.USER })
+  setDefaults(userId: string) {
+    return this.preferenceService.setDefaultPreferences(userId)
+  }
+
+  @Get("user/:userId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  findByUser(userId: string) {
+    return this.preferenceService.findByUser(userId)
+  }
+
+  @Get("user/:userId/summary")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  getUserSummary(userId: string) {
+    return this.preferenceService.getUserPreferenceSummary(userId)
+  }
+
+  @Get("user/:userId/enabled-channels/:type")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  getEnabledChannels(userId: string, type: NotificationType) {
+    return this.preferenceService.getEnabledChannels(userId, type)
+  }
+
+  @Patch("user/:userId/type/:type/channel/:channel")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.USER })
+  updatePreference(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannel,
+    updateData: UpdateNotificationPreferenceDto,
+  ) {
+    return this.preferenceService.updatePreference(userId, type, channel, updateData)
+  }
+
+  @Delete(":id")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.USER })
+  remove(id: string) {
+    return this.preferenceService.remove(id)
+  }
+}

--- a/backend/src/notifications/controllers/notification-templates.controller.ts
+++ b/backend/src/notifications/controllers/notification-templates.controller.ts
@@ -1,0 +1,79 @@
+import { Controller, Get, Post, Patch, Param, Delete, UseGuards } from "@nestjs/common"
+import type { NotificationTemplateService } from "../services/notification-template.service"
+import type { CreateNotificationTemplateDto } from "../dto/create-template.dto"
+import type { NotificationType, NotificationChannel } from "../entities/notification.entity"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("notification-templates")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class NotificationTemplatesController {
+  constructor(private readonly templateService: NotificationTemplateService) {}
+
+  @Post()
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  create(createTemplateDto: CreateNotificationTemplateDto) {
+    return this.templateService.create(createTemplateDto)
+  }
+
+  @Get()
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findAll() {
+    return this.templateService.findAll()
+  }
+
+  @Get("type/:type/channel/:channel")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findByTypeAndChannel(@Param("type") type: string, @Param("channel") channel: string) {
+    return this.templateService.findByTypeAndChannel(type as NotificationType, channel as NotificationChannel)
+  }
+
+  @Get("name/:name")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findByName(@Param("name") name: string) {
+    return this.templateService.findByName(name)
+  }
+
+  @Get("name/:name/variables")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getTemplateVariables(@Param("name") name: string) {
+    return this.templateService.getTemplateVariables(name)
+  }
+
+  @Post("name/:name/validate")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  validateTemplate(@Param("name") name: string, data: Record<string, any>) {
+    return this.templateService.validateTemplate(name, data)
+  }
+
+  @Post("name/:name/process")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  processTemplate(@Param("name") name: string, data: Record<string, any>) {
+    return this.templateService.processTemplate(name, data)
+  }
+
+  @Patch(":id")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  update(@Param("id") id: string, updateData: Partial<CreateNotificationTemplateDto>) {
+    return this.templateService.update(id, updateData)
+  }
+
+  @Delete(":id")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  remove(@Param("id") id: string) {
+    return this.templateService.remove(id)
+  }
+}

--- a/backend/src/notifications/controllers/notifications.controller.ts
+++ b/backend/src/notifications/controllers/notifications.controller.ts
@@ -1,0 +1,83 @@
+import { Controller, Get, Post, Patch, Param, Query, UseGuards, DefaultValuePipe } from "@nestjs/common"
+import type { NotificationService, NotificationFilters } from "../services/notification.service"
+import type { SendNotificationDto } from "../dto/send-notification.dto"
+import type { NotificationChannel, NotificationStatus } from "../entities/notification.entity"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("notifications")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class NotificationsController {
+  constructor(private readonly notificationService: NotificationService) {}
+
+  @Post("send")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  sendNotification(sendNotificationDto: SendNotificationDto) {
+    return this.notificationService.sendNotification(sendNotificationDto)
+  }
+
+  @Get()
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findAll(
+    @Query("page", new DefaultValuePipe(1)) page: number,
+    @Query("limit", new DefaultValuePipe(10)) limit: number,
+    @Query("recipientId") recipientId?: string,
+    @Query("type") type?: string,
+    @Query("channel") channel?: NotificationChannel,
+    @Query("status") status?: NotificationStatus,
+    @Query("startDate") startDate?: string,
+    @Query("endDate") endDate?: string,
+  ) {
+    const filters: NotificationFilters = {}
+
+    if (recipientId) filters.recipientId = recipientId
+    if (type) filters.type = type
+    if (channel) filters.channel = channel
+    if (status) filters.status = status
+    if (startDate) filters.startDate = new Date(startDate)
+    if (endDate) filters.endDate = new Date(endDate)
+
+    return this.notificationService.findAll(page, limit, filters)
+  }
+
+  @Get("stats")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getStats(@Query("recipientId") recipientId?: string) {
+    return this.notificationService.getNotificationStats(recipientId)
+  }
+
+  @Get("unread-count/:recipientId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  getUnreadCount(@Param("recipientId") recipientId: string) {
+    return this.notificationService.getUnreadCount(recipientId)
+  }
+
+  @Get(":id")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  findOne(@Param("id") id: string) {
+    return this.notificationService.findOne(id)
+  }
+
+  @Patch(":id/read")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  markAsRead(@Param("id") id: string) {
+    return this.notificationService.markAsRead(id)
+  }
+
+  @Patch("bulk-read")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  bulkMarkAsRead(body: { recipientId: string; notificationIds?: string[] }) {
+    return this.notificationService.bulkMarkAsRead(body.recipientId, body.notificationIds)
+  }
+}

--- a/backend/src/notifications/dto/create-notification.dto.ts
+++ b/backend/src/notifications/dto/create-notification.dto.ts
@@ -1,0 +1,76 @@
+import { IsEnum, IsString, IsOptional, IsUUID, IsObject, IsDateString, IsNumber, Min, Max } from "class-validator"
+import { NotificationType, NotificationChannel, NotificationPriority } from "../entities/notification.entity"
+
+export class CreateNotificationDto {
+  @IsEnum(NotificationType)
+  type: NotificationType
+
+  @IsEnum(NotificationChannel)
+  channel: NotificationChannel
+
+  @IsOptional()
+  @IsEnum(NotificationPriority)
+  priority?: NotificationPriority
+
+  @IsUUID()
+  recipientId: string
+
+  @IsString()
+  recipientEmail: string
+
+  @IsOptional()
+  @IsString()
+  recipientName?: string
+
+  @IsString()
+  title: string
+
+  @IsString()
+  message: string
+
+  @IsOptional()
+  @IsObject()
+  data?: Record<string, any>
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+
+  @IsOptional()
+  @IsUUID()
+  relatedEntityId?: string
+
+  @IsOptional()
+  @IsString()
+  relatedEntityType?: string
+
+  @IsOptional()
+  @IsString()
+  actionUrl?: string
+
+  @IsOptional()
+  @IsString()
+  actionText?: string
+
+  @IsOptional()
+  @IsUUID()
+  senderId?: string
+
+  @IsOptional()
+  @IsString()
+  senderName?: string
+
+  @IsOptional()
+  @IsDateString()
+  scheduledAt?: string
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(10)
+  maxRetries?: number
+}

--- a/backend/src/notifications/dto/create-template.dto.ts
+++ b/backend/src/notifications/dto/create-template.dto.ts
@@ -1,0 +1,44 @@
+import { IsEnum, IsString, IsOptional, IsBoolean, IsArray } from "class-validator"
+import { NotificationType, NotificationChannel } from "../entities/notification.entity"
+
+export class CreateNotificationTemplateDto {
+  @IsString()
+  name: string
+
+  @IsEnum(NotificationType)
+  type: NotificationType
+
+  @IsEnum(NotificationChannel)
+  channel: NotificationChannel
+
+  @IsString()
+  subject: string
+
+  @IsString()
+  template: string
+
+  @IsOptional()
+  @IsString()
+  htmlTemplate?: string
+
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  variables?: string[]
+
+  @IsOptional()
+  @IsString()
+  defaultData?: Record<string, any>
+
+  @IsOptional()
+  @IsBoolean()
+  isActive?: boolean
+
+  @IsOptional()
+  @IsString()
+  language?: string
+
+  @IsOptional()
+  @IsString()
+  description?: string
+}

--- a/backend/src/notifications/dto/notification-preference.dto.ts
+++ b/backend/src/notifications/dto/notification-preference.dto.ts
@@ -1,0 +1,39 @@
+import { IsEnum, IsBoolean, IsOptional, IsObject, IsUUID } from "class-validator"
+import { NotificationType, NotificationChannel } from "../entities/notification.entity"
+
+export class CreateNotificationPreferenceDto {
+  @IsUUID()
+  userId: string
+
+  @IsEnum(NotificationType)
+  type: NotificationType
+
+  @IsEnum(NotificationChannel)
+  channel: NotificationChannel
+
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean
+
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, any>
+}
+
+export class UpdateNotificationPreferenceDto {
+  @IsOptional()
+  @IsBoolean()
+  enabled?: boolean
+
+  @IsOptional()
+  @IsObject()
+  settings?: Record<string, any>
+}
+
+export class BulkUpdatePreferencesDto {
+  @IsUUID()
+  userId: string
+
+  @IsObject()
+  preferences: Record<string, { enabled: boolean; channels: NotificationChannel[] }>
+}

--- a/backend/src/notifications/dto/send-notification.dto.ts
+++ b/backend/src/notifications/dto/send-notification.dto.ts
@@ -1,0 +1,59 @@
+import { IsEnum, IsString, IsOptional, IsUUID, IsObject, IsArray } from "class-validator"
+import { NotificationType, NotificationChannel, NotificationPriority } from "../entities/notification.entity"
+
+export class SendNotificationDto {
+  @IsEnum(NotificationType)
+  type: NotificationType
+
+  @IsArray()
+  @IsEnum(NotificationChannel, { each: true })
+  channels: NotificationChannel[]
+
+  @IsOptional()
+  @IsEnum(NotificationPriority)
+  priority?: NotificationPriority
+
+  @IsArray()
+  @IsUUID(undefined, { each: true })
+  recipientIds: string[]
+
+  @IsOptional()
+  @IsString()
+  templateName?: string
+
+  @IsOptional()
+  @IsObject()
+  templateData?: Record<string, any>
+
+  @IsOptional()
+  @IsString()
+  customTitle?: string
+
+  @IsOptional()
+  @IsString()
+  customMessage?: string
+
+  @IsOptional()
+  @IsUUID()
+  relatedEntityId?: string
+
+  @IsOptional()
+  @IsString()
+  relatedEntityType?: string
+
+  @IsOptional()
+  @IsString()
+  actionUrl?: string
+
+  @IsOptional()
+  @IsString()
+  actionText?: string
+
+  @IsOptional()
+  @IsUUID()
+  senderId?: string
+
+  @IsOptional()
+  @IsString()
+  senderName?: string
+}

--- a/backend/src/notifications/entities/notification-preference.entity.ts
+++ b/backend/src/notifications/entities/notification-preference.entity.ts
@@ -1,0 +1,36 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from "typeorm"
+import { NotificationType, NotificationChannel } from "./notification.entity"
+
+@Entity("notification_preferences")
+@Index(["userId", "type"])
+export class NotificationPreference {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  userId: string
+
+  @Column({
+    type: "enum",
+    enum: NotificationType,
+  })
+  type: NotificationType
+
+  @Column({
+    type: "enum",
+    enum: NotificationChannel,
+  })
+  channel: NotificationChannel
+
+  @Column({ default: true })
+  enabled: boolean
+
+  @Column({ type: "jsonb", nullable: true })
+  settings: Record<string, any>
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/notifications/entities/notification-queue.entity.ts
+++ b/backend/src/notifications/entities/notification-queue.entity.ts
@@ -1,0 +1,68 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from "typeorm"
+import { NotificationChannel, NotificationPriority } from "./notification.entity"
+
+export enum QueueStatus {
+  PENDING = "pending",
+  PROCESSING = "processing",
+  COMPLETED = "completed",
+  FAILED = "failed",
+  CANCELLED = "cancelled",
+}
+
+@Entity("notification_queue")
+@Index(["status", "priority", "scheduledAt"])
+@Index(["channel", "status"])
+export class NotificationQueue {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  notificationId: string
+
+  @Column({
+    type: "enum",
+    enum: NotificationChannel,
+  })
+  channel: NotificationChannel
+
+  @Column({
+    type: "enum",
+    enum: QueueStatus,
+    default: QueueStatus.PENDING,
+  })
+  status: QueueStatus
+
+  @Column({
+    type: "enum",
+    enum: NotificationPriority,
+    default: NotificationPriority.NORMAL,
+  })
+  priority: NotificationPriority
+
+  @Column({ type: "jsonb" })
+  payload: Record<string, any>
+
+  @Column({ type: "timestamp", nullable: true })
+  scheduledAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  processedAt: Date
+
+  @Column({ type: "integer", default: 0 })
+  attempts: number
+
+  @Column({ type: "integer", default: 3 })
+  maxAttempts: number
+
+  @Column({ type: "text", nullable: true })
+  errorMessage: string
+
+  @Column({ type: "timestamp", nullable: true })
+  nextRetryAt: Date
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/notifications/entities/notification-template.entity.ts
+++ b/backend/src/notifications/entities/notification-template.entity.ts
@@ -1,0 +1,53 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn } from "typeorm"
+import { NotificationType, NotificationChannel } from "./notification.entity"
+
+@Entity("notification_templates")
+export class NotificationTemplate {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "varchar", length: 100, unique: true })
+  name: string
+
+  @Column({
+    type: "enum",
+    enum: NotificationType,
+  })
+  type: NotificationType
+
+  @Column({
+    type: "enum",
+    enum: NotificationChannel,
+  })
+  channel: NotificationChannel
+
+  @Column({ type: "varchar", length: 255 })
+  subject: string
+
+  @Column({ type: "text" })
+  template: string
+
+  @Column({ type: "text", nullable: true })
+  htmlTemplate: string
+
+  @Column({ type: "jsonb", nullable: true })
+  variables: string[]
+
+  @Column({ type: "jsonb", nullable: true })
+  defaultData: Record<string, any>
+
+  @Column({ default: true })
+  isActive: boolean
+
+  @Column({ type: "varchar", length: 50, default: "en" })
+  language: string
+
+  @Column({ type: "text", nullable: true })
+  description: string
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/notifications/entities/notification.entity.ts
+++ b/backend/src/notifications/entities/notification.entity.ts
@@ -1,0 +1,139 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from "typeorm"
+
+export enum NotificationType {
+  SHIPMENT_CREATED = "shipment_created",
+  SHIPMENT_DELIVERED = "shipment_delivered",
+  SHIPMENT_DELAYED = "shipment_delayed",
+  SHIPMENT_CANCELLED = "shipment_cancelled",
+  SYSTEM_ALERT = "system_alert",
+  USER_MENTION = "user_mention",
+  CUSTOM = "custom",
+}
+
+export enum NotificationChannel {
+  IN_APP = "in_app",
+  EMAIL = "email",
+  SMS = "sms",
+  PUSH = "push",
+  WEBHOOK = "webhook",
+}
+
+export enum NotificationStatus {
+  PENDING = "pending",
+  SENT = "sent",
+  DELIVERED = "delivered",
+  FAILED = "failed",
+  READ = "read",
+  ARCHIVED = "archived",
+}
+
+export enum NotificationPriority {
+  LOW = "low",
+  NORMAL = "normal",
+  HIGH = "high",
+  URGENT = "urgent",
+}
+
+@Entity("notifications")
+@Index(["recipientId", "status"])
+@Index(["type", "createdAt"])
+@Index(["channel", "status"])
+export class Notification {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({
+    type: "enum",
+    enum: NotificationType,
+  })
+  type: NotificationType
+
+  @Column({
+    type: "enum",
+    enum: NotificationChannel,
+  })
+  channel: NotificationChannel
+
+  @Column({
+    type: "enum",
+    enum: NotificationStatus,
+    default: NotificationStatus.PENDING,
+  })
+  status: NotificationStatus
+
+  @Column({
+    type: "enum",
+    enum: NotificationPriority,
+    default: NotificationPriority.NORMAL,
+  })
+  priority: NotificationPriority
+
+  @Column({ type: "uuid" })
+  recipientId: string
+
+  @Column({ type: "varchar", length: 255 })
+  recipientEmail: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  recipientName: string
+
+  @Column({ type: "varchar", length: 255 })
+  title: string
+
+  @Column({ type: "text" })
+  message: string
+
+  @Column({ type: "jsonb", nullable: true })
+  data: Record<string, any>
+
+  @Column({ type: "jsonb", nullable: true })
+  metadata: Record<string, any>
+
+  @Column({ type: "uuid", nullable: true })
+  relatedEntityId: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  relatedEntityType: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  actionUrl: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  actionText: string
+
+  @Column({ type: "uuid", nullable: true })
+  senderId: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  senderName: string
+
+  @Column({ type: "timestamp", nullable: true })
+  scheduledAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  sentAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  deliveredAt: Date
+
+  @Column({ type: "timestamp", nullable: true })
+  readAt: Date
+
+  @Column({ type: "text", nullable: true })
+  errorMessage: string
+
+  @Column({ type: "integer", default: 0 })
+  retryCount: number
+
+  @Column({ type: "integer", default: 3 })
+  maxRetries: number
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt: Date
+
+  @CreateDateColumn()
+  createdAt: Date
+
+  @UpdateDateColumn()
+  updatedAt: Date
+}

--- a/backend/src/notifications/events/shipment.events.ts
+++ b/backend/src/notifications/events/shipment.events.ts
@@ -1,0 +1,60 @@
+export class ShipmentCreatedEvent {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly trackingNumber: string,
+    public readonly recipientId: string,
+    public readonly recipientEmail: string,
+    public readonly recipientName: string,
+    public readonly origin: string,
+    public readonly destination: string,
+    public readonly estimatedDelivery: Date,
+    public readonly items: Array<{
+      name: string
+      quantity: number
+      value: number
+    }>,
+    public readonly metadata?: Record<string, any>,
+  ) {}
+}
+
+export class ShipmentDeliveredEvent {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly trackingNumber: string,
+    public readonly recipientId: string,
+    public readonly recipientEmail: string,
+    public readonly recipientName: string,
+    public readonly deliveredAt: Date,
+    public readonly deliveryLocation: string,
+    public readonly signedBy?: string,
+    public readonly deliveryNotes?: string,
+    public readonly metadata?: Record<string, any>,
+  ) {}
+}
+
+export class ShipmentDelayedEvent {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly trackingNumber: string,
+    public readonly recipientId: string,
+    public readonly recipientEmail: string,
+    public readonly recipientName: string,
+    public readonly originalDelivery: Date,
+    public readonly newEstimatedDelivery: Date,
+    public readonly delayReason: string,
+    public readonly metadata?: Record<string, any>,
+  ) {}
+}
+
+export class ShipmentCancelledEvent {
+  constructor(
+    public readonly shipmentId: string,
+    public readonly trackingNumber: string,
+    public readonly recipientId: string,
+    public readonly recipientEmail: string,
+    public readonly recipientName: string,
+    public readonly cancellationReason: string,
+    public readonly refundAmount?: number,
+    public readonly metadata?: Record<string, any>,
+  ) {}
+}

--- a/backend/src/notifications/example-usage.ts
+++ b/backend/src/notifications/example-usage.ts
@@ -1,0 +1,281 @@
+import { Injectable } from "@nestjs/common"
+import type { EventEmitter2 } from "@nestjs/event-emitter"
+import type { NotificationService } from "./services/notification.service"
+import type { NotificationPreferenceService } from "./services/notification-preference.service"
+import type { EmailService } from "./services/email.service"
+import type { InAppNotificationService } from "./services/in-app-notification.service"
+import { NotificationType, NotificationChannel, NotificationPriority } from "./entities/notification.entity"
+import { ShipmentCreatedEvent, ShipmentDeliveredEvent, ShipmentDelayedEvent } from "./events/shipment.events"
+
+@Injectable()
+export class NotificationExampleService {
+  constructor(
+    private eventEmitter: EventEmitter2,
+    private notificationService: NotificationService,
+    private preferenceService: NotificationPreferenceService,
+    private emailService: EmailService,
+    private inAppService: InAppNotificationService,
+  ) {}
+
+  // Example: Trigger shipment created notification
+  async triggerShipmentCreated(): Promise<void> {
+    const event = new ShipmentCreatedEvent(
+      "shipment-123",
+      "TRK123456789",
+      "user-456",
+      "customer@example.com",
+      "John Customer",
+      "New York Warehouse",
+      "123 Main St, Los Angeles, CA",
+      new Date(Date.now() + 3 * 24 * 60 * 60 * 1000), // 3 days from now
+      [
+        { name: "Wireless Headphones", quantity: 1, value: 199.99 },
+        { name: "Phone Case", quantity: 2, value: 29.99 },
+      ],
+      { orderNumber: "ORD-789", priority: "standard" },
+    )
+
+    // Emit the event - listeners will handle notification sending
+    this.eventEmitter.emit("shipment.created", event)
+  }
+
+  // Example: Trigger shipment delivered notification
+  async triggerShipmentDelivered(): Promise<void> {
+    const event = new ShipmentDeliveredEvent(
+      "shipment-123",
+      "TRK123456789",
+      "user-456",
+      "customer@example.com",
+      "John Customer",
+      new Date(),
+      "Front door",
+      "John Customer",
+      "Package left at front door as requested",
+      { deliveryPhoto: "photo-url", signature: "signature-data" },
+    )
+
+    this.eventEmitter.emit("shipment.delivered", event)
+  }
+
+  // Example: Send custom notification
+  async sendCustomNotification(): Promise<void> {
+    await this.notificationService.sendNotification({
+      type: NotificationType.SYSTEM_ALERT,
+      channels: [NotificationChannel.EMAIL, NotificationChannel.IN_APP],
+      priority: NotificationPriority.HIGH,
+      recipientIds: ["user-456"],
+      customTitle: "System Maintenance Scheduled",
+      customMessage:
+        "Our system will undergo maintenance on January 15th from 2:00 AM to 4:00 AM EST. During this time, tracking updates may be delayed.",
+      actionUrl: "https://app.example.com/maintenance-info",
+      actionText: "Learn More",
+      senderId: "system",
+      senderName: "System Administrator",
+    })
+  }
+
+  // Example: Set user notification preferences
+  async setupUserPreferences(userId: string): Promise<void> {
+    // Set default preferences for a new user
+    await this.preferenceService.setDefaultPreferences(userId)
+
+    // Customize specific preferences
+    await this.preferenceService.updatePreference(
+      userId,
+      NotificationType.SHIPMENT_CREATED,
+      NotificationChannel.EMAIL,
+      { enabled: true },
+    )
+
+    await this.preferenceService.updatePreference(
+      userId,
+      NotificationType.SHIPMENT_DELIVERED,
+      NotificationChannel.SMS,
+      { enabled: false }, // User doesn't want SMS for deliveries
+    )
+  }
+
+  // Example: Bulk update preferences
+  async bulkUpdatePreferences(userId: string): Promise<void> {
+    await this.preferenceService.bulkUpdatePreferences({
+      userId,
+      preferences: {
+        [NotificationType.SHIPMENT_CREATED]: {
+          enabled: true,
+          channels: [NotificationChannel.EMAIL, NotificationChannel.IN_APP],
+        },
+        [NotificationType.SHIPMENT_DELIVERED]: {
+          enabled: true,
+          channels: [NotificationChannel.EMAIL, NotificationChannel.IN_APP, NotificationChannel.SMS],
+        },
+        [NotificationType.SHIPMENT_DELAYED]: {
+          enabled: true,
+          channels: [NotificationChannel.EMAIL, NotificationChannel.IN_APP],
+        },
+        [NotificationType.SHIPMENT_CANCELLED]: {
+          enabled: true,
+          channels: [NotificationChannel.EMAIL],
+        },
+      },
+    })
+  }
+
+  // Example: Send direct email
+  async sendDirectEmail(): Promise<void> {
+    const result = await this.emailService.sendEmail({
+      to: "customer@example.com",
+      subject: "Welcome to Our Shipping Service",
+      text: "Thank you for choosing our shipping service. We're committed to delivering your packages safely and on time.",
+      html: `
+        <h2>Welcome to Our Shipping Service</h2>
+        <p>Thank you for choosing our shipping service.</p>
+        <p>We're committed to delivering your packages safely and on time.</p>
+        <p><a href="https://app.example.com/dashboard">Visit Your Dashboard</a></p>
+      `,
+    })
+
+    console.log("Email sent:", result)
+  }
+
+  // Example: Send template email
+  async sendTemplateEmail(): Promise<void> {
+    const result = await this.emailService.sendTemplateEmail("customer@example.com", "shipment_created", {
+      trackingNumber: "TRK987654321",
+      recipientName: "Jane Customer",
+      origin: "Chicago Distribution Center",
+      destination: "456 Oak Ave, Denver, CO",
+      estimatedDelivery: "January 18, 2024",
+      items: [
+        { name: "Laptop Stand", quantity: 1, value: 89.99 },
+        { name: "USB Cable", quantity: 3, value: 15.99 },
+      ],
+      actionUrl: "https://app.example.com/track/TRK987654321",
+    })
+
+    console.log("Template email sent:", result)
+  }
+
+  // Example: Get user's in-app notifications
+  async getUserInAppNotifications(userId: string): Promise<void> {
+    const notifications = await this.inAppService.getUserNotifications(userId, 10)
+    const unreadCount = await this.inAppService.getUnreadCount(userId)
+
+    console.log(`User ${userId} has ${unreadCount} unread notifications:`)
+    notifications.forEach((notif) => {
+      console.log(`- ${notif.title}: ${notif.message} (${notif.read ? "read" : "unread"})`)
+    })
+  }
+
+  // Example: Mark notifications as read
+  async markNotificationsAsRead(userId: string): Promise<void> {
+    // Mark specific notification as read
+    const notifications = await this.inAppService.getUserNotifications(userId, 5)
+    if (notifications.length > 0) {
+      await this.inAppService.markAsRead(userId, notifications[0].id)
+      console.log(`Marked notification ${notifications[0].id} as read`)
+    }
+
+    // Mark all notifications as read
+    await this.inAppService.markAllAsRead(userId)
+    console.log(`Marked all notifications as read for user ${userId}`)
+  }
+
+  // Example: Get notification statistics
+  async getNotificationStats(): Promise<void> {
+    const stats = await this.notificationService.getNotificationStats()
+    console.log("Notification Statistics:", {
+      total: stats.total,
+      unread: stats.unread,
+      byStatus: stats.byStatus,
+      byType: stats.byType,
+      byChannel: stats.byChannel,
+    })
+
+    // Get stats for specific user
+    const userStats = await this.notificationService.getNotificationStats("user-456")
+    console.log("User 456 Statistics:", userStats)
+  }
+
+  // Example: Simulate shipment lifecycle with notifications
+  async simulateShipmentLifecycle(): Promise<void> {
+    const shipmentId = "shipment-demo-001"
+    const trackingNumber = "DEMO123456"
+    const userId = "demo-user"
+    const userEmail = "demo@example.com"
+    const userName = "Demo User"
+
+    console.log("🚀 Starting shipment lifecycle simulation...")
+
+    // 1. Shipment created
+    console.log("📦 Creating shipment...")
+    const createdEvent = new ShipmentCreatedEvent(
+      shipmentId,
+      trackingNumber,
+      userId,
+      userEmail,
+      userName,
+      "Demo Warehouse",
+      "Demo Destination",
+      new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+      [{ name: "Demo Product", quantity: 1, value: 99.99 }],
+    )
+    this.eventEmitter.emit("shipment.created", createdEvent)
+
+    // Wait a bit to simulate processing time
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // 2. Shipment delayed (optional)
+    console.log("⏰ Simulating delay...")
+    const delayedEvent = new ShipmentDelayedEvent(
+      shipmentId,
+      trackingNumber,
+      userId,
+      userEmail,
+      userName,
+      new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+      new Date(Date.now() + 3 * 24 * 60 * 60 * 1000),
+      "Weather conditions",
+    )
+    this.eventEmitter.emit("shipment.delayed", delayedEvent)
+
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    // 3. Shipment delivered
+    console.log("✅ Delivering shipment...")
+    const deliveredEvent = new ShipmentDeliveredEvent(
+      shipmentId,
+      trackingNumber,
+      userId,
+      userEmail,
+      userName,
+      new Date(),
+      "Front door",
+      userName,
+      "Package delivered successfully",
+    )
+    this.eventEmitter.emit("shipment.delivered", deliveredEvent)
+
+    console.log("🎉 Shipment lifecycle simulation completed!")
+  }
+
+  // Example: Debug email and in-app queues
+  async debugQueues(): Promise<void> {
+    console.log("📧 Email Queue:")
+    const emailQueue = this.emailService.getEmailQueue()
+    emailQueue.forEach((email, index) => {
+      console.log(`  ${index + 1}. To: ${email.email.to}, Subject: ${email.email.subject}`)
+    })
+
+    console.log("\n🔔 In-App Notification Queue:")
+    const inAppQueue = await this.inAppService.getAllQueuedNotifications()
+    for (const [userId, notifications] of inAppQueue.entries()) {
+      console.log(`  User ${userId}: ${notifications.length} notifications`)
+      notifications.slice(0, 3).forEach((notif, index) => {
+        console.log(`    ${index + 1}. ${notif.title} (${notif.read ? "read" : "unread"})`)
+      })
+    }
+
+    console.log(`\nTotal email queue size: ${this.emailService.getQueueSize()}`)
+    console.log(`Total in-app queue size: ${this.inAppService.getQueueSize()}`)
+  }
+}

--- a/backend/src/notifications/listeners/shipment.listener.ts
+++ b/backend/src/notifications/listeners/shipment.listener.ts
@@ -1,0 +1,169 @@
+import { Injectable } from "@nestjs/common"
+import { OnEvent } from "@nestjs/event-emitter"
+import type { NotificationService } from "../services/notification.service"
+import type { NotificationPreferenceService } from "../services/notification-preference.service"
+import { NotificationType, NotificationPriority } from "../entities/notification.entity"
+import type {
+  ShipmentCreatedEvent,
+  ShipmentDeliveredEvent,
+  ShipmentDelayedEvent,
+  ShipmentCancelledEvent,
+} from "../events/shipment.events"
+
+@Injectable()
+export class ShipmentNotificationListener {
+  constructor(
+    private notificationService: NotificationService,
+    private preferenceService: NotificationPreferenceService,
+  ) {}
+
+  @OnEvent("shipment.created")
+  async handleShipmentCreated(event: ShipmentCreatedEvent): Promise<void> {
+    console.log(`📦 Shipment created event received for shipment ${event.shipmentId}`)
+
+    // Get user's enabled channels for this notification type
+    const enabledChannels = await this.preferenceService.getEnabledChannels(
+      event.recipientId,
+      NotificationType.SHIPMENT_CREATED,
+    )
+
+    if (enabledChannels.length === 0) {
+      console.log(`No enabled channels for user ${event.recipientId} for shipment created notifications`)
+      return
+    }
+
+    const templateData = {
+      shipmentId: event.shipmentId,
+      trackingNumber: event.trackingNumber,
+      recipientName: event.recipientName,
+      origin: event.origin,
+      destination: event.destination,
+      estimatedDelivery: event.estimatedDelivery.toLocaleDateString(),
+      items: event.items,
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}/track`,
+    }
+
+    await this.notificationService.sendNotification({
+      type: NotificationType.SHIPMENT_CREATED,
+      channels: enabledChannels,
+      priority: NotificationPriority.NORMAL,
+      recipientIds: [event.recipientId],
+      templateName: "shipment_created",
+      templateData,
+      relatedEntityId: event.shipmentId,
+      relatedEntityType: "shipment",
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}/track`,
+      actionText: "Track Shipment",
+    })
+  }
+
+  @OnEvent("shipment.delivered")
+  async handleShipmentDelivered(event: ShipmentDeliveredEvent): Promise<void> {
+    console.log(`📦 Shipment delivered event received for shipment ${event.shipmentId}`)
+
+    const enabledChannels = await this.preferenceService.getEnabledChannels(
+      event.recipientId,
+      NotificationType.SHIPMENT_DELIVERED,
+    )
+
+    if (enabledChannels.length === 0) {
+      console.log(`No enabled channels for user ${event.recipientId} for shipment delivered notifications`)
+      return
+    }
+
+    const templateData = {
+      shipmentId: event.shipmentId,
+      trackingNumber: event.trackingNumber,
+      recipientName: event.recipientName,
+      deliveredAt: event.deliveredAt.toLocaleString(),
+      deliveryLocation: event.deliveryLocation,
+      signedBy: event.signedBy,
+      deliveryNotes: event.deliveryNotes,
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}`,
+    }
+
+    await this.notificationService.sendNotification({
+      type: NotificationType.SHIPMENT_DELIVERED,
+      channels: enabledChannels,
+      priority: NotificationPriority.HIGH,
+      recipientIds: [event.recipientId],
+      templateName: "shipment_delivered",
+      templateData,
+      relatedEntityId: event.shipmentId,
+      relatedEntityType: "shipment",
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}`,
+      actionText: "View Shipment",
+    })
+  }
+
+  @OnEvent("shipment.delayed")
+  async handleShipmentDelayed(event: ShipmentDelayedEvent): Promise<void> {
+    console.log(`📦 Shipment delayed event received for shipment ${event.shipmentId}`)
+
+    const enabledChannels = await this.preferenceService.getEnabledChannels(
+      event.recipientId,
+      NotificationType.SHIPMENT_DELAYED,
+    )
+
+    if (enabledChannels.length === 0) {
+      return
+    }
+
+    const templateData = {
+      shipmentId: event.shipmentId,
+      trackingNumber: event.trackingNumber,
+      recipientName: event.recipientName,
+      originalDelivery: event.originalDelivery.toLocaleDateString(),
+      newEstimatedDelivery: event.newEstimatedDelivery.toLocaleDateString(),
+      delayReason: event.delayReason,
+    }
+
+    await this.notificationService.sendNotification({
+      type: NotificationType.SHIPMENT_DELAYED,
+      channels: enabledChannels,
+      priority: NotificationPriority.HIGH,
+      recipientIds: [event.recipientId],
+      customTitle: `Shipment ${event.trackingNumber} Delayed`,
+      customMessage: `Your shipment has been delayed. New estimated delivery: ${event.newEstimatedDelivery.toLocaleDateString()}. Reason: ${event.delayReason}`,
+      relatedEntityId: event.shipmentId,
+      relatedEntityType: "shipment",
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}/track`,
+      actionText: "Track Shipment",
+    })
+  }
+
+  @OnEvent("shipment.cancelled")
+  async handleShipmentCancelled(event: ShipmentCancelledEvent): Promise<void> {
+    console.log(`📦 Shipment cancelled event received for shipment ${event.shipmentId}`)
+
+    const enabledChannels = await this.preferenceService.getEnabledChannels(
+      event.recipientId,
+      NotificationType.SHIPMENT_CANCELLED,
+    )
+
+    if (enabledChannels.length === 0) {
+      return
+    }
+
+    const templateData = {
+      shipmentId: event.shipmentId,
+      trackingNumber: event.trackingNumber,
+      recipientName: event.recipientName,
+      cancellationReason: event.cancellationReason,
+      refundAmount: event.refundAmount,
+    }
+
+    await this.notificationService.sendNotification({
+      type: NotificationType.SHIPMENT_CANCELLED,
+      channels: enabledChannels,
+      priority: NotificationPriority.URGENT,
+      recipientIds: [event.recipientId],
+      customTitle: `Shipment ${event.trackingNumber} Cancelled`,
+      customMessage: `Your shipment has been cancelled. Reason: ${event.cancellationReason}${event.refundAmount ? `. Refund amount: $${event.refundAmount}` : ""}`,
+      relatedEntityId: event.shipmentId,
+      relatedEntityType: "shipment",
+      actionUrl: `https://app.example.com/shipments/${event.shipmentId}`,
+      actionText: "View Details",
+    })
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,0 +1,52 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { EventEmitterModule } from "@nestjs/event-emitter"
+import { Notification } from "./entities/notification.entity"
+import { NotificationTemplate } from "./entities/notification-template.entity"
+import { NotificationPreference } from "./entities/notification-preference.entity"
+import { NotificationQueue } from "./entities/notification-queue.entity"
+import { NotificationService } from "./services/notification.service"
+import { NotificationTemplateService } from "./services/notification-template.service"
+import { NotificationPreferenceService } from "./services/notification-preference.service"
+import { EmailService } from "./services/email.service"
+import { InAppNotificationService } from "./services/in-app-notification.service"
+import { NotificationProcessorService } from "./services/notification-processor.service"
+import { ShipmentNotificationListener } from "./listeners/shipment.listener"
+import { NotificationsController } from "./controllers/notifications.controller"
+import { NotificationPreferencesController } from "./controllers/notification-preferences.controller"
+import { NotificationTemplatesController } from "./controllers/notification-templates.controller"
+import { InAppNotificationsController } from "./controllers/in-app-notifications.controller"
+import { EmailDebugController } from "./controllers/email-debug.controller"
+import { RolesModule } from "../roles/roles.module"
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Notification, NotificationTemplate, NotificationPreference, NotificationQueue]),
+    EventEmitterModule.forRoot(),
+    RolesModule,
+  ],
+  controllers: [
+    NotificationsController,
+    NotificationPreferencesController,
+    NotificationTemplatesController,
+    InAppNotificationsController,
+    EmailDebugController,
+  ],
+  providers: [
+    NotificationService,
+    NotificationTemplateService,
+    NotificationPreferenceService,
+    EmailService,
+    InAppNotificationService,
+    NotificationProcessorService,
+    ShipmentNotificationListener,
+  ],
+  exports: [
+    NotificationService,
+    NotificationTemplateService,
+    NotificationPreferenceService,
+    EmailService,
+    InAppNotificationService,
+  ],
+})
+export class NotificationsModule {}

--- a/backend/src/notifications/services/email.service.ts
+++ b/backend/src/notifications/services/email.service.ts
@@ -1,0 +1,191 @@
+import { Injectable } from "@nestjs/common"
+
+export interface EmailOptions {
+  to: string
+  subject: string
+  text: string
+  html?: string
+  from?: string
+  replyTo?: string
+  attachments?: Array<{
+    filename: string
+    content: Buffer | string
+    contentType?: string
+  }>
+}
+
+export interface EmailResult {
+  success: boolean
+  messageId?: string
+  error?: string
+}
+
+@Injectable()
+export class EmailService {
+  private emailQueue: Array<{ email: EmailOptions; timestamp: Date; id: string }> = []
+
+  async sendEmail(options: EmailOptions): Promise<EmailResult> {
+    try {
+      // Simulate email sending with in-memory queue
+      const emailId = `email_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+
+      this.emailQueue.push({
+        id: emailId,
+        email: options,
+        timestamp: new Date(),
+      })
+
+      // Simulate processing delay
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      console.log(`📧 Email sent to ${options.to}:`)
+      console.log(`   Subject: ${options.subject}`)
+      console.log(`   Message: ${options.text}`)
+      console.log(`   Message ID: ${emailId}`)
+      console.log(`   Timestamp: ${new Date().toISOString()}`)
+
+      return {
+        success: true,
+        messageId: emailId,
+      }
+    } catch (error) {
+      console.error("Failed to send email:", error)
+      return {
+        success: false,
+        error: error.message,
+      }
+    }
+  }
+
+  async sendBulkEmails(emails: EmailOptions[]): Promise<EmailResult[]> {
+    const results: EmailResult[] = []
+
+    for (const email of emails) {
+      const result = await this.sendEmail(email)
+      results.push(result)
+    }
+
+    return results
+  }
+
+  getEmailQueue(): Array<{ email: EmailOptions; timestamp: Date; id: string }> {
+    return [...this.emailQueue]
+  }
+
+  clearEmailQueue(): void {
+    this.emailQueue = []
+  }
+
+  getQueueSize(): number {
+    return this.emailQueue.length
+  }
+
+  async sendTemplateEmail(
+    to: string,
+    templateName: string,
+    templateData: Record<string, any>,
+    options?: Partial<EmailOptions>,
+  ): Promise<EmailResult> {
+    // In a real implementation, this would use a template engine
+    const processedTemplate = this.processEmailTemplate(templateName, templateData)
+
+    return this.sendEmail({
+      to,
+      subject: processedTemplate.subject,
+      text: processedTemplate.text,
+      html: processedTemplate.html,
+      ...options,
+    })
+  }
+
+  private processEmailTemplate(
+    templateName: string,
+    data: Record<string, any>,
+  ): { subject: string; text: string; html?: string } {
+    // Mock template processing - in real app, use a proper template engine
+    const templates = {
+      shipment_created: {
+        subject: "Your shipment {{trackingNumber}} has been created",
+        text: `Hello {{recipientName}},
+
+Your shipment has been created and is being prepared for delivery.
+
+Tracking Number: {{trackingNumber}}
+From: {{origin}}
+To: {{destination}}
+Estimated Delivery: {{estimatedDelivery}}
+
+Items:
+{{#each items}}
+- {{name}} (Quantity: {{quantity}}, Value: ${{ value }})
+{{/each}}
+
+You can track your shipment at: {{actionUrl}}
+
+Thank you for your business!`,
+        html: `<h2>Shipment Created</h2>
+<p>Hello {{recipientName}},</p>
+<p>Your shipment has been created and is being prepared for delivery.</p>
+<ul>
+<li><strong>Tracking Number:</strong> {{trackingNumber}}</li>
+<li><strong>From:</strong> {{origin}}</li>
+<li><strong>To:</strong> {{destination}}</li>
+<li><strong>Estimated Delivery:</strong> {{estimatedDelivery}}</li>
+</ul>
+<h3>Items:</h3>
+<ul>
+{{#each items}}
+<li>{{name}} (Quantity: {{quantity}}, Value: ${{ value }})</li>
+{{/each}}
+</ul>
+<p><a href="{{actionUrl}}">Track your shipment</a></p>`,
+      },
+      shipment_delivered: {
+        subject: "Your shipment {{trackingNumber}} has been delivered",
+        text: `Hello {{recipientName}},
+
+Great news! Your shipment has been successfully delivered.
+
+Tracking Number: {{trackingNumber}}
+Delivered At: {{deliveredAt}}
+Delivery Location: {{deliveryLocation}}
+{{#if signedBy}}Signed By: {{signedBy}}{{/if}}
+
+{{#if deliveryNotes}}Delivery Notes: {{deliveryNotes}}{{/if}}
+
+Thank you for choosing our service!`,
+        html: `<h2>Shipment Delivered</h2>
+<p>Hello {{recipientName}},</p>
+<p>Great news! Your shipment has been successfully delivered.</p>
+<ul>
+<li><strong>Tracking Number:</strong> {{trackingNumber}}</li>
+<li><strong>Delivered At:</strong> {{deliveredAt}}</li>
+<li><strong>Delivery Location:</strong> {{deliveryLocation}}</li>
+{{#if signedBy}}<li><strong>Signed By:</strong> {{signedBy}}</li>{{/if}}
+</ul>
+{{#if deliveryNotes}}<p><strong>Delivery Notes:</strong> {{deliveryNotes}}</p>{{/if}}`,
+      },
+    }
+
+    const template = templates[templateName] || {
+      subject: "Notification",
+      text: "You have a new notification.",
+    }
+
+    // Simple template variable replacement
+    let subject = template.subject
+    let text = template.text
+    let html = template.html
+
+    for (const [key, value] of Object.entries(data)) {
+      const regex = new RegExp(`{{${key}}}`, "g")
+      subject = subject.replace(regex, String(value))
+      text = text.replace(regex, String(value))
+      if (html) {
+        html = html.replace(regex, String(value))
+      }
+    }
+
+    return { subject, text, html }
+  }
+}

--- a/backend/src/notifications/services/in-app-notification.service.ts
+++ b/backend/src/notifications/services/in-app-notification.service.ts
@@ -1,0 +1,95 @@
+import { Injectable } from "@nestjs/common"
+import type { Notification } from "../entities/notification.entity"
+
+export interface InAppNotificationMessage {
+  id: string
+  type: string
+  title: string
+  message: string
+  data?: Record<string, any>
+  actionUrl?: string
+  actionText?: string
+  timestamp: Date
+  read: boolean
+}
+
+@Injectable()
+export class InAppNotificationService {
+  private notificationQueue: Map<string, InAppNotificationMessage[]> = new Map()
+
+  async sendInAppNotification(notification: Notification): Promise<void> {
+    const message: InAppNotificationMessage = {
+      id: notification.id,
+      type: notification.type,
+      title: notification.title,
+      message: notification.message,
+      data: notification.data,
+      actionUrl: notification.actionUrl,
+      actionText: notification.actionText,
+      timestamp: new Date(),
+      read: false,
+    }
+
+    const userNotifications = this.notificationQueue.get(notification.recipientId) || []
+    userNotifications.unshift(message) // Add to beginning of array
+
+    // Keep only last 100 notifications per user
+    if (userNotifications.length > 100) {
+      userNotifications.splice(100)
+    }
+
+    this.notificationQueue.set(notification.recipientId, userNotifications)
+
+    console.log(`🔔 In-app notification sent to user ${notification.recipientId}:`)
+    console.log(`   Title: ${notification.title}`)
+    console.log(`   Message: ${notification.message}`)
+    console.log(`   Type: ${notification.type}`)
+    console.log(`   Timestamp: ${new Date().toISOString()}`)
+  }
+
+  async getUserNotifications(userId: string, limit = 20): Promise<InAppNotificationMessage[]> {
+    const notifications = this.notificationQueue.get(userId) || []
+    return notifications.slice(0, limit)
+  }
+
+  async getUnreadCount(userId: string): Promise<number> {
+    const notifications = this.notificationQueue.get(userId) || []
+    return notifications.filter((n) => !n.read).length
+  }
+
+  async markAsRead(userId: string, notificationId: string): Promise<void> {
+    const notifications = this.notificationQueue.get(userId) || []
+    const notification = notifications.find((n) => n.id === notificationId)
+
+    if (notification) {
+      notification.read = true
+    }
+  }
+
+  async markAllAsRead(userId: string): Promise<void> {
+    const notifications = this.notificationQueue.get(userId) || []
+    notifications.forEach((n) => {
+      n.read = true
+    })
+  }
+
+  async clearUserNotifications(userId: string): Promise<void> {
+    this.notificationQueue.delete(userId)
+  }
+
+  async getAllQueuedNotifications(): Promise<Map<string, InAppNotificationMessage[]>> {
+    return new Map(this.notificationQueue)
+  }
+
+  getQueueSize(): number {
+    let total = 0
+    for (const notifications of this.notificationQueue.values()) {
+      total += notifications.length
+    }
+    return total
+  }
+
+  clearAllQueues(): void {
+    this.notificationQueue.clear()
+  }
+}

--- a/backend/src/notifications/services/notification-preference.service.ts
+++ b/backend/src/notifications/services/notification-preference.service.ts
@@ -1,0 +1,170 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { NotificationPreference } from "../entities/notification-preference.entity"
+import type {
+  CreateNotificationPreferenceDto,
+  UpdateNotificationPreferenceDto,
+  BulkUpdatePreferencesDto,
+} from "../dto/notification-preference.dto"
+import { NotificationType, NotificationChannel } from "../entities/notification.entity"
+
+@Injectable()
+export class NotificationPreferenceService {
+  constructor(private preferenceRepository: Repository<NotificationPreference>) {}
+
+  async create(createPreferenceDto: CreateNotificationPreferenceDto): Promise<NotificationPreference> {
+    const preference = this.preferenceRepository.create(createPreferenceDto)
+    return this.preferenceRepository.save(preference)
+  }
+
+  async findByUser(userId: string): Promise<NotificationPreference[]> {
+    return this.preferenceRepository.find({
+      where: { userId },
+      order: { type: "ASC", channel: "ASC" },
+    })
+  }
+
+  async findUserPreference(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannel,
+  ): Promise<NotificationPreference | null> {
+    return this.preferenceRepository.findOne({
+      where: { userId, type, channel },
+    })
+  }
+
+  async updatePreference(
+    userId: string,
+    type: NotificationType,
+    channel: NotificationChannel,
+    updateData: UpdateNotificationPreferenceDto,
+  ): Promise<NotificationPreference> {
+    let preference = await this.findUserPreference(userId, type, channel)
+
+    if (!preference) {
+      preference = await this.create({
+        userId,
+        type,
+        channel,
+        ...updateData,
+      })
+    } else {
+      Object.assign(preference, updateData)
+      preference = await this.preferenceRepository.save(preference)
+    }
+
+    return preference
+  }
+
+  async bulkUpdatePreferences(bulkUpdateDto: BulkUpdatePreferencesDto): Promise<NotificationPreference[]> {
+    const preferences: NotificationPreference[] = []
+
+    for (const [typeKey, settings] of Object.entries(bulkUpdateDto.preferences)) {
+      const type = typeKey as NotificationType
+
+      for (const channel of settings.channels) {
+        const preference = await this.updatePreference(bulkUpdateDto.userId, type, channel, {
+          enabled: settings.enabled,
+        })
+        preferences.push(preference)
+      }
+    }
+
+    return preferences
+  }
+
+  async isNotificationEnabled(userId: string, type: NotificationType, channel: NotificationChannel): Promise<boolean> {
+    const preference = await this.findUserPreference(userId, type, channel)
+
+    // If no preference exists, default to enabled
+    return preference ? preference.enabled : true
+  }
+
+  async getEnabledChannels(userId: string, type: NotificationType): Promise<NotificationChannel[]> {
+    const preferences = await this.preferenceRepository.find({
+      where: { userId, type, enabled: true },
+    })
+
+    return preferences.map((pref) => pref.channel)
+  }
+
+  async setDefaultPreferences(userId: string): Promise<NotificationPreference[]> {
+    const defaultPreferences = [
+      // Shipment notifications
+      { type: NotificationType.SHIPMENT_CREATED, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.SHIPMENT_CREATED, channel: NotificationChannel.EMAIL, enabled: true },
+      { type: NotificationType.SHIPMENT_DELIVERED, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.SHIPMENT_DELIVERED, channel: NotificationChannel.EMAIL, enabled: true },
+      { type: NotificationType.SHIPMENT_DELAYED, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.SHIPMENT_DELAYED, channel: NotificationChannel.EMAIL, enabled: true },
+      { type: NotificationType.SHIPMENT_CANCELLED, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.SHIPMENT_CANCELLED, channel: NotificationChannel.EMAIL, enabled: false },
+
+      // System notifications
+      { type: NotificationType.SYSTEM_ALERT, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.SYSTEM_ALERT, channel: NotificationChannel.EMAIL, enabled: false },
+      { type: NotificationType.USER_MENTION, channel: NotificationChannel.IN_APP, enabled: true },
+      { type: NotificationType.USER_MENTION, channel: NotificationChannel.EMAIL, enabled: true },
+    ]
+
+    const preferences: NotificationPreference[] = []
+
+    for (const defaultPref of defaultPreferences) {
+      const existing = await this.findUserPreference(userId, defaultPref.type, defaultPref.channel)
+
+      if (!existing) {
+        const preference = await this.create({
+          userId,
+          type: defaultPref.type,
+          channel: defaultPref.channel,
+          enabled: defaultPref.enabled,
+        })
+        preferences.push(preference)
+      }
+    }
+
+    return preferences
+  }
+
+  async remove(id: string): Promise<void> {
+    const preference = await this.preferenceRepository.findOne({ where: { id } })
+
+    if (!preference) {
+      throw new NotFoundException(`Preference with ID ${id} not found`)
+    }
+
+    await this.preferenceRepository.remove(preference)
+  }
+
+  async getUserPreferenceSummary(userId: string): Promise<{
+    totalPreferences: number
+    enabledByChannel: Record<NotificationChannel, number>
+    enabledByType: Record<NotificationType, number>
+  }> {
+    const preferences = await this.findByUser(userId)
+    const enabledPreferences = preferences.filter((pref) => pref.enabled)
+
+    const enabledByChannel = enabledPreferences.reduce(
+      (acc, pref) => {
+        acc[pref.channel] = (acc[pref.channel] || 0) + 1
+        return acc
+      },
+      {} as Record<NotificationChannel, number>,
+    )
+
+    const enabledByType = enabledPreferences.reduce(
+      (acc, pref) => {
+        acc[pref.type] = (acc[pref.type] || 0) + 1
+        return acc
+      },
+      {} as Record<NotificationType, number>,
+    )
+
+    return {
+      totalPreferences: preferences.length,
+      enabledByChannel,
+      enabledByType,
+    }
+  }
+}

--- a/backend/src/notifications/services/notification-processor.service.ts
+++ b/backend/src/notifications/services/notification-processor.service.ts
@@ -1,0 +1,146 @@
+import { Injectable } from "@nestjs/common"
+import { OnEvent } from "@nestjs/event-emitter"
+import { NotificationChannel } from "../entities/notification.entity"
+import type { Notification } from "../entities/notification.entity"
+import type { NotificationService } from "./notification.service"
+import type { EmailService } from "./email.service"
+import type { InAppNotificationService } from "./in-app-notification.service"
+import type { NotificationPreferenceService } from "./notification-preference.service"
+
+@Injectable()
+export class NotificationProcessorService {
+  constructor(
+    private notificationService: NotificationService,
+    private emailService: EmailService,
+    private inAppNotificationService: InAppNotificationService,
+    private preferenceService: NotificationPreferenceService,
+  ) {}
+
+  @OnEvent("notification.created")
+  async handleNotificationCreated(notification: Notification): Promise<void> {
+    try {
+      // Check if user has enabled this notification type for this channel
+      const isEnabled = await this.preferenceService.isNotificationEnabled(
+        notification.recipientId,
+        notification.type,
+        notification.channel,
+      )
+
+      if (!isEnabled) {
+        console.log(`Notification ${notification.id} skipped - user preference disabled`)
+        return
+      }
+
+      // Process based on channel
+      switch (notification.channel) {
+        case NotificationChannel.EMAIL:
+          await this.processEmailNotification(notification)
+          break
+        case NotificationChannel.IN_APP:
+          await this.processInAppNotification(notification)
+          break
+        case NotificationChannel.SMS:
+          await this.processSMSNotification(notification)
+          break
+        case NotificationChannel.PUSH:
+          await this.processPushNotification(notification)
+          break
+        default:
+          console.warn(`Unsupported notification channel: ${notification.channel}`)
+      }
+    } catch (error) {
+      console.error(`Failed to process notification ${notification.id}:`, error)
+      await this.notificationService.markAsFailed(notification.id, error.message)
+    }
+  }
+
+  private async processEmailNotification(notification: Notification): Promise<void> {
+    try {
+      const result = await this.emailService.sendEmail({
+        to: notification.recipientEmail,
+        subject: notification.title,
+        text: notification.message,
+        html: this.generateEmailHTML(notification),
+      })
+
+      if (result.success) {
+        await this.notificationService.markAsDelivered(notification.id)
+      } else {
+        await this.notificationService.markAsFailed(notification.id, result.error || "Email sending failed")
+      }
+    } catch (error) {
+      await this.notificationService.markAsFailed(notification.id, error.message)
+    }
+  }
+
+  private async processInAppNotification(notification: Notification): Promise<void> {
+    try {
+      await this.inAppNotificationService.sendInAppNotification(notification)
+      await this.notificationService.markAsDelivered(notification.id)
+    } catch (error) {
+      await this.notificationService.markAsFailed(notification.id, error.message)
+    }
+  }
+
+  private async processSMSNotification(notification: Notification): Promise<void> {
+    // Mock SMS processing
+    console.log(`📱 SMS notification sent to ${notification.recipientId}:`)
+    console.log(`   Message: ${notification.message}`)
+    console.log(`   Timestamp: ${new Date().toISOString()}`)
+
+    await this.notificationService.markAsDelivered(notification.id)
+  }
+
+  private async processPushNotification(notification: Notification): Promise<void> {
+    // Mock push notification processing
+    console.log(`📲 Push notification sent to ${notification.recipientId}:`)
+    console.log(`   Title: ${notification.title}`)
+    console.log(`   Message: ${notification.message}`)
+    console.log(`   Timestamp: ${new Date().toISOString()}`)
+
+    await this.notificationService.markAsDelivered(notification.id)
+  }
+
+  private generateEmailHTML(notification: Notification): string {
+    return `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>${notification.title}</title>
+    <style>
+        body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; }
+        .container { max-width: 600px; margin: 0 auto; padding: 20px; }
+        .header { background-color: #f8f9fa; padding: 20px; border-radius: 5px; margin-bottom: 20px; }
+        .content { padding: 20px 0; }
+        .footer { background-color: #f8f9fa; padding: 15px; border-radius: 5px; margin-top: 20px; font-size: 12px; color: #666; }
+        .button { display: inline-block; padding: 10px 20px; background-color: #007bff; color: white; text-decoration: none; border-radius: 5px; }
+        .metadata { background-color: #f8f9fa; padding: 10px; border-radius: 3px; margin: 10px 0; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h2>${notification.title}</h2>
+        </div>
+        
+        <div class="content">
+            <p>Hello ${notification.recipientName || "there"},</p>
+            <p>${notification.message}</p>
+            
+            ${notification.actionUrl ? `<p><a href="${notification.actionUrl}" class="button">${notification.actionText || "View Details"}</a></p>` : ""}
+            
+            ${notification.data ? `<div class="metadata"><strong>Additional Information:</strong><br>${JSON.stringify(notification.data, null, 2)}</div>` : ""}
+        </div>
+        
+        <div class="footer">
+            <p>This notification was sent at ${notification.createdAt.toISOString()}</p>
+            <p>Notification ID: ${notification.id}</p>
+        </div>
+    </div>
+</body>
+</html>
+    `
+  }
+}

--- a/backend/src/notifications/services/notification-template.service.ts
+++ b/backend/src/notifications/services/notification-template.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, NotFoundException, ConflictException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { NotificationTemplate } from "../entities/notification-template.entity"
+import type { CreateNotificationTemplateDto } from "../dto/create-template.dto"
+import type { NotificationType, NotificationChannel } from "../entities/notification.entity"
+
+@Injectable()
+export class NotificationTemplateService {
+  constructor(private templateRepository: Repository<NotificationTemplate>) {}
+
+  async create(createTemplateDto: CreateNotificationTemplateDto): Promise<NotificationTemplate> {
+    const existingTemplate = await this.templateRepository.findOne({
+      where: { name: createTemplateDto.name },
+    })
+
+    if (existingTemplate) {
+      throw new ConflictException(`Template with name ${createTemplateDto.name} already exists`)
+    }
+
+    const template = this.templateRepository.create(createTemplateDto)
+    return this.templateRepository.save(template)
+  }
+
+  async findAll(): Promise<NotificationTemplate[]> {
+    return this.templateRepository.find({
+      where: { isActive: true },
+      order: { createdAt: "DESC" },
+    })
+  }
+
+  async findByTypeAndChannel(type: NotificationType, channel: NotificationChannel): Promise<NotificationTemplate[]> {
+    return this.templateRepository.find({
+      where: { type, channel, isActive: true },
+      order: { createdAt: "DESC" },
+    })
+  }
+
+  async findByName(name: string): Promise<NotificationTemplate> {
+    const template = await this.templateRepository.findOne({
+      where: { name, isActive: true },
+    })
+
+    if (!template) {
+      throw new NotFoundException(`Template with name ${name} not found`)
+    }
+
+    return template
+  }
+
+  async update(id: string, updateData: Partial<CreateNotificationTemplateDto>): Promise<NotificationTemplate> {
+    const template = await this.templateRepository.findOne({ where: { id } })
+
+    if (!template) {
+      throw new NotFoundException(`Template with ID ${id} not found`)
+    }
+
+    Object.assign(template, updateData)
+    return this.templateRepository.save(template)
+  }
+
+  async remove(id: string): Promise<void> {
+    const template = await this.templateRepository.findOne({ where: { id } })
+
+    if (!template) {
+      throw new NotFoundException(`Template with ID ${id} not found`)
+    }
+
+    await this.templateRepository.remove(template)
+  }
+
+  async processTemplate(
+    templateName: string,
+    data: Record<string, any>,
+  ): Promise<{ subject: string; message: string; htmlMessage?: string }> {
+    const template = await this.findByName(templateName)
+
+    let subject = template.subject
+    let message = template.template
+    let htmlMessage = template.htmlTemplate
+
+    // Replace variables in template
+    if (template.variables) {
+      for (const variable of template.variables) {
+        const value = data[variable] || template.defaultData?.[variable] || `{{${variable}}}`
+        const regex = new RegExp(`{{${variable}}}`, "g")
+
+        subject = subject.replace(regex, String(value))
+        message = message.replace(regex, String(value))
+
+        if (htmlMessage) {
+          htmlMessage = htmlMessage.replace(regex, String(value))
+        }
+      }
+    }
+
+    return { subject, message, htmlMessage }
+  }
+
+  async getTemplateVariables(templateName: string): Promise<string[]> {
+    const template = await this.findByName(templateName)
+    return template.variables || []
+  }
+
+  async validateTemplate(
+    templateName: string,
+    data: Record<string, any>,
+  ): Promise<{ valid: boolean; missingVariables: string[] }> {
+    const template = await this.findByName(templateName)
+    const requiredVariables = template.variables || []
+    const missingVariables = requiredVariables.filter(
+      (variable) => !(variable in data) && !(variable in (template.defaultData || {})),
+    )
+
+    return {
+      valid: missingVariables.length === 0,
+      missingVariables,
+    }
+  }
+}

--- a/backend/src/notifications/services/notification.service.ts
+++ b/backend/src/notifications/services/notification.service.ts
@@ -1,0 +1,290 @@
+import { Injectable, NotFoundException } from "@nestjs/common"
+import type { EventEmitter2 } from "@nestjs/event-emitter"
+import type { Repository } from "typeorm"
+import { type Notification, NotificationStatus, type NotificationChannel } from "../entities/notification.entity"
+import type { CreateNotificationDto } from "../dto/create-notification.dto"
+import type { SendNotificationDto } from "../dto/send-notification.dto"
+
+export interface NotificationFilters {
+  recipientId?: string
+  type?: string
+  channel?: NotificationChannel
+  status?: NotificationStatus
+  startDate?: Date
+  endDate?: Date
+  priority?: string
+}
+
+@Injectable()
+export class NotificationService {
+  constructor(
+    private notificationRepository: Repository<Notification>,
+    private eventEmitter: EventEmitter2,
+  ) {}
+
+  async create(createNotificationDto: CreateNotificationDto): Promise<Notification> {
+    const notification = this.notificationRepository.create({
+      ...createNotificationDto,
+      scheduledAt: createNotificationDto.scheduledAt ? new Date(createNotificationDto.scheduledAt) : new Date(),
+      expiresAt: createNotificationDto.expiresAt ? new Date(createNotificationDto.expiresAt) : null,
+    })
+
+    const savedNotification = await this.notificationRepository.save(notification)
+
+    // Emit event for processing
+    this.eventEmitter.emit("notification.created", savedNotification)
+
+    return savedNotification
+  }
+
+  async sendNotification(sendNotificationDto: SendNotificationDto): Promise<Notification[]> {
+    const notifications: Notification[] = []
+
+    for (const recipientId of sendNotificationDto.recipientIds) {
+      for (const channel of sendNotificationDto.channels) {
+        // Get recipient details (in real app, fetch from user service)
+        const recipientEmail = `user-${recipientId}@example.com`
+        const recipientName = `User ${recipientId}`
+
+        let title = sendNotificationDto.customTitle || ""
+        let message = sendNotificationDto.customMessage || ""
+
+        // If using template, process it
+        if (sendNotificationDto.templateName) {
+          const processed = await this.processTemplate(
+            sendNotificationDto.templateName,
+            channel,
+            sendNotificationDto.templateData || {},
+          )
+          title = processed.subject
+          message = processed.message
+        }
+
+        const notification = await this.create({
+          type: sendNotificationDto.type,
+          channel,
+          priority: sendNotificationDto.priority,
+          recipientId,
+          recipientEmail,
+          recipientName,
+          title,
+          message,
+          relatedEntityId: sendNotificationDto.relatedEntityId,
+          relatedEntityType: sendNotificationDto.relatedEntityType,
+          actionUrl: sendNotificationDto.actionUrl,
+          actionText: sendNotificationDto.actionText,
+          senderId: sendNotificationDto.senderId,
+          senderName: sendNotificationDto.senderName,
+          data: sendNotificationDto.templateData,
+        })
+
+        notifications.push(notification)
+      }
+    }
+
+    return notifications
+  }
+
+  async findAll(
+    page = 1,
+    limit = 10,
+    filters?: NotificationFilters,
+  ): Promise<{ data: Notification[]; total: number; page: number; limit: number }> {
+    const skip = (page - 1) * limit
+
+    const queryBuilder = this.notificationRepository.createQueryBuilder("notification")
+
+    if (filters?.recipientId) {
+      queryBuilder.andWhere("notification.recipientId = :recipientId", { recipientId: filters.recipientId })
+    }
+
+    if (filters?.type) {
+      queryBuilder.andWhere("notification.type = :type", { type: filters.type })
+    }
+
+    if (filters?.channel) {
+      queryBuilder.andWhere("notification.channel = :channel", { channel: filters.channel })
+    }
+
+    if (filters?.status) {
+      queryBuilder.andWhere("notification.status = :status", { status: filters.status })
+    }
+
+    if (filters?.startDate) {
+      queryBuilder.andWhere("notification.createdAt >= :startDate", { startDate: filters.startDate })
+    }
+
+    if (filters?.endDate) {
+      queryBuilder.andWhere("notification.createdAt <= :endDate", { endDate: filters.endDate })
+    }
+
+    const [data, total] = await queryBuilder
+      .orderBy("notification.createdAt", "DESC")
+      .skip(skip)
+      .take(limit)
+      .getManyAndCount()
+
+    return { data, total, page, limit }
+  }
+
+  async findOne(id: string): Promise<Notification> {
+    const notification = await this.notificationRepository.findOne({ where: { id } })
+
+    if (!notification) {
+      throw new NotFoundException(`Notification with ID ${id} not found`)
+    }
+
+    return notification
+  }
+
+  async markAsRead(id: string): Promise<Notification> {
+    const notification = await this.findOne(id)
+
+    notification.status = NotificationStatus.READ
+    notification.readAt = new Date()
+
+    return this.notificationRepository.save(notification)
+  }
+
+  async markAsDelivered(id: string): Promise<Notification> {
+    const notification = await this.findOne(id)
+
+    notification.status = NotificationStatus.DELIVERED
+    notification.deliveredAt = new Date()
+
+    return this.notificationRepository.save(notification)
+  }
+
+  async markAsFailed(id: string, errorMessage: string): Promise<Notification> {
+    const notification = await this.findOne(id)
+
+    notification.status = NotificationStatus.FAILED
+    notification.errorMessage = errorMessage
+    notification.retryCount += 1
+
+    return this.notificationRepository.save(notification)
+  }
+
+  async getUnreadCount(recipientId: string): Promise<number> {
+    return this.notificationRepository.count({
+      where: {
+        recipientId,
+        status: NotificationStatus.SENT,
+      },
+    })
+  }
+
+  async getNotificationStats(recipientId?: string): Promise<{
+    total: number
+    unread: number
+    byStatus: Record<NotificationStatus, number>
+    byType: Record<string, number>
+    byChannel: Record<NotificationChannel, number>
+  }> {
+    const queryBuilder = this.notificationRepository.createQueryBuilder("notification")
+
+    if (recipientId) {
+      queryBuilder.where("notification.recipientId = :recipientId", { recipientId })
+    }
+
+    const total = await queryBuilder.getCount()
+
+    const unreadQuery = queryBuilder.clone()
+    const unread = await unreadQuery
+      .andWhere("notification.status = :status", { status: NotificationStatus.SENT })
+      .getCount()
+
+    const statusStats = await queryBuilder
+      .clone()
+      .select("notification.status", "status")
+      .addSelect("COUNT(*)", "count")
+      .groupBy("notification.status")
+      .getRawMany()
+
+    const typeStats = await queryBuilder
+      .clone()
+      .select("notification.type", "type")
+      .addSelect("COUNT(*)", "count")
+      .groupBy("notification.type")
+      .getRawMany()
+
+    const channelStats = await queryBuilder
+      .clone()
+      .select("notification.channel", "channel")
+      .addSelect("COUNT(*)", "count")
+      .groupBy("notification.channel")
+      .getRawMany()
+
+    return {
+      total,
+      unread,
+      byStatus: statusStats.reduce(
+        (acc, item) => {
+          acc[item.status] = Number.parseInt(item.count)
+          return acc
+        },
+        {} as Record<NotificationStatus, number>,
+      ),
+      byType: typeStats.reduce(
+        (acc, item) => {
+          acc[item.type] = Number.parseInt(item.count)
+          return acc
+        },
+        {} as Record<string, number>,
+      ),
+      byChannel: channelStats.reduce(
+        (acc, item) => {
+          acc[item.channel] = Number.parseInt(item.count)
+          return acc
+        },
+        {} as Record<NotificationChannel, number>,
+      ),
+    }
+  }
+
+  async bulkMarkAsRead(recipientId: string, notificationIds?: string[]): Promise<void> {
+    const queryBuilder = this.notificationRepository
+      .createQueryBuilder()
+      .update(Notification)
+      .set({
+        status: NotificationStatus.READ,
+        readAt: new Date(),
+      })
+      .where("recipientId = :recipientId", { recipientId })
+
+    if (notificationIds && notificationIds.length > 0) {
+      queryBuilder.andWhere("id IN (:...ids)", { ids: notificationIds })
+    }
+
+    await queryBuilder.execute()
+  }
+
+  async deleteOldNotifications(olderThanDays: number): Promise<number> {
+    const cutoffDate = new Date()
+    cutoffDate.setDate(cutoffDate.getDate() - olderThanDays)
+
+    const result = await this.notificationRepository
+      .createQueryBuilder()
+      .delete()
+      .where("createdAt < :cutoffDate", { cutoffDate })
+      .andWhere("status IN (:...statuses)", {
+        statuses: [NotificationStatus.READ, NotificationStatus.DELIVERED, NotificationStatus.FAILED],
+      })
+      .execute()
+
+    return result.affected || 0
+  }
+
+  private async processTemplate(
+    templateName: string,
+    channel: NotificationChannel,
+    data: Record<string, any>,
+  ): Promise<{ subject: string; message: string }> {
+    // In a real implementation, this would fetch from NotificationTemplateService
+    // For now, return mock processed template
+    return {
+      subject: `Processed template: ${templateName}`,
+      message: `Template message with data: ${JSON.stringify(data)}`,
+    }
+  }
+}

--- a/backend/src/notifications/tests/email.service.spec.ts
+++ b/backend/src/notifications/tests/email.service.spec.ts
@@ -1,0 +1,117 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { EmailService } from "../services/email.service"
+import type { EmailOptions } from "../services/email.service"
+import { jest } from "@jest/globals"
+
+describe("EmailService", () => {
+  let service: EmailService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmailService],
+    }).compile()
+
+    service = module.get<EmailService>(EmailService)
+  })
+
+  afterEach(() => {
+    service.clearEmailQueue()
+  })
+
+  describe("sendEmail", () => {
+    it("should send email and add to queue", async () => {
+      const emailOptions: EmailOptions = {
+        to: "test@example.com",
+        subject: "Test Email",
+        text: "This is a test email",
+      }
+
+      const result = await service.sendEmail(emailOptions)
+
+      expect(result.success).toBe(true)
+      expect(result.messageId).toBeDefined()
+      expect(service.getQueueSize()).toBe(1)
+
+      const queue = service.getEmailQueue()
+      expect(queue[0].email).toEqual(emailOptions)
+    })
+
+    it("should handle email sending errors", async () => {
+      // Mock console.error to avoid test output
+      const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {})
+
+      // Force an error by passing invalid options
+      const emailOptions = null as any
+
+      const result = await service.sendEmail(emailOptions)
+
+      expect(result.success).toBe(false)
+      expect(result.error).toBeDefined()
+
+      consoleSpy.mockRestore()
+    })
+  })
+
+  describe("sendBulkEmails", () => {
+    it("should send multiple emails", async () => {
+      const emails: EmailOptions[] = [
+        { to: "user1@example.com", subject: "Email 1", text: "Message 1" },
+        { to: "user2@example.com", subject: "Email 2", text: "Message 2" },
+        { to: "user3@example.com", subject: "Email 3", text: "Message 3" },
+      ]
+
+      const results = await service.sendBulkEmails(emails)
+
+      expect(results).toHaveLength(3)
+      expect(results.every((r) => r.success)).toBe(true)
+      expect(service.getQueueSize()).toBe(3)
+    })
+  })
+
+  describe("sendTemplateEmail", () => {
+    it("should send email using template", async () => {
+      const result = await service.sendTemplateEmail("user@example.com", "shipment_created", {
+        trackingNumber: "TRK123456",
+        recipientName: "John Doe",
+        origin: "New York",
+        destination: "Los Angeles",
+        estimatedDelivery: "2024-01-15",
+        items: [{ name: "Widget", quantity: 1, value: 25 }],
+        actionUrl: "https://app.example.com/track/TRK123456",
+      })
+
+      expect(result.success).toBe(true)
+      expect(service.getQueueSize()).toBe(1)
+
+      const queue = service.getEmailQueue()
+      const sentEmail = queue[0].email
+
+      expect(sentEmail.to).toBe("user@example.com")
+      expect(sentEmail.subject).toContain("TRK123456")
+      expect(sentEmail.text).toContain("John Doe")
+      expect(sentEmail.text).toContain("New York")
+      expect(sentEmail.html).toContain("TRK123456")
+    })
+  })
+
+  describe("queue management", () => {
+    it("should manage email queue correctly", async () => {
+      expect(service.getQueueSize()).toBe(0)
+
+      await service.sendEmail({
+        to: "test@example.com",
+        subject: "Test",
+        text: "Test message",
+      })
+
+      expect(service.getQueueSize()).toBe(1)
+
+      const queue = service.getEmailQueue()
+      expect(queue).toHaveLength(1)
+      expect(queue[0].email.to).toBe("test@example.com")
+
+      service.clearEmailQueue()
+      expect(service.getQueueSize()).toBe(0)
+    })
+  })
+})

--- a/backend/src/notifications/tests/in-app-notification.service.spec.ts
+++ b/backend/src/notifications/tests/in-app-notification.service.spec.ts
@@ -1,0 +1,200 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { InAppNotificationService } from "../services/in-app-notification.service"
+import { type Notification, NotificationType, NotificationChannel } from "../entities/notification.entity"
+
+describe("InAppNotificationService", () => {
+  let service: InAppNotificationService
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [InAppNotificationService],
+    }).compile()
+
+    service = module.get<InAppNotificationService>(InAppNotificationService)
+  })
+
+  afterEach(() => {
+    service.clearAllQueues()
+  })
+
+  describe("sendInAppNotification", () => {
+    it("should send in-app notification", async () => {
+      const notification = {
+        id: "notif-1",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Shipment Created",
+        message: "Your shipment has been created",
+        data: { trackingNumber: "TRK123456" },
+        actionUrl: "https://app.example.com/track",
+        actionText: "Track Shipment",
+      } as Notification
+
+      await service.sendInAppNotification(notification)
+
+      const userNotifications = await service.getUserNotifications("user-1")
+      expect(userNotifications).toHaveLength(1)
+      expect(userNotifications[0].id).toBe("notif-1")
+      expect(userNotifications[0].title).toBe("Shipment Created")
+      expect(userNotifications[0].read).toBe(false)
+    })
+
+    it("should limit notifications per user to 100", async () => {
+      const notification = {
+        id: "notif-base",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      // Send 105 notifications
+      for (let i = 0; i < 105; i++) {
+        await service.sendInAppNotification({
+          ...notification,
+          id: `notif-${i}`,
+        })
+      }
+
+      const userNotifications = await service.getUserNotifications("user-1", 200)
+      expect(userNotifications).toHaveLength(100)
+      expect(userNotifications[0].id).toBe("notif-104") // Most recent first
+    })
+  })
+
+  describe("getUserNotifications", () => {
+    it("should return user notifications with limit", async () => {
+      const notification = {
+        id: "notif-base",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      // Send 25 notifications
+      for (let i = 0; i < 25; i++) {
+        await service.sendInAppNotification({
+          ...notification,
+          id: `notif-${i}`,
+        })
+      }
+
+      const notifications = await service.getUserNotifications("user-1", 10)
+      expect(notifications).toHaveLength(10)
+      expect(notifications[0].id).toBe("notif-24") // Most recent first
+    })
+  })
+
+  describe("getUnreadCount", () => {
+    it("should return correct unread count", async () => {
+      const notification = {
+        id: "notif-base",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      // Send 5 notifications
+      for (let i = 0; i < 5; i++) {
+        await service.sendInAppNotification({
+          ...notification,
+          id: `notif-${i}`,
+        })
+      }
+
+      let unreadCount = await service.getUnreadCount("user-1")
+      expect(unreadCount).toBe(5)
+
+      // Mark 2 as read
+      await service.markAsRead("user-1", "notif-0")
+      await service.markAsRead("user-1", "notif-1")
+
+      unreadCount = await service.getUnreadCount("user-1")
+      expect(unreadCount).toBe(3)
+    })
+  })
+
+  describe("markAsRead", () => {
+    it("should mark notification as read", async () => {
+      const notification = {
+        id: "notif-1",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      await service.sendInAppNotification(notification)
+
+      let userNotifications = await service.getUserNotifications("user-1")
+      expect(userNotifications[0].read).toBe(false)
+
+      await service.markAsRead("user-1", "notif-1")
+
+      userNotifications = await service.getUserNotifications("user-1")
+      expect(userNotifications[0].read).toBe(true)
+    })
+  })
+
+  describe("markAllAsRead", () => {
+    it("should mark all notifications as read", async () => {
+      const notification = {
+        id: "notif-base",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      // Send 3 notifications
+      for (let i = 0; i < 3; i++) {
+        await service.sendInAppNotification({
+          ...notification,
+          id: `notif-${i}`,
+        })
+      }
+
+      let unreadCount = await service.getUnreadCount("user-1")
+      expect(unreadCount).toBe(3)
+
+      await service.markAllAsRead("user-1")
+
+      unreadCount = await service.getUnreadCount("user-1")
+      expect(unreadCount).toBe(0)
+    })
+  })
+
+  describe("queue management", () => {
+    it("should manage notification queues correctly", async () => {
+      expect(service.getQueueSize()).toBe(0)
+
+      const notification = {
+        id: "notif-1",
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.IN_APP,
+        recipientId: "user-1",
+        title: "Test Notification",
+        message: "Test message",
+      } as Notification
+
+      await service.sendInAppNotification(notification)
+
+      expect(service.getQueueSize()).toBe(1)
+
+      const allQueues = await service.getAllQueuedNotifications()
+      expect(allQueues.size).toBe(1)
+      expect(allQueues.get("user-1")).toHaveLength(1)
+
+      service.clearAllQueues()
+      expect(service.getQueueSize()).toBe(0)
+    })
+  })
+})

--- a/backend/src/notifications/tests/notification.service.spec.ts
+++ b/backend/src/notifications/tests/notification.service.spec.ts
@@ -1,0 +1,293 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { EventEmitter2 } from "@nestjs/event-emitter"
+import type { Repository } from "typeorm"
+import { NotFoundException } from "@nestjs/common"
+import { NotificationService } from "../services/notification.service"
+import {
+  Notification,
+  NotificationType,
+  NotificationChannel,
+  NotificationStatus,
+  NotificationPriority,
+} from "../entities/notification.entity"
+import type { CreateNotificationDto } from "../dto/create-notification.dto"
+import { jest } from "@jest/globals"
+
+describe("NotificationService", () => {
+  let service: NotificationService
+  let repository: Repository<Notification>
+  let eventEmitter: EventEmitter2
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    count: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  }
+
+  const mockEventEmitter = {
+    emit: jest.fn(),
+  }
+
+  const mockQueryBuilder = {
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    skip: jest.fn().mockReturnThis(),
+    take: jest.fn().mockReturnThis(),
+    getManyAndCount: jest.fn(),
+    getCount: jest.fn(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn(),
+    where: jest.fn().mockReturnThis(),
+    clone: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+    execute: jest.fn(),
+    delete: jest.fn().mockReturnThis(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NotificationService,
+        {
+          provide: getRepositoryToken(Notification),
+          useValue: mockRepository,
+        },
+        {
+          provide: EventEmitter2,
+          useValue: mockEventEmitter,
+        },
+      ],
+    }).compile()
+
+    service = module.get<NotificationService>(NotificationService)
+    repository = module.get<Repository<Notification>>(getRepositoryToken(Notification))
+    eventEmitter = module.get<EventEmitter2>(EventEmitter2)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("create", () => {
+    it("should create a notification", async () => {
+      const createDto: CreateNotificationDto = {
+        type: NotificationType.SHIPMENT_CREATED,
+        channel: NotificationChannel.EMAIL,
+        priority: NotificationPriority.NORMAL,
+        recipientId: "user-1",
+        recipientEmail: "user@example.com",
+        recipientName: "John Doe",
+        title: "Shipment Created",
+        message: "Your shipment has been created",
+      }
+
+      const mockNotification = {
+        id: "notification-1",
+        ...createDto,
+        status: NotificationStatus.PENDING,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+
+      mockRepository.create.mockReturnValue(mockNotification)
+      mockRepository.save.mockResolvedValue(mockNotification)
+
+      const result = await service.create(createDto)
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        ...createDto,
+        scheduledAt: expect.any(Date),
+        expiresAt: null,
+      })
+      expect(mockRepository.save).toHaveBeenCalledWith(mockNotification)
+      expect(mockEventEmitter.emit).toHaveBeenCalledWith("notification.created", mockNotification)
+      expect(result).toEqual(mockNotification)
+    })
+  })
+
+  describe("findAll", () => {
+    it("should return paginated notifications", async () => {
+      const mockNotifications = [
+        { id: "1", title: "Test 1", type: NotificationType.SHIPMENT_CREATED },
+        { id: "2", title: "Test 2", type: NotificationType.SHIPMENT_DELIVERED },
+      ]
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([mockNotifications, 2])
+
+      const result = await service.findAll(1, 10)
+
+      expect(result).toEqual({
+        data: mockNotifications,
+        total: 2,
+        page: 1,
+        limit: 10,
+      })
+    })
+
+    it("should apply filters correctly", async () => {
+      const filters = {
+        recipientId: "user-1",
+        type: NotificationType.SHIPMENT_CREATED.toString(),
+        channel: NotificationChannel.EMAIL,
+        status: NotificationStatus.SENT,
+      }
+
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getManyAndCount.mockResolvedValue([[], 0])
+
+      await service.findAll(1, 10, filters)
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("notification.recipientId = :recipientId", {
+        recipientId: "user-1",
+      })
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("notification.type = :type", {
+        type: NotificationType.SHIPMENT_CREATED.toString(),
+      })
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("notification.channel = :channel", {
+        channel: NotificationChannel.EMAIL,
+      })
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("notification.status = :status", {
+        status: NotificationStatus.SENT,
+      })
+    })
+  })
+
+  describe("findOne", () => {
+    it("should return a notification by id", async () => {
+      const mockNotification = {
+        id: "notification-1",
+        title: "Test Notification",
+        message: "Test message",
+      }
+
+      mockRepository.findOne.mockResolvedValue(mockNotification)
+
+      const result = await service.findOne("notification-1")
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "notification-1" },
+      })
+      expect(result).toEqual(mockNotification)
+    })
+
+    it("should throw NotFoundException when notification not found", async () => {
+      mockRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.findOne("notification-1")).rejects.toThrow(NotFoundException)
+    })
+  })
+
+  describe("markAsRead", () => {
+    it("should mark notification as read", async () => {
+      const mockNotification = {
+        id: "notification-1",
+        status: NotificationStatus.SENT,
+        readAt: null,
+      }
+
+      mockRepository.findOne.mockResolvedValue(mockNotification)
+      mockRepository.save.mockResolvedValue({
+        ...mockNotification,
+        status: NotificationStatus.READ,
+        readAt: expect.any(Date),
+      })
+
+      const result = await service.markAsRead("notification-1")
+
+      expect(result.status).toBe(NotificationStatus.READ)
+      expect(result.readAt).toBeDefined()
+    })
+  })
+
+  describe("getUnreadCount", () => {
+    it("should return unread count for recipient", async () => {
+      mockRepository.count.mockResolvedValue(5)
+
+      const result = await service.getUnreadCount("user-1")
+
+      expect(mockRepository.count).toHaveBeenCalledWith({
+        where: {
+          recipientId: "user-1",
+          status: NotificationStatus.SENT,
+        },
+      })
+      expect(result).toBe(5)
+    })
+  })
+
+  describe("getNotificationStats", () => {
+    it("should return notification statistics", async () => {
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.getCount.mockResolvedValue(100)
+
+      const mockClone = {
+        ...mockQueryBuilder,
+        andWhere: jest.fn().mockReturnThis(),
+        getCount: jest.fn().mockResolvedValue(25),
+      }
+      mockQueryBuilder.clone.mockReturnValue(mockClone)
+
+      mockQueryBuilder.getRawMany
+        .mockResolvedValueOnce([
+          { status: NotificationStatus.SENT, count: "50" },
+          { status: NotificationStatus.READ, count: "30" },
+        ])
+        .mockResolvedValueOnce([
+          { type: NotificationType.SHIPMENT_CREATED, count: "40" },
+          { type: NotificationType.SHIPMENT_DELIVERED, count: "35" },
+        ])
+        .mockResolvedValueOnce([
+          { channel: NotificationChannel.EMAIL, count: "60" },
+          { channel: NotificationChannel.IN_APP, count: "40" },
+        ])
+
+      const result = await service.getNotificationStats("user-1")
+
+      expect(result.total).toBe(100)
+      expect(result.unread).toBe(25)
+      expect(result.byStatus[NotificationStatus.SENT]).toBe(50)
+      expect(result.byType[NotificationType.SHIPMENT_CREATED]).toBe(40)
+      expect(result.byChannel[NotificationChannel.EMAIL]).toBe(60)
+    })
+  })
+
+  describe("bulkMarkAsRead", () => {
+    it("should bulk mark notifications as read", async () => {
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.execute.mockResolvedValue({ affected: 5 })
+
+      await service.bulkMarkAsRead("user-1", ["notif-1", "notif-2"])
+
+      expect(mockQueryBuilder.update).toHaveBeenCalledWith(Notification)
+      expect(mockQueryBuilder.set).toHaveBeenCalledWith({
+        status: NotificationStatus.READ,
+        readAt: expect.any(Date),
+      })
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith("recipientId = :recipientId", { recipientId: "user-1" })
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("id IN (:...ids)", { ids: ["notif-1", "notif-2"] })
+    })
+  })
+
+  describe("deleteOldNotifications", () => {
+    it("should delete old notifications", async () => {
+      mockRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockQueryBuilder.execute.mockResolvedValue({ affected: 10 })
+
+      const result = await service.deleteOldNotifications(30)
+
+      expect(mockQueryBuilder.delete).toHaveBeenCalled()
+      expect(mockQueryBuilder.where).toHaveBeenCalledWith("createdAt < :cutoffDate", {
+        cutoffDate: expect.any(Date),
+      })
+      expect(result).toBe(10)
+    })
+  })
+})

--- a/backend/src/notifications/tests/shipment.listener.spec.ts
+++ b/backend/src/notifications/tests/shipment.listener.spec.ts
@@ -1,0 +1,158 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { ShipmentNotificationListener } from "../listeners/shipment.listener"
+import { NotificationService } from "../services/notification.service"
+import { NotificationPreferenceService } from "../services/notification-preference.service"
+import { NotificationType, NotificationChannel, NotificationPriority } from "../entities/notification.entity"
+import { ShipmentCreatedEvent, ShipmentDeliveredEvent } from "../events/shipment.events"
+import { jest } from "@jest/globals"
+
+describe("ShipmentNotificationListener", () => {
+  let listener: ShipmentNotificationListener
+  let notificationService: NotificationService
+  let preferenceService: NotificationPreferenceService
+
+  const mockNotificationService = {
+    sendNotification: jest.fn(),
+  }
+
+  const mockPreferenceService = {
+    getEnabledChannels: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShipmentNotificationListener,
+        {
+          provide: NotificationService,
+          useValue: mockNotificationService,
+        },
+        {
+          provide: NotificationPreferenceService,
+          useValue: mockPreferenceService,
+        },
+      ],
+    }).compile()
+
+    listener = module.get<ShipmentNotificationListener>(ShipmentNotificationListener)
+    notificationService = module.get<NotificationService>(NotificationService)
+    preferenceService = module.get<NotificationPreferenceService>(NotificationPreferenceService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("handleShipmentCreated", () => {
+    it("should send notifications for shipment created event", async () => {
+      const event = new ShipmentCreatedEvent(
+        "shipment-1",
+        "TRK123456",
+        "user-1",
+        "user@example.com",
+        "John Doe",
+        "New York",
+        "Los Angeles",
+        new Date("2024-01-15"),
+        [{ name: "Widget", quantity: 2, value: 50 }],
+      )
+
+      const enabledChannels = [NotificationChannel.EMAIL, NotificationChannel.IN_APP]
+      mockPreferenceService.getEnabledChannels.mockResolvedValue(enabledChannels)
+      mockNotificationService.sendNotification.mockResolvedValue([])
+
+      await listener.handleShipmentCreated(event)
+
+      expect(mockPreferenceService.getEnabledChannels).toHaveBeenCalledWith("user-1", NotificationType.SHIPMENT_CREATED)
+      expect(mockNotificationService.sendNotification).toHaveBeenCalledWith({
+        type: NotificationType.SHIPMENT_CREATED,
+        channels: enabledChannels,
+        priority: NotificationPriority.NORMAL,
+        recipientIds: ["user-1"],
+        templateName: "shipment_created",
+        templateData: {
+          shipmentId: "shipment-1",
+          trackingNumber: "TRK123456",
+          recipientName: "John Doe",
+          origin: "New York",
+          destination: "Los Angeles",
+          estimatedDelivery: "1/15/2024",
+          items: [{ name: "Widget", quantity: 2, value: 50 }],
+          actionUrl: "https://app.example.com/shipments/shipment-1/track",
+        },
+        relatedEntityId: "shipment-1",
+        relatedEntityType: "shipment",
+        actionUrl: "https://app.example.com/shipments/shipment-1/track",
+        actionText: "Track Shipment",
+      })
+    })
+
+    it("should skip notification if no enabled channels", async () => {
+      const event = new ShipmentCreatedEvent(
+        "shipment-1",
+        "TRK123456",
+        "user-1",
+        "user@example.com",
+        "John Doe",
+        "New York",
+        "Los Angeles",
+        new Date("2024-01-15"),
+        [],
+      )
+
+      mockPreferenceService.getEnabledChannels.mockResolvedValue([])
+
+      await listener.handleShipmentCreated(event)
+
+      expect(mockNotificationService.sendNotification).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("handleShipmentDelivered", () => {
+    it("should send notifications for shipment delivered event", async () => {
+      const event = new ShipmentDeliveredEvent(
+        "shipment-1",
+        "TRK123456",
+        "user-1",
+        "user@example.com",
+        "John Doe",
+        new Date("2024-01-15T14:30:00Z"),
+        "Front door",
+        "John Doe",
+        "Package left at front door",
+      )
+
+      const enabledChannels = [NotificationChannel.EMAIL, NotificationChannel.IN_APP]
+      mockPreferenceService.getEnabledChannels.mockResolvedValue(enabledChannels)
+      mockNotificationService.sendNotification.mockResolvedValue([])
+
+      await listener.handleShipmentDelivered(event)
+
+      expect(mockPreferenceService.getEnabledChannels).toHaveBeenCalledWith(
+        "user-1",
+        NotificationType.SHIPMENT_DELIVERED,
+      )
+      expect(mockNotificationService.sendNotification).toHaveBeenCalledWith({
+        type: NotificationType.SHIPMENT_DELIVERED,
+        channels: enabledChannels,
+        priority: NotificationPriority.HIGH,
+        recipientIds: ["user-1"],
+        templateName: "shipment_delivered",
+        templateData: {
+          shipmentId: "shipment-1",
+          trackingNumber: "TRK123456",
+          recipientName: "John Doe",
+          deliveredAt: event.deliveredAt.toLocaleString(),
+          deliveryLocation: "Front door",
+          signedBy: "John Doe",
+          deliveryNotes: "Package left at front door",
+          actionUrl: "https://app.example.com/shipments/shipment-1",
+        },
+        relatedEntityId: "shipment-1",
+        relatedEntityType: "shipment",
+        actionUrl: "https://app.example.com/shipments/shipment-1",
+        actionText: "View Shipment",
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces the **Notifications Module**, enabling both **in-app** and **email-based** notifications across the system. It lays the foundation for scalable and extensible notification delivery.

### What's Included:

* `notifications` module scaffolded under `src/notifications`
* Service layer for sending in-app and email notifications
* Interface and DTOs for notification payloads
* Integration with email service provider (e.g., `EmailService`)
* Simple in-app storage using TypeORM (NotificationEntity)
* Basic logic for triggering notifications via service calls

### Features:

* ✅ Send in-app notifications (e.g., alerts, system updates)
* ✅ Send transactional emails (e.g., verification, alerts)
* ✅ Centralized notification dispatch logic
* ✅ Basic unit tests for core services

### To Do in Future Iterations:

* User preferences for notification types
* Notification queueing (e.g., via BullMQ)
* Notification templates and localization
* Frontend rendering of in-app notifications

closes #332 
