### PR TITLE
Add Cache Module with Redis (Mocked Implementation)

### DIFF
--- a/backend/src/cache/cache.module.ts
+++ b/backend/src/cache/cache.module.ts
@@ -1,0 +1,56 @@
+import { Module, Global } from "@nestjs/common"
+import { ConfigModule, ConfigService } from "@nestjs/config"
+import { CacheService } from "./services/cache.service"
+import { ShipmentCacheService } from "./services/shipment-cache.service"
+import { CacheController } from "./controllers/cache.controller"
+import { ShipmentCacheController } from "./controllers/shipment-cache.controller"
+import type { CacheConfig } from "./interfaces/cache.interface"
+import { RolesModule } from "../roles/roles.module"
+
+@Global()
+@Module({
+  imports: [ConfigModule, RolesModule],
+  controllers: [CacheController, ShipmentCacheController],
+  providers: [
+    {
+      provide: "CACHE_CONFIG",
+      useFactory: (configService: ConfigService): CacheConfig => ({
+        provider: configService.get<"redis" | "memory">("CACHE_PROVIDER", "memory"),
+        redis: {
+          host: configService.get<string>("REDIS_HOST", "localhost"),
+          port: configService.get<number>("REDIS_PORT", 6379),
+          password: configService.get<string>("REDIS_PASSWORD"),
+          db: configService.get<number>("REDIS_DB", 0),
+          keyPrefix: configService.get<string>("REDIS_KEY_PREFIX", "app:"),
+          retryAttempts: configService.get<number>("REDIS_RETRY_ATTEMPTS", 3),
+          retryDelay: configService.get<number>("REDIS_RETRY_DELAY", 1000),
+          maxRetriesPerRequest: configService.get<number>("REDIS_MAX_RETRIES", 3),
+          lazyConnect: configService.get<boolean>("REDIS_LAZY_CONNECT", true),
+          keepAlive: configService.get<number>("REDIS_KEEP_ALIVE", 30000),
+          family: configService.get<number>("REDIS_FAMILY", 4),
+          connectTimeout: configService.get<number>("REDIS_CONNECT_TIMEOUT", 10000),
+          commandTimeout: configService.get<number>("REDIS_COMMAND_TIMEOUT", 5000),
+        },
+        memory: {
+          maxKeys: configService.get<number>("MEMORY_CACHE_MAX_KEYS", 10000),
+          maxMemory: configService.get<number>("MEMORY_CACHE_MAX_MEMORY", 100 * 1024 * 1024), // 100MB
+          ttl: configService.get<number>("MEMORY_CACHE_TTL", 3600),
+          checkPeriod: configService.get<number>("MEMORY_CACHE_CHECK_PERIOD", 60000),
+        },
+        defaultTtl: configService.get<number>("CACHE_DEFAULT_TTL", 3600),
+        namespace: configService.get<string>("CACHE_NAMESPACE", "app"),
+        compression: configService.get<boolean>("CACHE_COMPRESSION", false),
+        serialization: configService.get<boolean>("CACHE_SERIALIZATION", true),
+      }),
+      inject: [ConfigService],
+    },
+    {
+      provide: CacheService,
+      useFactory: (config: CacheConfig) => new CacheService(config),
+      inject: ["CACHE_CONFIG"],
+    },
+    ShipmentCacheService,
+  ],
+  exports: [CacheService, ShipmentCacheService],
+})
+export class CacheModule {}

--- a/backend/src/cache/controllers/cache.controller.ts
+++ b/backend/src/cache/controllers/cache.controller.ts
@@ -1,0 +1,102 @@
+import { Controller, Get, Post, Delete, Param, Query, UseGuards } from "@nestjs/common"
+import type { CacheService } from "../services/cache.service"
+import type { SetCacheDto, DeleteCacheDto, ExpireCacheDto, ClearCacheDto } from "../dto/cache.dto"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("cache")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class CacheController {
+  constructor(private readonly cacheService: CacheService) {}
+
+  @Post("set")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  async set(setCacheDto: SetCacheDto) {
+    const result = await this.cacheService.set(setCacheDto.key, setCacheDto.value, {
+      ttl: setCacheDto.ttl,
+      namespace: setCacheDto.namespace,
+      nx: setCacheDto.nx,
+    })
+
+    return { success: result, key: setCacheDto.key }
+  }
+
+  @Get("get/:key")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async get(@Param("key") key: string, @Query("namespace") namespace?: string) {
+    const value = await this.cacheService.get(key, { namespace })
+    return { key, value, found: value !== null }
+  }
+
+  @Delete("delete")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  async delete(deleteCacheDto: DeleteCacheDto) {
+    const deleted = await this.cacheService.del(deleteCacheDto.keys, deleteCacheDto.namespace)
+    return { deleted, keys: deleteCacheDto.keys }
+  }
+
+  @Get("exists/:key")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async exists(@Param("key") key: string, @Query("namespace") namespace?: string) {
+    const exists = await this.cacheService.exists(key, namespace)
+    return { key, exists }
+  }
+
+  @Get("ttl/:key")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async ttl(@Param("key") key: string, @Query("namespace") namespace?: string) {
+    const ttl = await this.cacheService.ttl(key, namespace)
+    return { key, ttl }
+  }
+
+  @Post("expire")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.UPDATE, resource: PermissionResource.ALL })
+  async expire(expireCacheDto: ExpireCacheDto) {
+    const result = await this.cacheService.expire(expireCacheDto.key, expireCacheDto.seconds, expireCacheDto.namespace)
+    return { success: result, key: expireCacheDto.key, seconds: expireCacheDto.seconds }
+  }
+
+  @Get("keys")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async keys(@Query("pattern") pattern: string, @Query("namespace") namespace?: string) {
+    const keys = await this.cacheService.keys(pattern || "*", namespace)
+    return { pattern: pattern || "*", keys, count: keys.length }
+  }
+
+  @Delete("clear")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  async clear(clearCacheDto: ClearCacheDto) {
+    const result = await this.cacheService.clear(clearCacheDto.namespace)
+    return { success: result, namespace: clearCacheDto.namespace || "default" }
+  }
+
+  @Get("stats")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async getStats() {
+    const stats = await this.cacheService.getStats()
+    const provider = this.cacheService.getProviderInfo()
+    return { stats, provider }
+  }
+
+  @Get("health")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async health() {
+    const isHealthy = await this.cacheService.isHealthy()
+    const provider = this.cacheService.getProviderInfo()
+    return { healthy: isHealthy, provider, timestamp: new Date().toISOString() }
+  }
+}

--- a/backend/src/cache/controllers/shipment-cache.controller.ts
+++ b/backend/src/cache/controllers/shipment-cache.controller.ts
@@ -1,0 +1,169 @@
+import { Controller, Get, Post, Delete, Body, UseGuards } from "@nestjs/common"
+import type { ShipmentCacheService, ShipmentStatus } from "../services/shipment-cache.service"
+import type { WarmupCacheDto } from "../dto/cache.dto"
+import { RolesGuard } from "../../roles/guards/roles.guard"
+import { PermissionsGuard } from "../../roles/guards/permissions.guard"
+import { Roles } from "../../roles/decorators/roles.decorator"
+import { RequirePermissions } from "../../roles/decorators/permissions.decorator"
+import { RoleType } from "../../roles/entities/role.entity"
+import { PermissionAction, PermissionResource } from "../../roles/entities/permission.entity"
+
+@Controller("cache/shipments")
+@UseGuards(RolesGuard, PermissionsGuard)
+export class ShipmentCacheController {
+  constructor(private readonly shipmentCacheService: ShipmentCacheService) {}
+
+  @Get("status/:shipmentId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async getShipmentStatus(shipmentId: string) {
+    const status = await this.shipmentCacheService.getShipmentStatus(shipmentId)
+    return {
+      shipmentId,
+      status,
+      cached: status !== null,
+      timestamp: new Date().toISOString(),
+    }
+  }
+
+  @Post("status/:shipmentId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  async setShipmentStatus(shipmentId: string, @Body() status: ShipmentStatus) {
+    const result = await this.shipmentCacheService.setShipmentStatus(shipmentId, status)
+    return {
+      success: result,
+      shipmentId,
+      message: result ? "Shipment status cached successfully" : "Failed to cache shipment status",
+    }
+  }
+
+  @Get("tracking/:trackingNumber")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async getShipmentByTracking(trackingNumber: string) {
+    const result = await this.shipmentCacheService.getShipmentByTracking(trackingNumber)
+    return {
+      trackingNumber,
+      result,
+      found: result !== null,
+    }
+  }
+
+  @Delete("status/:shipmentId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  async invalidateShipmentStatus(shipmentId: string) {
+    await this.shipmentCacheService.invalidateShipmentStatus(shipmentId)
+    return {
+      success: true,
+      shipmentId,
+      message: "Shipment status cache invalidated",
+    }
+  }
+
+  @Get("user/:userId/shipments")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.USER })
+  async getUserShipments(userId: string) {
+    const shipments = await this.shipmentCacheService.getUserShipments(userId)
+    return {
+      userId,
+      shipments,
+      cached: shipments !== null,
+      count: shipments?.length || 0,
+    }
+  }
+
+  @Post("user/:userId/shipments")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.USER })
+  async setUserShipments(userId: string, @Body() shipments: ShipmentStatus[]) {
+    const result = await this.shipmentCacheService.setUserShipments(userId, shipments)
+    return {
+      success: result,
+      userId,
+      count: shipments.length,
+      message: result ? "User shipments cached successfully" : "Failed to cache user shipments",
+    }
+  }
+
+  @Get("events/:shipmentId")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST, RoleType.REVIEWER, RoleType.USER)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async getShipmentEvents(shipmentId: string) {
+    const events = await this.shipmentCacheService.getShipmentEvents(shipmentId)
+    return {
+      shipmentId,
+      events,
+      cached: events !== null,
+      count: events?.length || 0,
+    }
+  }
+
+  @Get("stats/:period")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ANALYTICS })
+  async getShipmentStats(period: "daily" | "weekly" | "monthly") {
+    const stats = await this.shipmentCacheService.getShipmentStats(period)
+    return {
+      period,
+      stats,
+      cached: stats !== null,
+    }
+  }
+
+  @Post("stats/:period")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ANALYTICS })
+  async setShipmentStats(period: "daily" | "weekly" | "monthly", @Body() stats: any) {
+    const result = await this.shipmentCacheService.setShipmentStats(period, stats)
+    return {
+      success: result,
+      period,
+      message: result ? "Shipment stats cached successfully" : "Failed to cache shipment stats",
+    }
+  }
+
+  @Post("warmup")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.CREATE, resource: PermissionResource.ALL })
+  async warmupCache(@Body() warmupDto: WarmupCacheDto) {
+    await this.shipmentCacheService.warmupCache(warmupDto.shipmentIds)
+    return {
+      success: true,
+      count: warmupDto.shipmentIds.length,
+      message: `Cache warmed up for ${warmupDto.shipmentIds.length} shipments`,
+    }
+  }
+
+  @Get("health")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.READ, resource: PermissionResource.ALL })
+  async getCacheHealth() {
+    return await this.shipmentCacheService.getCacheHealth()
+  }
+
+  @Delete("clear")
+  @Roles(RoleType.ADMIN)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.ALL })
+  async clearAllCache() {
+    const result = await this.shipmentCacheService.clearAllShipmentCache()
+    return {
+      success: result,
+      message: result ? "All shipment cache cleared successfully" : "Failed to clear shipment cache",
+    }
+  }
+
+  @Delete("user/:userId/queries")
+  @Roles(RoleType.ADMIN, RoleType.ANALYST)
+  @RequirePermissions({ action: PermissionAction.DELETE, resource: PermissionResource.USER })
+  async invalidateUserQueries(userId: string) {
+    await this.shipmentCacheService.invalidateQueriesForUser(userId)
+    return {
+      success: true,
+      userId,
+      message: "User query caches invalidated",
+    }
+  }
+}

--- a/backend/src/cache/dto/cache.dto.ts
+++ b/backend/src/cache/dto/cache.dto.ts
@@ -1,0 +1,103 @@
+import { IsString, IsOptional, IsNumber, IsBoolean, IsArray, Min, Max } from "class-validator"
+
+export class SetCacheDto {
+  @IsString()
+  key: string
+
+  value: any
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  ttl?: number
+
+  @IsOptional()
+  @IsString()
+  namespace?: string
+
+  @IsOptional()
+  @IsBoolean()
+  nx?: boolean
+}
+
+export class GetCacheDto {
+  @IsString()
+  key: string
+
+  @IsOptional()
+  @IsString()
+  namespace?: string
+}
+
+export class DeleteCacheDto {
+  @IsArray()
+  @IsString({ each: true })
+  keys: string[]
+
+  @IsOptional()
+  @IsString()
+  namespace?: string
+}
+
+export class ExpireCacheDto {
+  @IsString()
+  key: string
+
+  @IsNumber()
+  @Min(1)
+  seconds: number
+
+  @IsOptional()
+  @IsString()
+  namespace?: string
+}
+
+export class KeysDto {
+  @IsString()
+  pattern: string
+
+  @IsOptional()
+  @IsString()
+  namespace?: string
+}
+
+export class ClearCacheDto {
+  @IsOptional()
+  @IsString()
+  namespace?: string
+}
+
+export class WarmupCacheDto {
+  @IsArray()
+  @IsString({ each: true })
+  shipmentIds: string[]
+}
+
+export class ShipmentQueryDto {
+  @IsOptional()
+  @IsString()
+  userId?: string
+
+  @IsOptional()
+  @IsString()
+  status?: string
+
+  @IsOptional()
+  @IsString()
+  startDate?: string
+
+  @IsOptional()
+  @IsString()
+  endDate?: string
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  limit?: number
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  offset?: number
+}

--- a/backend/src/cache/example-usage.ts
+++ b/backend/src/cache/example-usage.ts
@@ -1,0 +1,327 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type { CacheService } from "./services/cache.service"
+import type { ShipmentCacheService, ShipmentStatus, ShipmentEvent } from "./services/shipment-cache.service"
+
+@Injectable()
+export class CacheExampleService {
+  private readonly logger = new Logger(CacheExampleService.name)
+
+  constructor(
+    private readonly cacheService: CacheService,
+    private readonly shipmentCacheService: ShipmentCacheService,
+  ) {}
+
+  // Basic cache operations examples
+  async basicCacheOperations(): Promise<void> {
+    this.logger.log("🔄 Demonstrating basic cache operations...")
+
+    // Set a simple value
+    await this.cacheService.set("user:123", { name: "John Doe", email: "john@example.com" }, { ttl: 3600 })
+
+    // Get the value
+    const user = await this.cacheService.get("user:123")
+    this.logger.log("Retrieved user:", user)
+
+    // Check if key exists
+    const exists = await this.cacheService.exists("user:123")
+    this.logger.log("User exists in cache:", exists)
+
+    // Get TTL
+    const ttl = await this.cacheService.ttl("user:123")
+    this.logger.log("TTL for user:123:", ttl, "seconds")
+
+    // Set with namespace
+    await this.cacheService.set("config", { theme: "dark", language: "en" }, { namespace: "app-settings" })
+
+    // Get with namespace
+    const config = await this.cacheService.get("config", { namespace: "app-settings" })
+    this.logger.log("App config:", config)
+  }
+
+  // Shipment caching examples
+  async shipmentCachingExamples(): Promise<void> {
+    this.logger.log("📦 Demonstrating shipment caching...")
+
+    // Create sample shipment data
+    const shipmentId = "shipment-demo-001"
+    const shipmentStatus: ShipmentStatus = {
+      id: shipmentId,
+      trackingNumber: "TRK123456789",
+      status: "in_transit",
+      currentLocation: "Distribution Center - Chicago",
+      estimatedDelivery: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000), // 2 days from now
+      lastUpdated: new Date(),
+      events: [
+        {
+          id: "event-1",
+          timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000), // 1 day ago
+          status: "created",
+          location: "Origin Facility",
+          description: "Shipment created and ready for pickup",
+        },
+        {
+          id: "event-2",
+          timestamp: new Date(Date.now() - 12 * 60 * 60 * 1000), // 12 hours ago
+          status: "in_transit",
+          location: "Distribution Center - Chicago",
+          description: "Package arrived at distribution center",
+        },
+      ],
+    }
+
+    // Cache shipment status
+    await this.shipmentCacheService.setShipmentStatus(shipmentId, shipmentStatus)
+    this.logger.log("✅ Cached shipment status")
+
+    // Retrieve shipment status
+    const cachedStatus = await this.shipmentCacheService.getShipmentStatus(shipmentId)
+    this.logger.log("📋 Retrieved shipment status:", cachedStatus?.status, cachedStatus?.currentLocation)
+
+    // Get shipment by tracking number
+    const trackingResult = await this.shipmentCacheService.getShipmentByTracking("TRK123456789")
+    this.logger.log("🔍 Found by tracking number:", trackingResult)
+
+    // Add a new event
+    const newEvent: ShipmentEvent = {
+      id: "event-3",
+      timestamp: new Date(),
+      status: "out_for_delivery",
+      location: "Local Delivery Hub",
+      description: "Package is out for delivery",
+    }
+
+    await this.shipmentCacheService.addShipmentEvent(shipmentId, newEvent)
+    this.logger.log("📝 Added new shipment event")
+
+    // Get updated events
+    const events = await this.shipmentCacheService.getShipmentEvents(shipmentId)
+    this.logger.log("📅 Total events:", events?.length)
+  }
+
+  // User shipments caching example
+  async userShipmentsCaching(): Promise<void> {
+    this.logger.log("👤 Demonstrating user shipments caching...")
+
+    const userId = "user-456"
+    const userShipments: ShipmentStatus[] = [
+      {
+        id: "shipment-001",
+        trackingNumber: "TRK001",
+        status: "delivered",
+        actualDelivery: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        lastUpdated: new Date(),
+        events: [],
+      },
+      {
+        id: "shipment-002",
+        trackingNumber: "TRK002",
+        status: "in_transit",
+        currentLocation: "Distribution Center",
+        estimatedDelivery: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        lastUpdated: new Date(),
+        events: [],
+      },
+    ]
+
+    // Cache user shipments
+    await this.shipmentCacheService.setUserShipments(userId, userShipments)
+    this.logger.log("✅ Cached user shipments")
+
+    // Retrieve user shipments
+    const cachedUserShipments = await this.shipmentCacheService.getUserShipments(userId)
+    this.logger.log("📦 User has", cachedUserShipments?.length, "shipments")
+  }
+
+  // Statistics caching example
+  async statisticsCaching(): Promise<void> {
+    this.logger.log("📊 Demonstrating statistics caching...")
+
+    const dailyStats = {
+      date: new Date().toISOString().split("T")[0],
+      totalShipments: 1250,
+      delivered: 980,
+      inTransit: 220,
+      delayed: 35,
+      cancelled: 15,
+      averageDeliveryTime: 2.3,
+      onTimeDeliveryRate: 94.2,
+    }
+
+    // Cache daily statistics
+    await this.shipmentCacheService.setShipmentStats("daily", dailyStats)
+    this.logger.log("✅ Cached daily statistics")
+
+    // Retrieve statistics
+    const cachedStats = await this.shipmentCacheService.getShipmentStats("daily")
+    this.logger.log("📈 Daily stats - Total shipments:", cachedStats?.totalShipments)
+    this.logger.log("📈 On-time delivery rate:", cachedStats?.onTimeDeliveryRate + "%")
+  }
+
+  // Advanced caching patterns
+  async advancedCachingPatterns(): Promise<void> {
+    this.logger.log("🚀 Demonstrating advanced caching patterns...")
+
+    // Cache with conditional set (NX - only if not exists)
+    const sessionKey = "session:abc123"
+    const sessionData = { userId: "user-789", loginTime: new Date(), permissions: ["read", "write"] }
+
+    const setResult = await this.cacheService.set(sessionKey, sessionData, { nx: true, ttl: 1800 })
+    this.logger.log("Session created:", setResult)
+
+    // Try to set again (should fail because key exists)
+    const setAgainResult = await this.cacheService.set(sessionKey, { ...sessionData, hacked: true }, { nx: true })
+    this.logger.log("Attempt to overwrite session:", setAgainResult) // Should be false
+
+    // Pattern matching for keys
+    await this.cacheService.set("user:123:profile", { name: "Alice" })
+    await this.cacheService.set("user:456:profile", { name: "Bob" })
+    await this.cacheService.set("user:789:profile", { name: "Charlie" })
+
+    const userProfileKeys = await this.cacheService.keys("user:*:profile")
+    this.logger.log("Found user profile keys:", userProfileKeys)
+
+    // Bulk operations
+    const keysToDelete = ["user:123:profile", "user:456:profile"]
+    const deletedCount = await this.cacheService.del(keysToDelete)
+    this.logger.log("Deleted", deletedCount, "user profiles")
+  }
+
+  // Cache performance monitoring
+  async cachePerformanceMonitoring(): Promise<void> {
+    this.logger.log("📊 Monitoring cache performance...")
+
+    // Generate some cache activity
+    for (let i = 0; i < 100; i++) {
+      await this.cacheService.set(`test:${i}`, { value: i, timestamp: new Date() }, { ttl: 300 })
+    }
+
+    // Generate some hits and misses
+    for (let i = 0; i < 150; i++) {
+      await this.cacheService.get(`test:${i}`) // Some will hit, some will miss
+    }
+
+    // Get cache statistics
+    const stats = await this.cacheService.getStats()
+    this.logger.log("📈 Cache Statistics:")
+    this.logger.log("  - Total keys:", stats.keys)
+    this.logger.log("  - Cache hits:", stats.hits)
+    this.logger.log("  - Cache misses:", stats.misses)
+    this.logger.log("  - Hit rate:", stats.hitRate + "%")
+    this.logger.log("  - Memory usage:", Math.round((stats.memory || 0) / 1024), "KB")
+
+    // Check cache health
+    const isHealthy = await this.cacheService.isHealthy()
+    this.logger.log("💚 Cache is healthy:", isHealthy)
+
+    // Get provider information
+    const providerInfo = this.cacheService.getProviderInfo()
+    this.logger.log("🔧 Cache provider:", providerInfo.primary)
+    this.logger.log("🔄 Using fallback:", providerInfo.usingFallback)
+  }
+
+  // Cache warmup example
+  async cacheWarmupExample(): Promise<void> {
+    this.logger.log("🔥 Demonstrating cache warmup...")
+
+    // Simulate warming up cache for frequently accessed shipments
+    const popularShipmentIds = [
+      "shipment-popular-001",
+      "shipment-popular-002",
+      "shipment-popular-003",
+      "shipment-popular-004",
+      "shipment-popular-005",
+    ]
+
+    await this.shipmentCacheService.warmupCache(popularShipmentIds)
+    this.logger.log("✅ Cache warmed up for", popularShipmentIds.length, "popular shipments")
+
+    // Verify warmup worked
+    for (const shipmentId of popularShipmentIds) {
+      const status = await this.shipmentCacheService.getShipmentStatus(shipmentId)
+      if (status) {
+        this.logger.log(`📦 ${shipmentId}: ${status.status} - ${status.trackingNumber}`)
+      }
+    }
+  }
+
+  // Cache invalidation patterns
+  async cacheInvalidationPatterns(): Promise<void> {
+    this.logger.log("🗑️ Demonstrating cache invalidation patterns...")
+
+    const userId = "user-invalidation-test"
+    const shipmentId = "shipment-invalidation-test"
+
+    // Set up some cached data
+    await this.shipmentCacheService.setUserShipments(userId, [
+      {
+        id: shipmentId,
+        trackingNumber: "TRK-INVALID-001",
+        status: "created",
+        lastUpdated: new Date(),
+        events: [],
+      },
+    ])
+
+    // Cache some query results (simulated)
+    await this.cacheService.set(`query:user-shipments:${userId}`, { cached: true }, { namespace: "queries" })
+
+    this.logger.log("✅ Set up cached data for invalidation test")
+
+    // Invalidate specific shipment
+    await this.shipmentCacheService.invalidateShipmentStatus(shipmentId)
+    this.logger.log("🗑️ Invalidated shipment status")
+
+    // Invalidate user queries
+    await this.shipmentCacheService.invalidateQueriesForUser(userId)
+    this.logger.log("🗑️ Invalidated user query caches")
+
+    // Verify invalidation
+    const shipmentStatus = await this.shipmentCacheService.getShipmentStatus(shipmentId)
+    const queryResult = await this.cacheService.get(`query:user-shipments:${userId}`, { namespace: "queries" })
+
+    this.logger.log("Shipment status after invalidation:", shipmentStatus === null ? "✅ Cleared" : "❌ Still cached")
+    this.logger.log("Query result after invalidation:", queryResult === null ? "✅ Cleared" : "❌ Still cached")
+  }
+
+  // Run all examples
+  async runAllExamples(): Promise<void> {
+    this.logger.log("🎯 Running comprehensive cache examples...")
+
+    try {
+      await this.basicCacheOperations()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.shipmentCachingExamples()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.userShipmentsCaching()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.statisticsCaching()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.advancedCachingPatterns()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.cacheWarmupExample()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.cacheInvalidationPatterns()
+      await new Promise((resolve) => setTimeout(resolve, 500))
+
+      await this.cachePerformanceMonitoring()
+
+      this.logger.log("🎉 All cache examples completed successfully!")
+    } catch (error) {
+      this.logger.error("❌ Error running cache examples:", error)
+    }
+  }
+
+  // Cleanup method
+  async cleanup(): Promise<void> {
+    this.logger.log("🧹 Cleaning up cache examples...")
+    await this.shipmentCacheService.clearAllShipmentCache()
+    await this.cacheService.clear()
+    this.logger.log("✅ Cache cleanup completed")
+  }
+}

--- a/backend/src/cache/interfaces/cache.interface.ts
+++ b/backend/src/cache/interfaces/cache.interface.ts
@@ -1,0 +1,67 @@
+export interface CacheOptions {
+  ttl?: number // Time to live in seconds
+  namespace?: string
+  compress?: boolean
+  serialize?: boolean
+}
+
+export interface CacheSetOptions extends CacheOptions {
+  nx?: boolean // Only set if key doesn't exist
+  ex?: number // Expiration time in seconds
+}
+
+export interface CacheGetOptions {
+  namespace?: string
+  decompress?: boolean
+  deserialize?: boolean
+}
+
+export interface CacheStats {
+  hits: number
+  misses: number
+  keys: number
+  memory?: number
+  hitRate: number
+}
+
+export interface CacheProvider {
+  get<T = any>(key: string, options?: CacheGetOptions): Promise<T | null>
+  set<T = any>(key: string, value: T, options?: CacheSetOptions): Promise<boolean>
+  del(key: string | string[], namespace?: string): Promise<number>
+  exists(key: string, namespace?: string): Promise<boolean>
+  ttl(key: string, namespace?: string): Promise<number>
+  expire(key: string, seconds: number, namespace?: string): Promise<boolean>
+  keys(pattern: string, namespace?: string): Promise<string[]>
+  clear(namespace?: string): Promise<boolean>
+  getStats(): Promise<CacheStats>
+  isHealthy(): Promise<boolean>
+}
+
+export interface CacheConfig {
+  provider: "redis" | "memory"
+  redis?: {
+    host: string
+    port: number
+    password?: string
+    db?: number
+    keyPrefix?: string
+    retryAttempts?: number
+    retryDelay?: number
+    maxRetriesPerRequest?: number
+    lazyConnect?: boolean
+    keepAlive?: number
+    family?: number
+    connectTimeout?: number
+    commandTimeout?: number
+  }
+  memory?: {
+    maxKeys?: number
+    maxMemory?: number
+    ttl?: number
+    checkPeriod?: number
+  }
+  defaultTtl?: number
+  namespace?: string
+  compression?: boolean
+  serialization?: boolean
+}

--- a/backend/src/cache/providers/memory-cache.provider.ts
+++ b/backend/src/cache/providers/memory-cache.provider.ts
@@ -1,0 +1,277 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type {
+  CacheProvider,
+  CacheSetOptions,
+  CacheGetOptions,
+  CacheStats,
+  CacheConfig,
+} from "../interfaces/cache.interface"
+
+interface CacheItem<T = any> {
+  value: T
+  expiry?: number
+  createdAt: number
+  accessCount: number
+  lastAccessed: number
+}
+
+@Injectable()
+export class MemoryCacheProvider implements CacheProvider {
+  private readonly logger = new Logger(MemoryCacheProvider.name)
+  private readonly storage = new Map<string, CacheItem>()
+  private readonly stats = {
+    hits: 0,
+    misses: 0,
+    operations: 0,
+    evictions: 0,
+  }
+  private cleanupInterval: NodeJS.Timeout
+
+  constructor(private readonly config: CacheConfig) {
+    this.startCleanupProcess()
+    this.logger.log("Memory cache provider initialized")
+  }
+
+  private startCleanupProcess(): void {
+    const checkPeriod = this.config.memory?.checkPeriod || 60000 // 1 minute
+
+    this.cleanupInterval = setInterval(() => {
+      this.cleanup()
+    }, checkPeriod)
+  }
+
+  private cleanup(): void {
+    const now = Date.now()
+    let cleaned = 0
+
+    for (const [key, item] of this.storage.entries()) {
+      if (item.expiry && now > item.expiry) {
+        this.storage.delete(key)
+        cleaned++
+      }
+    }
+
+    if (cleaned > 0) {
+      this.logger.debug(`Cleaned up ${cleaned} expired cache entries`)
+    }
+
+    // Check memory limits
+    this.enforceMemoryLimits()
+  }
+
+  private enforceMemoryLimits(): void {
+    const maxKeys = this.config.memory?.maxKeys
+    const maxMemory = this.config.memory?.maxMemory
+
+    if (maxKeys && this.storage.size > maxKeys) {
+      this.evictLeastRecentlyUsed(this.storage.size - maxKeys)
+    }
+
+    if (maxMemory) {
+      const currentMemory = this.getMemoryUsage()
+      if (currentMemory > maxMemory) {
+        // Evict 10% of entries to free up memory
+        const toEvict = Math.ceil(this.storage.size * 0.1)
+        this.evictLeastRecentlyUsed(toEvict)
+      }
+    }
+  }
+
+  private evictLeastRecentlyUsed(count: number): void {
+    const entries = Array.from(this.storage.entries())
+    entries.sort((a, b) => a[1].lastAccessed - b[1].lastAccessed)
+
+    for (let i = 0; i < count && i < entries.length; i++) {
+      this.storage.delete(entries[i][0])
+      this.stats.evictions++
+    }
+
+    this.logger.debug(`Evicted ${count} least recently used cache entries`)
+  }
+
+  private getMemoryUsage(): number {
+    // Rough estimation of memory usage
+    let size = 0
+    for (const [key, item] of this.storage.entries()) {
+      size += key.length * 2 // UTF-16 characters
+      size += JSON.stringify(item.value).length * 2
+      size += 64 // Overhead for item metadata
+    }
+    return size
+  }
+
+  private buildKey(key: string, namespace?: string): string {
+    const ns = namespace || this.config.namespace || "cache"
+    return `${ns}:${key}`
+  }
+
+  private isExpired(item: CacheItem): boolean {
+    return item.expiry ? Date.now() > item.expiry : false
+  }
+
+  async get<T = any>(key: string, options?: CacheGetOptions): Promise<T | null> {
+    this.stats.operations++
+    const fullKey = this.buildKey(key, options?.namespace)
+    const item = this.storage.get(fullKey)
+
+    if (!item || this.isExpired(item)) {
+      if (item && this.isExpired(item)) {
+        this.storage.delete(fullKey)
+      }
+      this.stats.misses++
+      return null
+    }
+
+    // Update access statistics
+    item.accessCount++
+    item.lastAccessed = Date.now()
+    this.stats.hits++
+
+    return item.value as T
+  }
+
+  async set<T = any>(key: string, value: T, options?: CacheSetOptions): Promise<boolean> {
+    this.stats.operations++
+    const fullKey = this.buildKey(key, options?.namespace)
+
+    // Check if key exists and NX option is set
+    if (options?.nx && this.storage.has(fullKey)) {
+      const existingItem = this.storage.get(fullKey)
+      if (existingItem && !this.isExpired(existingItem)) {
+        return false
+      }
+    }
+
+    const now = Date.now()
+    const ttl = options?.ttl || options?.ex || this.config.defaultTtl
+    const expiry = ttl ? now + ttl * 1000 : undefined
+
+    const item: CacheItem<T> = {
+      value,
+      expiry,
+      createdAt: now,
+      accessCount: 0,
+      lastAccessed: now,
+    }
+
+    this.storage.set(fullKey, item)
+    return true
+  }
+
+  async del(key: string | string[], namespace?: string): Promise<number> {
+    this.stats.operations++
+    const keys = Array.isArray(key) ? key : [key]
+    let deleted = 0
+
+    for (const k of keys) {
+      const fullKey = this.buildKey(k, namespace)
+      if (this.storage.delete(fullKey)) {
+        deleted++
+      }
+    }
+
+    return deleted
+  }
+
+  async exists(key: string, namespace?: string): Promise<boolean> {
+    this.stats.operations++
+    const fullKey = this.buildKey(key, namespace)
+    const item = this.storage.get(fullKey)
+
+    if (!item) return false
+    if (this.isExpired(item)) {
+      this.storage.delete(fullKey)
+      return false
+    }
+
+    return true
+  }
+
+  async ttl(key: string, namespace?: string): Promise<number> {
+    this.stats.operations++
+    const fullKey = this.buildKey(key, namespace)
+    const item = this.storage.get(fullKey)
+
+    if (!item) return -2 // Key doesn't exist
+    if (!item.expiry) return -1 // Key exists but has no expiry
+
+    const remaining = Math.ceil((item.expiry - Date.now()) / 1000)
+    return remaining > 0 ? remaining : -2
+  }
+
+  async expire(key: string, seconds: number, namespace?: string): Promise<boolean> {
+    this.stats.operations++
+    const fullKey = this.buildKey(key, namespace)
+    const item = this.storage.get(fullKey)
+
+    if (!item || this.isExpired(item)) return false
+
+    item.expiry = Date.now() + seconds * 1000
+    return true
+  }
+
+  async keys(pattern: string, namespace?: string): Promise<string[]> {
+    this.stats.operations++
+    const fullPattern = this.buildKey(pattern, namespace)
+    const regex = new RegExp(fullPattern.replace(/\*/g, ".*").replace(/\?/g, "."))
+    const matchingKeys: string[] = []
+
+    for (const [key, item] of this.storage.entries()) {
+      if (regex.test(key) && !this.isExpired(item)) {
+        // Remove namespace prefix
+        const prefix = this.buildKey("", namespace)
+        matchingKeys.push(key.replace(prefix, ""))
+      }
+    }
+
+    return matchingKeys
+  }
+
+  async clear(namespace?: string): Promise<boolean> {
+    this.stats.operations++
+
+    if (!namespace && !this.config.namespace) {
+      this.storage.clear()
+      return true
+    }
+
+    const prefix = this.buildKey("", namespace)
+    const keysToDelete: string[] = []
+
+    for (const key of this.storage.keys()) {
+      if (key.startsWith(prefix)) {
+        keysToDelete.push(key)
+      }
+    }
+
+    for (const key of keysToDelete) {
+      this.storage.delete(key)
+    }
+
+    return true
+  }
+
+  async getStats(): Promise<CacheStats> {
+    const hitRate = this.stats.operations > 0 ? (this.stats.hits / this.stats.operations) * 100 : 0
+
+    return {
+      hits: this.stats.hits,
+      misses: this.stats.misses,
+      keys: this.storage.size,
+      memory: this.getMemoryUsage(),
+      hitRate: Math.round(hitRate * 100) / 100,
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    return true // Memory cache is always healthy
+  }
+
+  destroy(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval)
+    }
+    this.storage.clear()
+    this.logger.log("Memory cache provider destroyed")
+  }
+}

--- a/backend/src/cache/providers/redis-cache.provider.ts
+++ b/backend/src/cache/providers/redis-cache.provider.ts
@@ -1,0 +1,403 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type {
+  CacheProvider,
+  CacheSetOptions,
+  CacheGetOptions,
+  CacheStats,
+  CacheConfig,
+} from "../interfaces/cache.interface"
+
+// Mock Redis client interface
+interface MockRedisClient {
+  get(key: string): Promise<string | null>
+  set(key: string, value: string, mode?: string, duration?: number): Promise<string | null>
+  setex(key: string, seconds: number, value: string): Promise<string>
+  del(...keys: string[]): Promise<number>
+  exists(...keys: string[]): Promise<number>
+  ttl(key: string): Promise<number>
+  expire(key: string, seconds: number): Promise<number>
+  keys(pattern: string): Promise<string[]>
+  flushdb(): Promise<string>
+  info(section?: string): Promise<string>
+  ping(): Promise<string>
+  quit(): Promise<string>
+  on(event: string, callback: (...args: any[]) => void): void
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+}
+
+@Injectable()
+export class RedisCacheProvider implements CacheProvider {
+  private readonly logger = new Logger(RedisCacheProvider.name)
+  private client: MockRedisClient
+  private isConnected = false
+  private stats = {
+    hits: 0,
+    misses: 0,
+    operations: 0,
+  }
+
+  constructor(private readonly config: CacheConfig) {
+    this.initializeClient()
+  }
+
+  private initializeClient(): void {
+    // Mock Redis client implementation
+    this.client = this.createMockRedisClient()
+    this.setupEventHandlers()
+    this.connect()
+  }
+
+  private createMockRedisClient(): MockRedisClient {
+    const storage = new Map<string, { value: string; expiry?: number }>()
+
+    const checkExpiry = (key: string): boolean => {
+      const item = storage.get(key)
+      if (item && item.expiry && Date.now() > item.expiry) {
+        storage.delete(key)
+        return false
+      }
+      return !!item
+    }
+
+    return {
+      async get(key: string): Promise<string | null> {
+        if (checkExpiry(key)) {
+          const item = storage.get(key)
+          return item?.value || null
+        }
+        return null
+      },
+
+      async set(key: string, value: string, mode?: string, duration?: number): Promise<string | null> {
+        if (mode === "NX" && storage.has(key)) {
+          return null // Key already exists
+        }
+
+        const expiry = duration ? Date.now() + duration * 1000 : undefined
+        storage.set(key, { value, expiry })
+        return "OK"
+      },
+
+      async setex(key: string, seconds: number, value: string): Promise<string> {
+        const expiry = Date.now() + seconds * 1000
+        storage.set(key, { value, expiry })
+        return "OK"
+      },
+
+      async del(...keys: string[]): Promise<number> {
+        let deleted = 0
+        for (const key of keys) {
+          if (storage.delete(key)) {
+            deleted++
+          }
+        }
+        return deleted
+      },
+
+      async exists(...keys: string[]): Promise<number> {
+        let count = 0
+        for (const key of keys) {
+          if (checkExpiry(key)) {
+            count++
+          }
+        }
+        return count
+      },
+
+      async ttl(key: string): Promise<number> {
+        const item = storage.get(key)
+        if (!item) return -2 // Key doesn't exist
+        if (!item.expiry) return -1 // Key exists but has no expiry
+
+        const remaining = Math.ceil((item.expiry - Date.now()) / 1000)
+        return remaining > 0 ? remaining : -2
+      },
+
+      async expire(key: string, seconds: number): Promise<number> {
+        const item = storage.get(key)
+        if (!item) return 0
+
+        item.expiry = Date.now() + seconds * 1000
+        storage.set(key, item)
+        return 1
+      },
+
+      async keys(pattern: string): Promise<string[]> {
+        const regex = new RegExp(pattern.replace(/\*/g, ".*").replace(/\?/g, "."))
+        const matchingKeys: string[] = []
+
+        for (const key of storage.keys()) {
+          if (checkExpiry(key) && regex.test(key)) {
+            matchingKeys.push(key)
+          }
+        }
+
+        return matchingKeys
+      },
+
+      async flushdb(): Promise<string> {
+        storage.clear()
+        return "OK"
+      },
+
+      async info(section?: string): Promise<string> {
+        return `# Memory\nused_memory:${storage.size * 100}\nused_memory_human:${((storage.size * 100) / 1024).toFixed(2)}K\n# Stats\nkeyspace_hits:${this.stats.hits}\nkeyspace_misses:${this.stats.misses}`
+      },
+
+      async ping(): Promise<string> {
+        return "PONG"
+      },
+
+      async quit(): Promise<string> {
+        return "OK"
+      },
+
+      on(event: string, callback: (...args: any[]) => void): void {
+        // Mock event handling
+        if (event === "connect") {
+          setTimeout(() => callback(), 100)
+        }
+      },
+
+      async connect(): Promise<void> {
+        // Mock connection
+        await new Promise((resolve) => setTimeout(resolve, 50))
+      },
+
+      async disconnect(): Promise<void> {
+        // Mock disconnection
+        await new Promise((resolve) => setTimeout(resolve, 10))
+      },
+    }
+  }
+
+  private setupEventHandlers(): void {
+    this.client.on("connect", () => {
+      this.isConnected = true
+      this.logger.log("Connected to Redis (mocked)")
+    })
+
+    this.client.on("error", (error: Error) => {
+      this.logger.error("Redis connection error (mocked):", error)
+      this.isConnected = false
+    })
+
+    this.client.on("close", () => {
+      this.logger.warn("Redis connection closed (mocked)")
+      this.isConnected = false
+    })
+  }
+
+  private async connect(): Promise<void> {
+    try {
+      await this.client.connect()
+      this.logger.log("Redis client connected (mocked)")
+    } catch (error) {
+      this.logger.error("Failed to connect to Redis (mocked):", error)
+      throw error
+    }
+  }
+
+  private buildKey(key: string, namespace?: string): string {
+    const ns = namespace || this.config.namespace || "cache"
+    const prefix = this.config.redis?.keyPrefix || ""
+    return `${prefix}${ns}:${key}`
+  }
+
+  private serialize(value: any): string {
+    if (this.config.serialization === false) {
+      return String(value)
+    }
+    return JSON.stringify(value)
+  }
+
+  private deserialize<T>(value: string): T {
+    if (this.config.serialization === false) {
+      return value as T
+    }
+    try {
+      return JSON.parse(value)
+    } catch {
+      return value as T
+    }
+  }
+
+  async get<T = any>(key: string, options?: CacheGetOptions): Promise<T | null> {
+    try {
+      this.stats.operations++
+      const fullKey = this.buildKey(key, options?.namespace)
+      const value = await this.client.get(fullKey)
+
+      if (value === null) {
+        this.stats.misses++
+        return null
+      }
+
+      this.stats.hits++
+      return this.deserialize<T>(value)
+    } catch (error) {
+      this.logger.error(`Failed to get key ${key}:`, error)
+      this.stats.misses++
+      return null
+    }
+  }
+
+  async set<T = any>(key: string, value: T, options?: CacheSetOptions): Promise<boolean> {
+    try {
+      this.stats.operations++
+      const fullKey = this.buildKey(key, options?.namespace)
+      const serializedValue = this.serialize(value)
+      const ttl = options?.ttl || options?.ex || this.config.defaultTtl
+
+      let result: string | null
+
+      if (options?.nx) {
+        result = await this.client.set(fullKey, serializedValue, "NX", ttl)
+      } else if (ttl) {
+        result = await this.client.setex(fullKey, ttl, serializedValue)
+      } else {
+        result = await this.client.set(fullKey, serializedValue)
+      }
+
+      return result === "OK"
+    } catch (error) {
+      this.logger.error(`Failed to set key ${key}:`, error)
+      return false
+    }
+  }
+
+  async del(key: string | string[], namespace?: string): Promise<number> {
+    try {
+      this.stats.operations++
+      const keys = Array.isArray(key) ? key : [key]
+      const fullKeys = keys.map((k) => this.buildKey(k, namespace))
+      return await this.client.del(...fullKeys)
+    } catch (error) {
+      this.logger.error(`Failed to delete keys:`, error)
+      return 0
+    }
+  }
+
+  async exists(key: string, namespace?: string): Promise<boolean> {
+    try {
+      this.stats.operations++
+      const fullKey = this.buildKey(key, namespace)
+      const result = await this.client.exists(fullKey)
+      return result > 0
+    } catch (error) {
+      this.logger.error(`Failed to check existence of key ${key}:`, error)
+      return false
+    }
+  }
+
+  async ttl(key: string, namespace?: string): Promise<number> {
+    try {
+      this.stats.operations++
+      const fullKey = this.buildKey(key, namespace)
+      return await this.client.ttl(fullKey)
+    } catch (error) {
+      this.logger.error(`Failed to get TTL for key ${key}:`, error)
+      return -2
+    }
+  }
+
+  async expire(key: string, seconds: number, namespace?: string): Promise<boolean> {
+    try {
+      this.stats.operations++
+      const fullKey = this.buildKey(key, namespace)
+      const result = await this.client.expire(fullKey, seconds)
+      return result === 1
+    } catch (error) {
+      this.logger.error(`Failed to set expiry for key ${key}:`, error)
+      return false
+    }
+  }
+
+  async keys(pattern: string, namespace?: string): Promise<string[]> {
+    try {
+      this.stats.operations++
+      const fullPattern = this.buildKey(pattern, namespace)
+      const keys = await this.client.keys(fullPattern)
+
+      // Remove namespace prefix from returned keys
+      const prefix = this.buildKey("", namespace)
+      return keys.map((key) => key.replace(prefix, ""))
+    } catch (error) {
+      this.logger.error(`Failed to get keys with pattern ${pattern}:`, error)
+      return []
+    }
+  }
+
+  async clear(namespace?: string): Promise<boolean> {
+    try {
+      this.stats.operations++
+      const pattern = this.buildKey("*", namespace)
+      const keys = await this.client.keys(pattern)
+
+      if (keys.length > 0) {
+        await this.client.del(...keys)
+      }
+
+      return true
+    } catch (error) {
+      this.logger.error(`Failed to clear cache:`, error)
+      return false
+    }
+  }
+
+  async getStats(): Promise<CacheStats> {
+    try {
+      const info = await this.client.info("memory")
+      const memoryMatch = info.match(/used_memory:(\d+)/)
+      const memory = memoryMatch ? Number.parseInt(memoryMatch[1]) : 0
+
+      const hitRate = this.stats.operations > 0 ? (this.stats.hits / this.stats.operations) * 100 : 0
+
+      return {
+        hits: this.stats.hits,
+        misses: this.stats.misses,
+        keys: await this.getKeyCount(),
+        memory,
+        hitRate: Math.round(hitRate * 100) / 100,
+      }
+    } catch (error) {
+      this.logger.error("Failed to get cache stats:", error)
+      return {
+        hits: this.stats.hits,
+        misses: this.stats.misses,
+        keys: 0,
+        memory: 0,
+        hitRate: 0,
+      }
+    }
+  }
+
+  private async getKeyCount(): Promise<number> {
+    try {
+      const keys = await this.client.keys("*")
+      return keys.length
+    } catch {
+      return 0
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      const response = await this.client.ping()
+      return response === "PONG" && this.isConnected
+    } catch {
+      return false
+    }
+  }
+
+  async disconnect(): Promise<void> {
+    try {
+      await this.client.quit()
+      this.isConnected = false
+      this.logger.log("Disconnected from Redis (mocked)")
+    } catch (error) {
+      this.logger.error("Error disconnecting from Redis (mocked):", error)
+    }
+  }
+}

--- a/backend/src/cache/services/cache.service.ts
+++ b/backend/src/cache/services/cache.service.ts
@@ -1,0 +1,246 @@
+import { Injectable, Logger, type OnModuleDestroy } from "@nestjs/common"
+import type {
+  CacheProvider,
+  CacheSetOptions,
+  CacheGetOptions,
+  CacheStats,
+  CacheConfig,
+} from "../interfaces/cache.interface"
+import { RedisCacheProvider } from "../providers/redis-cache.provider"
+import { MemoryCacheProvider } from "../providers/memory-cache.provider"
+
+@Injectable()
+export class CacheService implements CacheProvider, OnModuleDestroy {
+  private readonly logger = new Logger(CacheService.name)
+  private primaryProvider: CacheProvider
+  private fallbackProvider: CacheProvider
+  private useFallback = false
+
+  constructor(private readonly config: CacheConfig) {
+    this.initializeProviders()
+  }
+
+  private initializeProviders(): void {
+    try {
+      // Initialize primary provider
+      if (this.config.provider === "redis") {
+        this.primaryProvider = new RedisCacheProvider(this.config)
+        this.fallbackProvider = new MemoryCacheProvider(this.config)
+        this.logger.log("Initialized Redis cache with memory fallback")
+      } else {
+        this.primaryProvider = new MemoryCacheProvider(this.config)
+        this.logger.log("Initialized memory cache")
+      }
+
+      // Check primary provider health periodically
+      if (this.fallbackProvider) {
+        this.startHealthCheck()
+      }
+    } catch (error) {
+      this.logger.error("Failed to initialize cache providers:", error)
+      throw error
+    }
+  }
+
+  private startHealthCheck(): void {
+    setInterval(async () => {
+      const isHealthy = await this.primaryProvider.isHealthy()
+
+      if (!isHealthy && !this.useFallback) {
+        this.logger.warn("Primary cache provider is unhealthy, switching to fallback")
+        this.useFallback = true
+      } else if (isHealthy && this.useFallback) {
+        this.logger.log("Primary cache provider is healthy again, switching back")
+        this.useFallback = false
+      }
+    }, 30000) // Check every 30 seconds
+  }
+
+  private getActiveProvider(): CacheProvider {
+    return this.useFallback && this.fallbackProvider ? this.fallbackProvider : this.primaryProvider
+  }
+
+  async get<T = any>(key: string, options?: CacheGetOptions): Promise<T | null> {
+    try {
+      return await this.getActiveProvider().get<T>(key, options)
+    } catch (error) {
+      this.logger.error(`Cache get failed for key ${key}:`, error)
+
+      // Try fallback if available and not already using it
+      if (this.fallbackProvider && !this.useFallback) {
+        try {
+          return await this.fallbackProvider.get<T>(key, options)
+        } catch (fallbackError) {
+          this.logger.error(`Fallback cache get failed for key ${key}:`, fallbackError)
+        }
+      }
+
+      return null
+    }
+  }
+
+  async set<T = any>(key: string, value: T, options?: CacheSetOptions): Promise<boolean> {
+    try {
+      const result = await this.getActiveProvider().set(key, value, options)
+
+      // Also set in fallback if available and primary succeeded
+      if (result && this.fallbackProvider && !this.useFallback) {
+        try {
+          await this.fallbackProvider.set(key, value, options)
+        } catch (error) {
+          this.logger.warn(`Failed to sync to fallback cache for key ${key}:`, error)
+        }
+      }
+
+      return result
+    } catch (error) {
+      this.logger.error(`Cache set failed for key ${key}:`, error)
+
+      // Try fallback if available and not already using it
+      if (this.fallbackProvider && !this.useFallback) {
+        try {
+          return await this.fallbackProvider.set(key, value, options)
+        } catch (fallbackError) {
+          this.logger.error(`Fallback cache set failed for key ${key}:`, fallbackError)
+        }
+      }
+
+      return false
+    }
+  }
+
+  async del(key: string | string[], namespace?: string): Promise<number> {
+    try {
+      const result = await this.getActiveProvider().del(key, namespace)
+
+      // Also delete from fallback if available
+      if (this.fallbackProvider && !this.useFallback) {
+        try {
+          await this.fallbackProvider.del(key, namespace)
+        } catch (error) {
+          this.logger.warn(`Failed to delete from fallback cache:`, error)
+        }
+      }
+
+      return result
+    } catch (error) {
+      this.logger.error(`Cache delete failed:`, error)
+      return 0
+    }
+  }
+
+  async exists(key: string, namespace?: string): Promise<boolean> {
+    try {
+      return await this.getActiveProvider().exists(key, namespace)
+    } catch (error) {
+      this.logger.error(`Cache exists check failed for key ${key}:`, error)
+      return false
+    }
+  }
+
+  async ttl(key: string, namespace?: string): Promise<number> {
+    try {
+      return await this.getActiveProvider().ttl(key, namespace)
+    } catch (error) {
+      this.logger.error(`Cache TTL check failed for key ${key}:`, error)
+      return -2
+    }
+  }
+
+  async expire(key: string, seconds: number, namespace?: string): Promise<boolean> {
+    try {
+      const result = await this.getActiveProvider().expire(key, seconds, namespace)
+
+      // Also expire in fallback if available
+      if (this.fallbackProvider && !this.useFallback) {
+        try {
+          await this.fallbackProvider.expire(key, seconds, namespace)
+        } catch (error) {
+          this.logger.warn(`Failed to set expiry in fallback cache for key ${key}:`, error)
+        }
+      }
+
+      return result
+    } catch (error) {
+      this.logger.error(`Cache expire failed for key ${key}:`, error)
+      return false
+    }
+  }
+
+  async keys(pattern: string, namespace?: string): Promise<string[]> {
+    try {
+      return await this.getActiveProvider().keys(pattern, namespace)
+    } catch (error) {
+      this.logger.error(`Cache keys search failed for pattern ${pattern}:`, error)
+      return []
+    }
+  }
+
+  async clear(namespace?: string): Promise<boolean> {
+    try {
+      const result = await this.getActiveProvider().clear(namespace)
+
+      // Also clear fallback if available
+      if (this.fallbackProvider && !this.useFallback) {
+        try {
+          await this.fallbackProvider.clear(namespace)
+        } catch (error) {
+          this.logger.warn(`Failed to clear fallback cache:`, error)
+        }
+      }
+
+      return result
+    } catch (error) {
+      this.logger.error(`Cache clear failed:`, error)
+      return false
+    }
+  }
+
+  async getStats(): Promise<CacheStats> {
+    try {
+      return await this.getActiveProvider().getStats()
+    } catch (error) {
+      this.logger.error(`Failed to get cache stats:`, error)
+      return {
+        hits: 0,
+        misses: 0,
+        keys: 0,
+        memory: 0,
+        hitRate: 0,
+      }
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    try {
+      return await this.getActiveProvider().isHealthy()
+    } catch (error) {
+      this.logger.error(`Health check failed:`, error)
+      return false
+    }
+  }
+
+  getProviderInfo(): { primary: string; fallback?: string; usingFallback: boolean } {
+    return {
+      primary: this.config.provider,
+      fallback: this.fallbackProvider ? "memory" : undefined,
+      usingFallback: this.useFallback,
+    }
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    try {
+      if (this.primaryProvider && "disconnect" in this.primaryProvider) {
+        await (this.primaryProvider as any).disconnect()
+      }
+
+      if (this.fallbackProvider && "destroy" in this.fallbackProvider) {
+        ;(this.fallbackProvider as any).destroy()
+      }
+
+      this.logger.log("Cache service destroyed")
+    } catch (error) {
+      this.logger.error("Error during cache service destruction:", error)
+    }
+  }
+}

--- a/backend/src/cache/services/shipment-cache.service.ts
+++ b/backend/src/cache/services/shipment-cache.service.ts
@@ -1,0 +1,359 @@
+import { Injectable, Logger } from "@nestjs/common"
+import type { CacheService } from "./cache.service"
+
+export interface ShipmentStatus {
+  id: string
+  trackingNumber: string
+  status: "created" | "in_transit" | "delivered" | "delayed" | "cancelled"
+  currentLocation?: string
+  estimatedDelivery?: Date
+  actualDelivery?: Date
+  lastUpdated: Date
+  events: ShipmentEvent[]
+}
+
+export interface ShipmentEvent {
+  id: string
+  timestamp: Date
+  status: string
+  location: string
+  description: string
+  metadata?: Record<string, any>
+}
+
+export interface ShipmentQuery {
+  userId?: string
+  status?: string
+  dateRange?: {
+    start: Date
+    end: Date
+  }
+  limit?: number
+  offset?: number
+}
+
+@Injectable()
+export class ShipmentCacheService {
+  private readonly logger = new Logger(ShipmentCacheService.name)
+  private readonly SHIPMENT_TTL = 3600 // 1 hour
+  private readonly QUERY_TTL = 300 // 5 minutes
+  private readonly STATUS_TTL = 1800 // 30 minutes
+
+  constructor(private readonly cacheService: CacheService) {}
+
+  // Shipment Status Caching
+  async getShipmentStatus(shipmentId: string): Promise<ShipmentStatus | null> {
+    const key = `shipment:status:${shipmentId}`
+
+    try {
+      const cached = await this.cacheService.get<ShipmentStatus>(key, { namespace: "shipments" })
+
+      if (cached) {
+        this.logger.debug(`Cache hit for shipment status: ${shipmentId}`)
+        return cached
+      }
+
+      this.logger.debug(`Cache miss for shipment status: ${shipmentId}`)
+      return null
+    } catch (error) {
+      this.logger.error(`Failed to get shipment status from cache: ${shipmentId}`, error)
+      return null
+    }
+  }
+
+  async setShipmentStatus(shipmentId: string, status: ShipmentStatus): Promise<boolean> {
+    const key = `shipment:status:${shipmentId}`
+
+    try {
+      const result = await this.cacheService.set(key, status, {
+        ttl: this.SHIPMENT_TTL,
+        namespace: "shipments",
+      })
+
+      if (result) {
+        this.logger.debug(`Cached shipment status: ${shipmentId}`)
+
+        // Also cache by tracking number for quick lookups
+        await this.cacheService.set(
+          `tracking:${status.trackingNumber}`,
+          { shipmentId, status: status.status, lastUpdated: status.lastUpdated },
+          { ttl: this.SHIPMENT_TTL, namespace: "shipments" },
+        )
+      }
+
+      return result
+    } catch (error) {
+      this.logger.error(`Failed to cache shipment status: ${shipmentId}`, error)
+      return false
+    }
+  }
+
+  async getShipmentByTracking(
+    trackingNumber: string,
+  ): Promise<{ shipmentId: string; status: string; lastUpdated: Date } | null> {
+    const key = `tracking:${trackingNumber}`
+
+    try {
+      return await this.cacheService.get(key, { namespace: "shipments" })
+    } catch (error) {
+      this.logger.error(`Failed to get shipment by tracking number: ${trackingNumber}`, error)
+      return null
+    }
+  }
+
+  async invalidateShipmentStatus(shipmentId: string): Promise<void> {
+    try {
+      // Get the shipment to find tracking number
+      const shipment = await this.getShipmentStatus(shipmentId)
+
+      // Delete shipment status cache
+      await this.cacheService.del(`shipment:status:${shipmentId}`, "shipments")
+
+      // Delete tracking number cache if available
+      if (shipment?.trackingNumber) {
+        await this.cacheService.del(`tracking:${shipment.trackingNumber}`, "shipments")
+      }
+
+      this.logger.debug(`Invalidated cache for shipment: ${shipmentId}`)
+    } catch (error) {
+      this.logger.error(`Failed to invalidate shipment cache: ${shipmentId}`, error)
+    }
+  }
+
+  // Query Result Caching
+  async getQueryResult<T>(queryKey: string, query: ShipmentQuery): Promise<T | null> {
+    const key = `query:${queryKey}:${this.hashQuery(query)}`
+
+    try {
+      const cached = await this.cacheService.get<T>(key, { namespace: "queries" })
+
+      if (cached) {
+        this.logger.debug(`Cache hit for query: ${queryKey}`)
+        return cached
+      }
+
+      this.logger.debug(`Cache miss for query: ${queryKey}`)
+      return null
+    } catch (error) {
+      this.logger.error(`Failed to get query result from cache: ${queryKey}`, error)
+      return null
+    }
+  }
+
+  async setQueryResult<T>(queryKey: string, query: ShipmentQuery, result: T): Promise<boolean> {
+    const key = `query:${queryKey}:${this.hashQuery(query)}`
+
+    try {
+      const success = await this.cacheService.set(key, result, {
+        ttl: this.QUERY_TTL,
+        namespace: "queries",
+      })
+
+      if (success) {
+        this.logger.debug(`Cached query result: ${queryKey}`)
+      }
+
+      return success
+    } catch (error) {
+      this.logger.error(`Failed to cache query result: ${queryKey}`, error)
+      return false
+    }
+  }
+
+  async invalidateQueriesForUser(userId: string): Promise<void> {
+    try {
+      const pattern = `query:*user:${userId}*`
+      const keys = await this.cacheService.keys(pattern, "queries")
+
+      if (keys.length > 0) {
+        await this.cacheService.del(keys, "queries")
+        this.logger.debug(`Invalidated ${keys.length} query caches for user: ${userId}`)
+      }
+    } catch (error) {
+      this.logger.error(`Failed to invalidate query caches for user: ${userId}`, error)
+    }
+  }
+
+  // Frequently Accessed Data Caching
+  async getUserShipments(userId: string): Promise<ShipmentStatus[] | null> {
+    const key = `user:shipments:${userId}`
+
+    try {
+      return await this.cacheService.get<ShipmentStatus[]>(key, { namespace: "users" })
+    } catch (error) {
+      this.logger.error(`Failed to get user shipments from cache: ${userId}`, error)
+      return null
+    }
+  }
+
+  async setUserShipments(userId: string, shipments: ShipmentStatus[]): Promise<boolean> {
+    const key = `user:shipments:${userId}`
+
+    try {
+      return await this.cacheService.set(key, shipments, {
+        ttl: this.STATUS_TTL,
+        namespace: "users",
+      })
+    } catch (error) {
+      this.logger.error(`Failed to cache user shipments: ${userId}`, error)
+      return false
+    }
+  }
+
+  async getShipmentEvents(shipmentId: string): Promise<ShipmentEvent[] | null> {
+    const key = `shipment:events:${shipmentId}`
+
+    try {
+      return await this.cacheService.get<ShipmentEvent[]>(key, { namespace: "events" })
+    } catch (error) {
+      this.logger.error(`Failed to get shipment events from cache: ${shipmentId}`, error)
+      return null
+    }
+  }
+
+  async setShipmentEvents(shipmentId: string, events: ShipmentEvent[]): Promise<boolean> {
+    const key = `shipment:events:${shipmentId}`
+
+    try {
+      return await this.cacheService.set(key, events, {
+        ttl: this.SHIPMENT_TTL,
+        namespace: "events",
+      })
+    } catch (error) {
+      this.logger.error(`Failed to cache shipment events: ${shipmentId}`, error)
+      return false
+    }
+  }
+
+  async addShipmentEvent(shipmentId: string, event: ShipmentEvent): Promise<boolean> {
+    try {
+      // Get existing events
+      const existingEvents = (await this.getShipmentEvents(shipmentId)) || []
+
+      // Add new event
+      const updatedEvents = [event, ...existingEvents].slice(0, 50) // Keep last 50 events
+
+      // Cache updated events
+      await this.setShipmentEvents(shipmentId, updatedEvents)
+
+      // Invalidate shipment status to force refresh
+      await this.invalidateShipmentStatus(shipmentId)
+
+      return true
+    } catch (error) {
+      this.logger.error(`Failed to add shipment event: ${shipmentId}`, error)
+      return false
+    }
+  }
+
+  // Statistics and Analytics Caching
+  async getShipmentStats(period: "daily" | "weekly" | "monthly"): Promise<any | null> {
+    const key = `stats:shipments:${period}`
+
+    try {
+      return await this.cacheService.get(key, { namespace: "stats" })
+    } catch (error) {
+      this.logger.error(`Failed to get shipment stats from cache: ${period}`, error)
+      return null
+    }
+  }
+
+  async setShipmentStats(period: "daily" | "weekly" | "monthly", stats: any): Promise<boolean> {
+    const key = `stats:shipments:${period}`
+    const ttl = period === "daily" ? 3600 : period === "weekly" ? 7200 : 14400 // 1h, 2h, 4h
+
+    try {
+      return await this.cacheService.set(key, stats, {
+        ttl,
+        namespace: "stats",
+      })
+    } catch (error) {
+      this.logger.error(`Failed to cache shipment stats: ${period}`, error)
+      return false
+    }
+  }
+
+  // Utility Methods
+  private hashQuery(query: ShipmentQuery): string {
+    // Simple hash function for query parameters
+    const queryString = JSON.stringify(query, Object.keys(query).sort())
+    let hash = 0
+
+    for (let i = 0; i < queryString.length; i++) {
+      const char = queryString.charCodeAt(i)
+      hash = (hash << 5) - hash + char
+      hash = hash & hash // Convert to 32-bit integer
+    }
+
+    return Math.abs(hash).toString(36)
+  }
+
+  async warmupCache(shipmentIds: string[]): Promise<void> {
+    this.logger.log(`Warming up cache for ${shipmentIds.length} shipments`)
+
+    // This would typically fetch from database and cache the results
+    // For demo purposes, we'll create mock data
+    for (const shipmentId of shipmentIds) {
+      const mockStatus: ShipmentStatus = {
+        id: shipmentId,
+        trackingNumber: `TRK${shipmentId.slice(-6).toUpperCase()}`,
+        status: "in_transit",
+        currentLocation: "Distribution Center",
+        estimatedDelivery: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000),
+        lastUpdated: new Date(),
+        events: [
+          {
+            id: `event-${shipmentId}-1`,
+            timestamp: new Date(),
+            status: "in_transit",
+            location: "Distribution Center",
+            description: "Package is in transit",
+          },
+        ],
+      }
+
+      await this.setShipmentStatus(shipmentId, mockStatus)
+    }
+
+    this.logger.log(`Cache warmup completed for ${shipmentIds.length} shipments`)
+  }
+
+  async getCacheHealth(): Promise<{
+    isHealthy: boolean
+    stats: any
+    provider: any
+  }> {
+    try {
+      const isHealthy = await this.cacheService.isHealthy()
+      const stats = await this.cacheService.getStats()
+      const provider = this.cacheService.getProviderInfo()
+
+      return { isHealthy, stats, provider }
+    } catch (error) {
+      this.logger.error("Failed to get cache health:", error)
+      return {
+        isHealthy: false,
+        stats: null,
+        provider: null,
+      }
+    }
+  }
+
+  async clearAllShipmentCache(): Promise<boolean> {
+    try {
+      await Promise.all([
+        this.cacheService.clear("shipments"),
+        this.cacheService.clear("queries"),
+        this.cacheService.clear("users"),
+        this.cacheService.clear("events"),
+        this.cacheService.clear("stats"),
+      ])
+
+      this.logger.log("Cleared all shipment cache")
+      return true
+    } catch (error) {
+      this.logger.error("Failed to clear shipment cache:", error)
+      return false
+    }
+  }
+}

--- a/backend/src/cache/tests/cache.service.spec.ts
+++ b/backend/src/cache/tests/cache.service.spec.ts
@@ -1,0 +1,193 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { CacheService } from "../services/cache.service"
+import type { CacheConfig } from "../interfaces/cache.interface"
+
+describe("CacheService", () => {
+  let service: CacheService
+  let config: CacheConfig
+
+  beforeEach(async () => {
+    config = {
+      provider: "memory",
+      memory: {
+        maxKeys: 1000,
+        maxMemory: 10 * 1024 * 1024, // 10MB
+        ttl: 3600,
+        checkPeriod: 60000,
+      },
+      defaultTtl: 3600,
+      namespace: "test",
+      compression: false,
+      serialization: true,
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        {
+          provide: CacheService,
+          useFactory: () => new CacheService(config),
+        },
+      ],
+    }).compile()
+
+    service = module.get<CacheService>(CacheService)
+  })
+
+  afterEach(async () => {
+    await service.clear()
+    await service.onModuleDestroy()
+  })
+
+  describe("basic operations", () => {
+    it("should set and get a value", async () => {
+      const key = "test-key"
+      const value = { message: "Hello, World!" }
+
+      const setResult = await service.set(key, value)
+      expect(setResult).toBe(true)
+
+      const getValue = await service.get(key)
+      expect(getValue).toEqual(value)
+    })
+
+    it("should return null for non-existent key", async () => {
+      const value = await service.get("non-existent-key")
+      expect(value).toBeNull()
+    })
+
+    it("should delete a key", async () => {
+      const key = "delete-test"
+      const value = "test-value"
+
+      await service.set(key, value)
+      expect(await service.get(key)).toBe(value)
+
+      const deleteResult = await service.del(key)
+      expect(deleteResult).toBe(1)
+
+      expect(await service.get(key)).toBeNull()
+    })
+
+    it("should check if key exists", async () => {
+      const key = "exists-test"
+      const value = "test-value"
+
+      expect(await service.exists(key)).toBe(false)
+
+      await service.set(key, value)
+      expect(await service.exists(key)).toBe(true)
+
+      await service.del(key)
+      expect(await service.exists(key)).toBe(false)
+    })
+  })
+
+  describe("TTL operations", () => {
+    it("should set TTL and expire key", async () => {
+      const key = "ttl-test"
+      const value = "test-value"
+
+      await service.set(key, value, { ttl: 1 }) // 1 second TTL
+
+      expect(await service.get(key)).toBe(value)
+      expect(await service.ttl(key)).toBeGreaterThan(0)
+
+      // Wait for expiration
+      await new Promise((resolve) => setTimeout(resolve, 1100))
+
+      expect(await service.get(key)).toBeNull()
+      expect(await service.ttl(key)).toBe(-2) // Key doesn't exist
+    })
+
+    it("should update TTL with expire", async () => {
+      const key = "expire-test"
+      const value = "test-value"
+
+      await service.set(key, value)
+      expect(await service.ttl(key)).toBe(-1) // No expiry
+
+      const expireResult = await service.expire(key, 10)
+      expect(expireResult).toBe(true)
+      expect(await service.ttl(key)).toBeGreaterThan(0)
+    })
+  })
+
+  describe("namespace operations", () => {
+    it("should handle namespaced keys", async () => {
+      const key = "namespaced-key"
+      const value1 = "value1"
+      const value2 = "value2"
+
+      await service.set(key, value1, { namespace: "ns1" })
+      await service.set(key, value2, { namespace: "ns2" })
+
+      expect(await service.get(key, { namespace: "ns1" })).toBe(value1)
+      expect(await service.get(key, { namespace: "ns2" })).toBe(value2)
+    })
+
+    it("should clear namespace", async () => {
+      await service.set("key1", "value1", { namespace: "clear-test" })
+      await service.set("key2", "value2", { namespace: "clear-test" })
+      await service.set("key3", "value3", { namespace: "other" })
+
+      expect(await service.get("key1", { namespace: "clear-test" })).toBe("value1")
+      expect(await service.get("key3", { namespace: "other" })).toBe("value3")
+
+      await service.clear("clear-test")
+
+      expect(await service.get("key1", { namespace: "clear-test" })).toBeNull()
+      expect(await service.get("key2", { namespace: "clear-test" })).toBeNull()
+      expect(await service.get("key3", { namespace: "other" })).toBe("value3")
+    })
+  })
+
+  describe("pattern matching", () => {
+    it("should find keys by pattern", async () => {
+      await service.set("user:1", "user1")
+      await service.set("user:2", "user2")
+      await service.set("order:1", "order1")
+
+      const userKeys = await service.keys("user:*")
+      expect(userKeys).toHaveLength(2)
+      expect(userKeys).toContain("user:1")
+      expect(userKeys).toContain("user:2")
+
+      const allKeys = await service.keys("*")
+      expect(allKeys).toHaveLength(3)
+    })
+  })
+
+  describe("statistics", () => {
+    it("should return cache statistics", async () => {
+      await service.set("stat-key1", "value1")
+      await service.set("stat-key2", "value2")
+
+      // Generate some hits and misses
+      await service.get("stat-key1") // hit
+      await service.get("stat-key2") // hit
+      await service.get("non-existent") // miss
+
+      const stats = await service.getStats()
+
+      expect(stats.keys).toBeGreaterThanOrEqual(2)
+      expect(stats.hits).toBeGreaterThanOrEqual(2)
+      expect(stats.misses).toBeGreaterThanOrEqual(1)
+      expect(stats.hitRate).toBeGreaterThan(0)
+    })
+  })
+
+  describe("health check", () => {
+    it("should report healthy status", async () => {
+      const isHealthy = await service.isHealthy()
+      expect(isHealthy).toBe(true)
+    })
+  })
+
+  describe("provider info", () => {
+    it("should return provider information", () => {
+      const info = service.getProviderInfo()
+      expect(info.primary).toBe("memory")
+      expect(info.usingFallback).toBe(false)
+    })
+  })
+})

--- a/backend/src/cache/tests/shipment-cache.service.spec.ts
+++ b/backend/src/cache/tests/shipment-cache.service.spec.ts
@@ -1,0 +1,280 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { ShipmentCacheService, type ShipmentStatus } from "../services/shipment-cache.service"
+import { CacheService } from "../services/cache.service"
+import type { CacheConfig } from "../interfaces/cache.interface"
+
+describe("ShipmentCacheService", () => {
+  let service: ShipmentCacheService
+  let cacheService: CacheService
+
+  beforeEach(async () => {
+    const config: CacheConfig = {
+      provider: "memory",
+      memory: {
+        maxKeys: 1000,
+        maxMemory: 10 * 1024 * 1024,
+        ttl: 3600,
+        checkPeriod: 60000,
+      },
+      defaultTtl: 3600,
+      namespace: "test",
+      compression: false,
+      serialization: true,
+    }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShipmentCacheService,
+        {
+          provide: CacheService,
+          useFactory: () => new CacheService(config),
+        },
+      ],
+    }).compile()
+
+    service = module.get<ShipmentCacheService>(ShipmentCacheService)
+    cacheService = module.get<CacheService>(CacheService)
+  })
+
+  afterEach(async () => {
+    await service.clearAllShipmentCache()
+    await cacheService.onModuleDestroy()
+  })
+
+  describe("shipment status caching", () => {
+    it("should cache and retrieve shipment status", async () => {
+      const shipmentId = "shipment-123"
+      const status: ShipmentStatus = {
+        id: shipmentId,
+        trackingNumber: "TRK123456",
+        status: "in_transit",
+        currentLocation: "Distribution Center",
+        estimatedDelivery: new Date("2024-01-15"),
+        lastUpdated: new Date(),
+        events: [
+          {
+            id: "event-1",
+            timestamp: new Date(),
+            status: "in_transit",
+            location: "Distribution Center",
+            description: "Package is in transit",
+          },
+        ],
+      }
+
+      // Initially should return null
+      expect(await service.getShipmentStatus(shipmentId)).toBeNull()
+
+      // Cache the status
+      const setResult = await service.setShipmentStatus(shipmentId, status)
+      expect(setResult).toBe(true)
+
+      // Should now return the cached status
+      const cachedStatus = await service.getShipmentStatus(shipmentId)
+      expect(cachedStatus).toEqual(status)
+    })
+
+    it("should cache shipment by tracking number", async () => {
+      const shipmentId = "shipment-456"
+      const trackingNumber = "TRK789012"
+      const status: ShipmentStatus = {
+        id: shipmentId,
+        trackingNumber,
+        status: "delivered",
+        currentLocation: "Customer Address",
+        actualDelivery: new Date(),
+        lastUpdated: new Date(),
+        events: [],
+      }
+
+      await service.setShipmentStatus(shipmentId, status)
+
+      const trackingResult = await service.getShipmentByTracking(trackingNumber)
+      expect(trackingResult).toEqual({
+        shipmentId,
+        status: "delivered",
+        lastUpdated: status.lastUpdated,
+      })
+    })
+
+    it("should invalidate shipment status cache", async () => {
+      const shipmentId = "shipment-789"
+      const status: ShipmentStatus = {
+        id: shipmentId,
+        trackingNumber: "TRK345678",
+        status: "created",
+        lastUpdated: new Date(),
+        events: [],
+      }
+
+      await service.setShipmentStatus(shipmentId, status)
+      expect(await service.getShipmentStatus(shipmentId)).toEqual(status)
+
+      await service.invalidateShipmentStatus(shipmentId)
+      expect(await service.getShipmentStatus(shipmentId)).toBeNull()
+    })
+  })
+
+  describe("user shipments caching", () => {
+    it("should cache and retrieve user shipments", async () => {
+      const userId = "user-123"
+      const shipments: ShipmentStatus[] = [
+        {
+          id: "shipment-1",
+          trackingNumber: "TRK001",
+          status: "in_transit",
+          lastUpdated: new Date(),
+          events: [],
+        },
+        {
+          id: "shipment-2",
+          trackingNumber: "TRK002",
+          status: "delivered",
+          lastUpdated: new Date(),
+          events: [],
+        },
+      ]
+
+      expect(await service.getUserShipments(userId)).toBeNull()
+
+      const setResult = await service.setUserShipments(userId, shipments)
+      expect(setResult).toBe(true)
+
+      const cachedShipments = await service.getUserShipments(userId)
+      expect(cachedShipments).toEqual(shipments)
+    })
+  })
+
+  describe("shipment events caching", () => {
+    it("should cache and retrieve shipment events", async () => {
+      const shipmentId = "shipment-events-test"
+      const events = [
+        {
+          id: "event-1",
+          timestamp: new Date("2024-01-10T10:00:00Z"),
+          status: "created",
+          location: "Origin",
+          description: "Shipment created",
+        },
+        {
+          id: "event-2",
+          timestamp: new Date("2024-01-11T14:30:00Z"),
+          status: "in_transit",
+          location: "Distribution Center",
+          description: "Package in transit",
+        },
+      ]
+
+      expect(await service.getShipmentEvents(shipmentId)).toBeNull()
+
+      const setResult = await service.setShipmentEvents(shipmentId, events)
+      expect(setResult).toBe(true)
+
+      const cachedEvents = await service.getShipmentEvents(shipmentId)
+      expect(cachedEvents).toEqual(events)
+    })
+
+    it("should add new event to existing events", async () => {
+      const shipmentId = "shipment-add-event-test"
+      const initialEvents = [
+        {
+          id: "event-1",
+          timestamp: new Date("2024-01-10T10:00:00Z"),
+          status: "created",
+          location: "Origin",
+          description: "Shipment created",
+        },
+      ]
+
+      await service.setShipmentEvents(shipmentId, initialEvents)
+
+      const newEvent = {
+        id: "event-2",
+        timestamp: new Date("2024-01-11T14:30:00Z"),
+        status: "in_transit",
+        location: "Distribution Center",
+        description: "Package in transit",
+      }
+
+      const addResult = await service.addShipmentEvent(shipmentId, newEvent)
+      expect(addResult).toBe(true)
+
+      const updatedEvents = await service.getShipmentEvents(shipmentId)
+      expect(updatedEvents).toHaveLength(2)
+      expect(updatedEvents?.[0]).toEqual(newEvent) // New event should be first
+      expect(updatedEvents?.[1]).toEqual(initialEvents[0])
+    })
+  })
+
+  describe("statistics caching", () => {
+    it("should cache and retrieve shipment statistics", async () => {
+      const period = "daily"
+      const stats = {
+        totalShipments: 150,
+        delivered: 120,
+        inTransit: 25,
+        delayed: 5,
+        averageDeliveryTime: 2.5,
+      }
+
+      expect(await service.getShipmentStats(period)).toBeNull()
+
+      const setResult = await service.setShipmentStats(period, stats)
+      expect(setResult).toBe(true)
+
+      const cachedStats = await service.getShipmentStats(period)
+      expect(cachedStats).toEqual(stats)
+    })
+  })
+
+  describe("cache warmup", () => {
+    it("should warm up cache for multiple shipments", async () => {
+      const shipmentIds = ["shipment-1", "shipment-2", "shipment-3"]
+
+      await service.warmupCache(shipmentIds)
+
+      // Check that all shipments were cached
+      for (const shipmentId of shipmentIds) {
+        const status = await service.getShipmentStatus(shipmentId)
+        expect(status).not.toBeNull()
+        expect(status?.id).toBe(shipmentId)
+        expect(status?.trackingNumber).toContain("TRK")
+      }
+    })
+  })
+
+  describe("cache health", () => {
+    it("should return cache health information", async () => {
+      const health = await service.getCacheHealth()
+
+      expect(health).toHaveProperty("isHealthy")
+      expect(health).toHaveProperty("stats")
+      expect(health).toHaveProperty("provider")
+      expect(health.isHealthy).toBe(true)
+    })
+  })
+
+  describe("cache clearing", () => {
+    it("should clear all shipment cache", async () => {
+      // Add some test data
+      const shipmentId = "clear-test-shipment"
+      const status: ShipmentStatus = {
+        id: shipmentId,
+        trackingNumber: "TRK999",
+        status: "created",
+        lastUpdated: new Date(),
+        events: [],
+      }
+
+      await service.setShipmentStatus(shipmentId, status)
+      expect(await service.getShipmentStatus(shipmentId)).toEqual(status)
+
+      // Clear all cache
+      const clearResult = await service.clearAllShipmentCache()
+      expect(clearResult).toBe(true)
+
+      // Verify cache is cleared
+      expect(await service.getShipmentStatus(shipmentId)).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
closes #333 

This PR introduces a new cache module using Redis as the caching layer. For development and testing purposes, Redis interactions are currently mocked. The structure has been set up to allow easy integration with a real Redis instance in the future.

**✅ Changes Include:**

* Created a `CacheModule` with provider(s) for caching logic
* Introduced a mock Redis client to simulate caching behavior
* Added necessary configuration scaffolding for Redis
* Ensured the module is scalable for real Redis integration
* Wrote basic unit tests for the mocked implementation

**📌 Notes:**

* This implementation is mocked and intended for local development or CI environments.
* Integration with a real Redis service can be added later by swapping out the mock provider.