### PR TITLE
Feat cargor insur

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PartnerModule } from './partner/partner.module';
 import { InvoiceModule } from './invoice/invoice.module';
 import { ShipmentModule } from './shipment/shipment.module';
+import { InsuranceModule } from './insurance/insurance.module';
 
 @Module({
   imports: [
@@ -29,6 +30,7 @@ import { ShipmentModule } from './shipment/shipment.module';
     PartnerModule,
     InvoiceModule,
     ShipmentModule,
+    InsuranceModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/insurance/README.md
+++ b/backend/src/insurance/README.md
@@ -1,0 +1,162 @@
+# Insurance Module
+
+This module manages insurance policies for shipments and their associated claim history.
+
+## Features
+
+- **Insurance Policy Management**: Create, read, update, and delete insurance policies
+- **Claim History Tracking**: Manage claims associated with insurance policies
+- **Comprehensive Filtering**: Advanced query capabilities for both policies and claims
+- **Analytics & Reporting**: Statistics and insights on insurance data
+- **Shipment Integration**: Link insurance policies to specific shipments
+
+## Entities
+
+### InsurancePolicy
+- `id`: Unique identifier (UUID)
+- `policyNumber`: Unique policy number
+- `provider`: Insurance provider name
+- `coverageType`: Type of coverage (all_risk, general_average, etc.)
+- `coverageAmount`: Maximum coverage amount
+- `premiumAmount`: Premium paid for the policy
+- `currency`: Currency code (default: USD)
+- `deductible`: Deductible amount (optional)
+- `effectiveDate`: Policy start date
+- `expiryDate`: Policy end date
+- `status`: Policy status (active, expired, cancelled, etc.)
+- `termsAndConditions`: Policy terms (optional)
+- `exclusions`: Policy exclusions (optional)
+- `notes`: Additional notes (optional)
+- `contactPerson`: Contact person name (optional)
+- `contactEmail`: Contact email (optional)
+- `contactPhone`: Contact phone (optional)
+- `shipmentId`: Associated shipment ID
+
+### ClaimHistory
+- `id`: Unique identifier (UUID)
+- `claimNumber`: Unique claim number
+- `claimType`: Type of claim (damage, loss, theft, etc.)
+- `status`: Claim status (submitted, under_review, approved, etc.)
+- `claimedAmount`: Amount claimed
+- `approvedAmount`: Amount approved (optional)
+- `paidAmount`: Amount paid (optional)
+- `currency`: Currency code (default: USD)
+- `incidentDate`: Date of incident
+- `claimDate`: Date claim was filed
+- `settlementDate`: Date of settlement (optional)
+- `description`: Detailed description of the claim
+- `investigationNotes`: Investigation notes (optional)
+- `supportingDocuments`: Supporting documents (JSON string)
+- `adjusterNotes`: Adjuster notes (optional)
+- `adjusterName`: Adjuster name (optional)
+- `adjusterContact`: Adjuster contact (optional)
+- `rejectionReason`: Reason for rejection (optional)
+- `settlementNotes`: Settlement notes (optional)
+- `insurancePolicyId`: Associated insurance policy ID
+
+## API Endpoints
+
+### Insurance Policies
+- `POST /api/v1/insurance/policies` - Create insurance policy
+- `GET /api/v1/insurance/policies` - Get all policies (with filtering)
+- `GET /api/v1/insurance/policies/:id` - Get policy by ID
+- `GET /api/v1/insurance/policies/policy-number/:policyNumber` - Get policy by policy number
+- `PATCH /api/v1/insurance/policies/:id` - Update policy
+- `DELETE /api/v1/insurance/policies/:id` - Delete policy
+- `GET /api/v1/insurance/shipments/:shipmentId/policies` - Get policies for shipment
+
+### Claims
+- `POST /api/v1/insurance/claims` - Create claim
+- `GET /api/v1/insurance/claims` - Get all claims (with filtering)
+- `GET /api/v1/insurance/claims/:id` - Get claim by ID
+- `GET /api/v1/insurance/claims/claim-number/:claimNumber` - Get claim by claim number
+- `PATCH /api/v1/insurance/claims/:id` - Update claim
+- `DELETE /api/v1/insurance/claims/:id` - Delete claim
+- `GET /api/v1/insurance/policies/:insurancePolicyId/claims` - Get claims for policy
+
+### Analytics
+- `GET /api/v1/insurance/statistics` - Get insurance statistics
+
+## Query Parameters
+
+### Insurance Policy Queries
+- `page`: Page number (default: 1)
+- `limit`: Items per page (default: 10)
+- `policyNumber`: Filter by policy number (partial match)
+- `provider`: Filter by provider (partial match)
+- `coverageType`: Filter by coverage type
+- `status`: Filter by policy status
+- `shipmentId`: Filter by shipment ID
+- `effectiveDateFrom`: Filter by effective date from
+- `effectiveDateTo`: Filter by effective date to
+- `expiryDateFrom`: Filter by expiry date from
+- `expiryDateTo`: Filter by expiry date to
+
+### Claim Queries
+- `page`: Page number (default: 1)
+- `limit`: Items per page (default: 10)
+- `claimNumber`: Filter by claim number (partial match)
+- `claimType`: Filter by claim type
+- `status`: Filter by claim status
+- `insurancePolicyId`: Filter by insurance policy ID
+- `incidentDateFrom`: Filter by incident date from
+- `incidentDateTo`: Filter by incident date to
+- `claimDateFrom`: Filter by claim date from
+- `claimDateTo`: Filter by claim date to
+
+## Usage Examples
+
+### Create Insurance Policy
+```typescript
+const policy = await insuranceService.createInsurancePolicy({
+  policyNumber: 'POL-2024-001',
+  provider: 'Global Insurance Co.',
+  coverageType: CoverageType.ALL_RISK,
+  coverageAmount: 100000,
+  premiumAmount: 1500,
+  effectiveDate: '2024-01-01',
+  expiryDate: '2024-12-31',
+  shipmentId: 'shipment-uuid'
+});
+```
+
+### Create Claim
+```typescript
+const claim = await insuranceService.createClaim({
+  claimNumber: 'CLM-2024-001',
+  claimType: ClaimType.DAMAGE,
+  claimedAmount: 5000,
+  incidentDate: '2024-06-15',
+  claimDate: '2024-06-16',
+  description: 'Package damaged during transit',
+  insurancePolicyId: 'policy-uuid'
+});
+```
+
+### Get Statistics
+```typescript
+const stats = await insuranceService.getInsuranceStatistics();
+// Returns: totalPolicies, activePolicies, expiredPolicies, 
+//          totalClaims, pendingClaims, approvedClaims,
+//          totalClaimAmount, totalPaidAmount
+```
+
+## Database Relationships
+
+- `InsurancePolicy` belongs to `Shipment` (many-to-one)
+- `ClaimHistory` belongs to `InsurancePolicy` (many-to-one)
+- `InsurancePolicy` has many `ClaimHistory` (one-to-many)
+
+## Validation
+
+- Policy numbers and claim numbers must be unique
+- Expiry dates must be after effective dates
+- All monetary amounts must be non-negative
+- Required fields are validated using class-validator decorators
+- Date formats must be ISO 8601 strings
+
+## Error Handling
+
+- `NotFoundException`: When entity is not found
+- `ConflictException`: When unique constraints are violated
+- `BadRequestException`: When validation fails or business rules are violated

--- a/backend/src/insurance/controllers/insurance.controller.ts
+++ b/backend/src/insurance/controllers/insurance.controller.ts
@@ -1,0 +1,210 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { InsuranceService } from '../services/insurance.service';
+import { CreateInsurancePolicyDto } from '../dto/create-insurance-policy.dto';
+import { UpdateInsurancePolicyDto } from '../dto/update-insurance-policy.dto';
+import { CreateClaimDto } from '../dto/create-claim.dto';
+import { UpdateClaimDto } from '../dto/update-claim.dto';
+import { InsurancePolicyQueryDto, ClaimQueryDto } from '../dto/insurance-query.dto';
+import { InsurancePolicy } from '../entities/insurance-policy.entity';
+import { ClaimHistory } from '../entities/claim-history.entity';
+
+@ApiTags('Insurance')
+@Controller('insurance')
+export class InsuranceController {
+  constructor(private readonly insuranceService: InsuranceService) {}
+
+  // Insurance Policy Endpoints
+
+  @Post('policies')
+  @ApiOperation({ summary: 'Create a new insurance policy' })
+  @ApiResponse({ status: 201, description: 'Insurance policy created successfully', type: InsurancePolicy })
+  @ApiResponse({ status: 400, description: 'Bad request - Invalid input data' })
+  @ApiResponse({ status: 409, description: 'Conflict - Policy number already exists' })
+  async createInsurancePolicy(@Body() createDto: CreateInsurancePolicyDto): Promise<InsurancePolicy> {
+    return await this.insuranceService.createInsurancePolicy(createDto);
+  }
+
+  @Get('policies')
+  @ApiOperation({ summary: 'Get all insurance policies with filtering and pagination' })
+  @ApiResponse({ status: 200, description: 'Insurance policies retrieved successfully' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
+  @ApiQuery({ name: 'policyNumber', required: false, type: String, description: 'Filter by policy number' })
+  @ApiQuery({ name: 'provider', required: false, type: String, description: 'Filter by provider' })
+  @ApiQuery({ name: 'coverageType', required: false, enum: ['all_risk', 'general_average', 'particular_average', 'free_of_particular_average', 'total_loss_only', 'cargo', 'liability'] })
+  @ApiQuery({ name: 'status', required: false, enum: ['active', 'expired', 'cancelled', 'suspended', 'pending'] })
+  @ApiQuery({ name: 'shipmentId', required: false, type: String, description: 'Filter by shipment ID' })
+  async findAllInsurancePolicies(@Query() queryDto: InsurancePolicyQueryDto) {
+    return await this.insuranceService.findAllInsurancePolicies(queryDto);
+  }
+
+  @Get('policies/:id')
+  @ApiOperation({ summary: 'Get insurance policy by ID' })
+  @ApiParam({ name: 'id', description: 'Insurance policy ID' })
+  @ApiResponse({ status: 200, description: 'Insurance policy retrieved successfully', type: InsurancePolicy })
+  @ApiResponse({ status: 404, description: 'Insurance policy not found' })
+  async findInsurancePolicyById(@Param('id') id: string): Promise<InsurancePolicy> {
+    return await this.insuranceService.findInsurancePolicyById(id);
+  }
+
+  @Get('policies/policy-number/:policyNumber')
+  @ApiOperation({ summary: 'Get insurance policy by policy number' })
+  @ApiParam({ name: 'policyNumber', description: 'Insurance policy number' })
+  @ApiResponse({ status: 200, description: 'Insurance policy retrieved successfully', type: InsurancePolicy })
+  @ApiResponse({ status: 404, description: 'Insurance policy not found' })
+  async findInsurancePolicyByPolicyNumber(@Param('policyNumber') policyNumber: string): Promise<InsurancePolicy> {
+    return await this.insuranceService.findInsurancePolicyByPolicyNumber(policyNumber);
+  }
+
+  @Patch('policies/:id')
+  @ApiOperation({ summary: 'Update insurance policy' })
+  @ApiParam({ name: 'id', description: 'Insurance policy ID' })
+  @ApiResponse({ status: 200, description: 'Insurance policy updated successfully', type: InsurancePolicy })
+  @ApiResponse({ status: 404, description: 'Insurance policy not found' })
+  @ApiResponse({ status: 400, description: 'Bad request - Invalid input data' })
+  @ApiResponse({ status: 409, description: 'Conflict - Policy number already exists' })
+  async updateInsurancePolicy(
+    @Param('id') id: string,
+    @Body() updateDto: UpdateInsurancePolicyDto,
+  ): Promise<InsurancePolicy> {
+    return await this.insuranceService.updateInsurancePolicy(id, updateDto);
+  }
+
+  @Delete('policies/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete insurance policy' })
+  @ApiParam({ name: 'id', description: 'Insurance policy ID' })
+  @ApiResponse({ status: 204, description: 'Insurance policy deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Insurance policy not found' })
+  async deleteInsurancePolicy(@Param('id') id: string): Promise<void> {
+    return await this.insuranceService.deleteInsurancePolicy(id);
+  }
+
+  @Get('shipments/:shipmentId/policies')
+  @ApiOperation({ summary: 'Get insurance policies for a specific shipment' })
+  @ApiParam({ name: 'shipmentId', description: 'Shipment ID' })
+  @ApiResponse({ status: 200, description: 'Insurance policies retrieved successfully', type: [InsurancePolicy] })
+  async getInsurancePoliciesByShipment(@Param('shipmentId') shipmentId: string): Promise<InsurancePolicy[]> {
+    return await this.insuranceService.getInsurancePoliciesByShipment(shipmentId);
+  }
+
+  // Claim History Endpoints
+
+  @Post('claims')
+  @ApiOperation({ summary: 'Create a new claim' })
+  @ApiResponse({ status: 201, description: 'Claim created successfully', type: ClaimHistory })
+  @ApiResponse({ status: 400, description: 'Bad request - Invalid input data' })
+  @ApiResponse({ status: 404, description: 'Insurance policy not found' })
+  @ApiResponse({ status: 409, description: 'Conflict - Claim number already exists' })
+  async createClaim(@Body() createDto: CreateClaimDto): Promise<ClaimHistory> {
+    return await this.insuranceService.createClaim(createDto);
+  }
+
+  @Get('claims')
+  @ApiOperation({ summary: 'Get all claims with filtering and pagination' })
+  @ApiResponse({ status: 200, description: 'Claims retrieved successfully' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page' })
+  @ApiQuery({ name: 'claimNumber', required: false, type: String, description: 'Filter by claim number' })
+  @ApiQuery({ name: 'claimType', required: false, enum: ['damage', 'loss', 'theft', 'delay', 'general_average', 'particular_average', 'other'] })
+  @ApiQuery({ name: 'status', required: false, enum: ['submitted', 'under_review', 'approved', 'rejected', 'settled', 'closed'] })
+  @ApiQuery({ name: 'insurancePolicyId', required: false, type: String, description: 'Filter by insurance policy ID' })
+  async findAllClaims(@Query() queryDto: ClaimQueryDto) {
+    return await this.insuranceService.findAllClaims(queryDto);
+  }
+
+  @Get('claims/:id')
+  @ApiOperation({ summary: 'Get claim by ID' })
+  @ApiParam({ name: 'id', description: 'Claim ID' })
+  @ApiResponse({ status: 200, description: 'Claim retrieved successfully', type: ClaimHistory })
+  @ApiResponse({ status: 404, description: 'Claim not found' })
+  async findClaimById(@Param('id') id: string): Promise<ClaimHistory> {
+    return await this.insuranceService.findClaimById(id);
+  }
+
+  @Get('claims/claim-number/:claimNumber')
+  @ApiOperation({ summary: 'Get claim by claim number' })
+  @ApiParam({ name: 'claimNumber', description: 'Claim number' })
+  @ApiResponse({ status: 200, description: 'Claim retrieved successfully', type: ClaimHistory })
+  @ApiResponse({ status: 404, description: 'Claim not found' })
+  async findClaimByClaimNumber(@Param('claimNumber') claimNumber: string): Promise<ClaimHistory> {
+    return await this.insuranceService.findClaimByClaimNumber(claimNumber);
+  }
+
+  @Patch('claims/:id')
+  @ApiOperation({ summary: 'Update claim' })
+  @ApiParam({ name: 'id', description: 'Claim ID' })
+  @ApiResponse({ status: 200, description: 'Claim updated successfully', type: ClaimHistory })
+  @ApiResponse({ status: 404, description: 'Claim not found' })
+  @ApiResponse({ status: 400, description: 'Bad request - Invalid input data' })
+  @ApiResponse({ status: 409, description: 'Conflict - Claim number already exists' })
+  async updateClaim(
+    @Param('id') id: string,
+    @Body() updateDto: UpdateClaimDto,
+  ): Promise<ClaimHistory> {
+    return await this.insuranceService.updateClaim(id, updateDto);
+  }
+
+  @Delete('claims/:id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete claim' })
+  @ApiParam({ name: 'id', description: 'Claim ID' })
+  @ApiResponse({ status: 204, description: 'Claim deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Claim not found' })
+  async deleteClaim(@Param('id') id: string): Promise<void> {
+    return await this.insuranceService.deleteClaim(id);
+  }
+
+  @Get('policies/:insurancePolicyId/claims')
+  @ApiOperation({ summary: 'Get claims for a specific insurance policy' })
+  @ApiParam({ name: 'insurancePolicyId', description: 'Insurance policy ID' })
+  @ApiResponse({ status: 200, description: 'Claims retrieved successfully', type: [ClaimHistory] })
+  async getClaimsByInsurancePolicy(@Param('insurancePolicyId') insurancePolicyId: string): Promise<ClaimHistory[]> {
+    return await this.insuranceService.getClaimsByInsurancePolicy(insurancePolicyId);
+  }
+
+  // Analytics and Reporting Endpoints
+
+  @Get('statistics')
+  @ApiOperation({ summary: 'Get insurance statistics and analytics' })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'Insurance statistics retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        totalPolicies: { type: 'number' },
+        activePolicies: { type: 'number' },
+        expiredPolicies: { type: 'number' },
+        totalClaims: { type: 'number' },
+        pendingClaims: { type: 'number' },
+        approvedClaims: { type: 'number' },
+        totalClaimAmount: { type: 'number' },
+        totalPaidAmount: { type: 'number' },
+      },
+    },
+  })
+  async getInsuranceStatistics() {
+    return await this.insuranceService.getInsuranceStatistics();
+  }
+}

--- a/backend/src/insurance/dto/create-claim.dto.ts
+++ b/backend/src/insurance/dto/create-claim.dto.ts
@@ -1,0 +1,96 @@
+import { IsString, IsEnum, IsNumber, IsDateString, IsOptional, IsUUID, Min } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { ClaimType, ClaimStatus } from '../entities/claim-history.entity';
+
+export class CreateClaimDto {
+  @ApiProperty({ description: 'Unique claim number' })
+  @IsString()
+  claimNumber: string;
+
+  @ApiProperty({ enum: ClaimType, description: 'Type of claim' })
+  @IsEnum(ClaimType)
+  claimType: ClaimType;
+
+  @ApiPropertyOptional({ enum: ClaimStatus, description: 'Claim status', default: ClaimStatus.SUBMITTED })
+  @IsOptional()
+  @IsEnum(ClaimStatus)
+  status?: ClaimStatus;
+
+  @ApiProperty({ description: 'Claimed amount', minimum: 0 })
+  @IsNumber()
+  @Min(0)
+  claimedAmount: number;
+
+  @ApiPropertyOptional({ description: 'Approved amount', minimum: 0 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  approvedAmount?: number;
+
+  @ApiPropertyOptional({ description: 'Paid amount', minimum: 0 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  paidAmount?: number;
+
+  @ApiPropertyOptional({ description: 'Currency code', default: 'USD' })
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @ApiProperty({ description: 'Date of incident' })
+  @IsDateString()
+  incidentDate: string;
+
+  @ApiProperty({ description: 'Date claim was filed' })
+  @IsDateString()
+  claimDate: string;
+
+  @ApiPropertyOptional({ description: 'Settlement date' })
+  @IsOptional()
+  @IsDateString()
+  settlementDate?: string;
+
+  @ApiProperty({ description: 'Detailed description of the claim' })
+  @IsString()
+  description: string;
+
+  @ApiPropertyOptional({ description: 'Investigation notes' })
+  @IsOptional()
+  @IsString()
+  investigationNotes?: string;
+
+  @ApiPropertyOptional({ description: 'Supporting documents (JSON string of URLs/paths)' })
+  @IsOptional()
+  @IsString()
+  supportingDocuments?: string;
+
+  @ApiPropertyOptional({ description: 'Adjuster notes' })
+  @IsOptional()
+  @IsString()
+  adjusterNotes?: string;
+
+  @ApiPropertyOptional({ description: 'Adjuster name' })
+  @IsOptional()
+  @IsString()
+  adjusterName?: string;
+
+  @ApiPropertyOptional({ description: 'Adjuster contact information' })
+  @IsOptional()
+  @IsString()
+  adjusterContact?: string;
+
+  @ApiPropertyOptional({ description: 'Reason for rejection' })
+  @IsOptional()
+  @IsString()
+  rejectionReason?: string;
+
+  @ApiPropertyOptional({ description: 'Settlement notes' })
+  @IsOptional()
+  @IsString()
+  settlementNotes?: string;
+
+  @ApiProperty({ description: 'Associated insurance policy ID' })
+  @IsUUID()
+  insurancePolicyId: string;
+}

--- a/backend/src/insurance/dto/create-insurance-policy.dto.ts
+++ b/backend/src/insurance/dto/create-insurance-policy.dto.ts
@@ -1,0 +1,85 @@
+import { IsString, IsEnum, IsNumber, IsDateString, IsOptional, IsUUID, IsEmail, IsPhoneNumber, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CoverageType, PolicyStatus } from '../entities/insurance-policy.entity';
+
+export class CreateInsurancePolicyDto {
+  @ApiProperty({ description: 'Unique policy number' })
+  @IsString()
+  policyNumber: string;
+
+  @ApiProperty({ description: 'Insurance provider name' })
+  @IsString()
+  provider: string;
+
+  @ApiProperty({ enum: CoverageType, description: 'Type of coverage' })
+  @IsEnum(CoverageType)
+  coverageType: CoverageType;
+
+  @ApiProperty({ description: 'Coverage amount', minimum: 0 })
+  @IsNumber()
+  @Min(0)
+  coverageAmount: number;
+
+  @ApiProperty({ description: 'Premium amount', minimum: 0 })
+  @IsNumber()
+  @Min(0)
+  premiumAmount: number;
+
+  @ApiPropertyOptional({ description: 'Currency code', default: 'USD' })
+  @IsOptional()
+  @IsString()
+  currency?: string;
+
+  @ApiPropertyOptional({ description: 'Deductible amount', minimum: 0 })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  deductible?: number;
+
+  @ApiProperty({ description: 'Policy effective date' })
+  @IsDateString()
+  effectiveDate: string;
+
+  @ApiProperty({ description: 'Policy expiry date' })
+  @IsDateString()
+  expiryDate: string;
+
+  @ApiPropertyOptional({ enum: PolicyStatus, description: 'Policy status', default: PolicyStatus.PENDING })
+  @IsOptional()
+  @IsEnum(PolicyStatus)
+  status?: PolicyStatus;
+
+  @ApiPropertyOptional({ description: 'Terms and conditions' })
+  @IsOptional()
+  @IsString()
+  termsAndConditions?: string;
+
+  @ApiPropertyOptional({ description: 'Policy exclusions' })
+  @IsOptional()
+  @IsString()
+  exclusions?: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsOptional()
+  @IsString()
+  notes?: string;
+
+  @ApiPropertyOptional({ description: 'Contact person name' })
+  @IsOptional()
+  @IsString()
+  contactPerson?: string;
+
+  @ApiPropertyOptional({ description: 'Contact email' })
+  @IsOptional()
+  @IsEmail()
+  contactEmail?: string;
+
+  @ApiPropertyOptional({ description: 'Contact phone number' })
+  @IsOptional()
+  @IsString()
+  contactPhone?: string;
+
+  @ApiProperty({ description: 'Associated shipment ID' })
+  @IsUUID()
+  shipmentId: string;
+}

--- a/backend/src/insurance/dto/insurance-query.dto.ts
+++ b/backend/src/insurance/dto/insurance-query.dto.ts
@@ -1,0 +1,122 @@
+import { IsOptional, IsString, IsEnum, IsUUID, IsDateString, IsNumber, Min } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { CoverageType, PolicyStatus } from '../entities/insurance-policy.entity';
+import { ClaimStatus, ClaimType } from '../entities/claim-history.entity';
+
+export class InsurancePolicyQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by policy number' })
+  @IsOptional()
+  @IsString()
+  policyNumber?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by provider' })
+  @IsOptional()
+  @IsString()
+  provider?: string;
+
+  @ApiPropertyOptional({ enum: CoverageType, description: 'Filter by coverage type' })
+  @IsOptional()
+  @IsEnum(CoverageType)
+  coverageType?: CoverageType;
+
+  @ApiPropertyOptional({ enum: PolicyStatus, description: 'Filter by policy status' })
+  @IsOptional()
+  @IsEnum(PolicyStatus)
+  status?: PolicyStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by shipment ID' })
+  @IsOptional()
+  @IsUUID()
+  shipmentId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by effective date from' })
+  @IsOptional()
+  @IsDateString()
+  effectiveDateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by effective date to' })
+  @IsOptional()
+  @IsDateString()
+  effectiveDateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by expiry date from' })
+  @IsOptional()
+  @IsDateString()
+  expiryDateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by expiry date to' })
+  @IsOptional()
+  @IsDateString()
+  expiryDateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Page number', minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
+}
+
+export class ClaimQueryDto {
+  @ApiPropertyOptional({ description: 'Filter by claim number' })
+  @IsOptional()
+  @IsString()
+  claimNumber?: string;
+
+  @ApiPropertyOptional({ enum: ClaimType, description: 'Filter by claim type' })
+  @IsOptional()
+  @IsEnum(ClaimType)
+  claimType?: ClaimType;
+
+  @ApiPropertyOptional({ enum: ClaimStatus, description: 'Filter by claim status' })
+  @IsOptional()
+  @IsEnum(ClaimStatus)
+  status?: ClaimStatus;
+
+  @ApiPropertyOptional({ description: 'Filter by insurance policy ID' })
+  @IsOptional()
+  @IsUUID()
+  insurancePolicyId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by incident date from' })
+  @IsOptional()
+  @IsDateString()
+  incidentDateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by incident date to' })
+  @IsOptional()
+  @IsDateString()
+  incidentDateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by claim date from' })
+  @IsOptional()
+  @IsDateString()
+  claimDateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by claim date to' })
+  @IsOptional()
+  @IsDateString()
+  claimDateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Page number', minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page', minimum: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(1)
+  limit?: number = 10;
+}

--- a/backend/src/insurance/dto/update-claim.dto.ts
+++ b/backend/src/insurance/dto/update-claim.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateClaimDto } from './create-claim.dto';
+
+export class UpdateClaimDto extends PartialType(CreateClaimDto) {}

--- a/backend/src/insurance/dto/update-insurance-policy.dto.ts
+++ b/backend/src/insurance/dto/update-insurance-policy.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateInsurancePolicyDto } from './create-insurance-policy.dto';
+
+export class UpdateInsurancePolicyDto extends PartialType(CreateInsurancePolicyDto) {}

--- a/backend/src/insurance/entities/claim-history.entity.ts
+++ b/backend/src/insurance/entities/claim-history.entity.ts
@@ -1,0 +1,107 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { InsurancePolicy } from './insurance-policy.entity';
+
+export enum ClaimStatus {
+  SUBMITTED = 'submitted',
+  UNDER_REVIEW = 'under_review',
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  SETTLED = 'settled',
+  CLOSED = 'closed',
+}
+
+export enum ClaimType {
+  DAMAGE = 'damage',
+  LOSS = 'loss',
+  THEFT = 'theft',
+  DELAY = 'delay',
+  GENERAL_AVERAGE = 'general_average',
+  PARTICULAR_AVERAGE = 'particular_average',
+  OTHER = 'other',
+}
+
+@Entity({ name: 'claim_history' })
+export class ClaimHistory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 50, unique: true })
+  claimNumber: string;
+
+  @Column({ type: 'enum', enum: ClaimType })
+  claimType: ClaimType;
+
+  @Column({ type: 'enum', enum: ClaimStatus, default: ClaimStatus.SUBMITTED })
+  status: ClaimStatus;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  claimedAmount: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2, nullable: true })
+  approvedAmount?: number;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2, nullable: true })
+  paidAmount?: number;
+
+  @Column({ type: 'varchar', length: 3, default: 'USD' })
+  currency: string;
+
+  @Column({ type: 'timestamptz' })
+  incidentDate: Date;
+
+  @Column({ type: 'timestamptz' })
+  claimDate: Date;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  settlementDate?: Date;
+
+  @Column({ type: 'text' })
+  description: string;
+
+  @Column({ type: 'text', nullable: true })
+  investigationNotes?: string;
+
+  @Column({ type: 'text', nullable: true })
+  supportingDocuments?: string; // JSON string of document URLs/paths
+
+  @Column({ type: 'text', nullable: true })
+  adjusterNotes?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  adjusterName?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  adjusterContact?: string;
+
+  @Column({ type: 'text', nullable: true })
+  rejectionReason?: string;
+
+  @Column({ type: 'text', nullable: true })
+  settlementNotes?: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  // Relationship with Insurance Policy
+  @Column({ type: 'uuid' })
+  insurancePolicyId: string;
+
+  @ManyToOne(() => InsurancePolicy, (policy) => policy.claimHistory, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'insurancePolicyId' })
+  insurancePolicy: InsurancePolicy;
+}

--- a/backend/src/insurance/entities/insurance-policy.entity.ts
+++ b/backend/src/insurance/entities/insurance-policy.entity.ts
@@ -1,0 +1,106 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Shipment } from '../../shipment/shipment.entity';
+import { ClaimHistory } from './claim-history.entity';
+
+export enum CoverageType {
+  ALL_RISK = 'all_risk',
+  GENERAL_AVERAGE = 'general_average',
+  PARTICULAR_AVERAGE = 'particular_average',
+  FREE_OF_PARTICULAR_AVERAGE = 'free_of_particular_average',
+  TOTAL_LOSS_ONLY = 'total_loss_only',
+  CARGO = 'cargo',
+  LIABILITY = 'liability',
+}
+
+export enum PolicyStatus {
+  ACTIVE = 'active',
+  EXPIRED = 'expired',
+  CANCELLED = 'cancelled',
+  SUSPENDED = 'suspended',
+  PENDING = 'pending',
+}
+
+@Entity({ name: 'insurance_policies' })
+export class InsurancePolicy {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index({ unique: true })
+  @Column({ type: 'varchar', length: 50, unique: true })
+  policyNumber: string;
+
+  @Column({ type: 'varchar', length: 255 })
+  provider: string;
+
+  @Column({ type: 'enum', enum: CoverageType })
+  coverageType: CoverageType;
+
+  @Column({ type: 'decimal', precision: 15, scale: 2 })
+  coverageAmount: number;
+
+  @Column({ type: 'decimal', precision: 8, scale: 4 })
+  premiumAmount: number;
+
+  @Column({ type: 'varchar', length: 3, default: 'USD' })
+  currency: string;
+
+  @Column({ type: 'decimal', precision: 5, scale: 2, nullable: true })
+  deductible?: number;
+
+  @Column({ type: 'timestamptz' })
+  effectiveDate: Date;
+
+  @Column({ type: 'timestamptz' })
+  expiryDate: Date;
+
+  @Column({ type: 'enum', enum: PolicyStatus, default: PolicyStatus.PENDING })
+  status: PolicyStatus;
+
+  @Column({ type: 'text', nullable: true })
+  termsAndConditions?: string;
+
+  @Column({ type: 'text', nullable: true })
+  exclusions?: string;
+
+  @Column({ type: 'text', nullable: true })
+  notes?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  contactPerson?: string;
+
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  contactEmail?: string;
+
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  contactPhone?: string;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz' })
+  updatedAt: Date;
+
+  // Relationship with Shipment
+  @Column({ type: 'uuid' })
+  shipmentId: string;
+
+  @ManyToOne(() => Shipment, (shipment) => shipment.id, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'shipmentId' })
+  shipment: Shipment;
+
+  // Relationship with Claim History
+  @OneToMany(() => ClaimHistory, (claim) => claim.insurancePolicy)
+  claimHistory: ClaimHistory[];
+}

--- a/backend/src/insurance/index.ts
+++ b/backend/src/insurance/index.ts
@@ -1,0 +1,19 @@
+// Entities
+export * from './entities/insurance-policy.entity';
+export * from './entities/claim-history.entity';
+
+// DTOs
+export * from './dto/create-insurance-policy.dto';
+export * from './dto/update-insurance-policy.dto';
+export * from './dto/create-claim.dto';
+export * from './dto/update-claim.dto';
+export * from './dto/insurance-query.dto';
+
+// Services
+export * from './services/insurance.service';
+
+// Controllers
+export * from './controllers/insurance.controller';
+
+// Module
+export * from './insurance.module';

--- a/backend/src/insurance/insurance.module.ts
+++ b/backend/src/insurance/insurance.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { InsuranceController } from './controllers/insurance.controller';
+import { InsuranceService } from './services/insurance.service';
+import { InsurancePolicy } from './entities/insurance-policy.entity';
+import { ClaimHistory } from './entities/claim-history.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([InsurancePolicy, ClaimHistory]),
+  ],
+  controllers: [InsuranceController],
+  providers: [InsuranceService],
+  exports: [InsuranceService],
+})
+export class InsuranceModule {}

--- a/backend/src/insurance/insurance.service.spec.ts
+++ b/backend/src/insurance/insurance.service.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { InsuranceService } from "./services/insurance.service";
+import { InsurancePolicy } from "./entities/insurance-policy.entity";
+import { ClaimHistory, ClaimStatus, ClaimType } from "./entities/claim-history.entity";
+import { Shipment } from "../shipment/shipment.entity";
+import { ShipmentStatusHistory } from "../shipment/shipment-status-history.entity";
+
+describe("InsuranceService (unit)", () => {
+	let service: InsuranceService;
+	let createdShipment: Shipment;
+
+	beforeAll(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			imports: [
+				TypeOrmModule.forRoot({
+					type: "sqlite",
+					database: ":memory:",
+					dropSchema: true,
+					entities: [Shipment, ShipmentStatusHistory, InsurancePolicy, ClaimHistory],
+					synchronize: true,
+				}),
+				TypeOrmModule.forFeature([Shipment, ShipmentStatusHistory, InsurancePolicy, ClaimHistory]),
+			],
+			providers: [InsuranceService],
+		}).compile();
+
+		service = module.get<InsuranceService>(InsuranceService);
+
+		// Manually create a shipment via TypeORM repository through the data source
+		const dataSource = module.get<any>("DataSource");
+		const shipmentRepo = dataSource.getRepository(Shipment);
+		createdShipment = await shipmentRepo.save(
+			shipmentRepo.create({
+				trackingId: "FF-20240101-ABCDE",
+				origin: "NYC",
+				destination: "LA",
+				carrier: "FedEx",
+			})
+		);
+	});
+
+	it("creates an insurance policy for a shipment", async () => {
+		const policy = await service.createInsurancePolicy({
+			policyNumber: "POL-001",
+			provider: "Global Insure",
+			coverageType: "all_risk" as any,
+			coverageAmount: 100000,
+			premiumAmount: 1200,
+			effectiveDate: new Date("2024-01-01").toISOString(),
+			expiryDate: new Date("2024-12-31").toISOString(),
+			shipmentId: createdShipment.id,
+		} as any);
+
+		expect(policy).toHaveProperty("id");
+		expect(policy.policyNumber).toBe("POL-001");
+		expect(policy.shipmentId).toBe(createdShipment.id);
+	});
+
+	it("lists policies with pagination", async () => {
+		const res = await service.findAllInsurancePolicies({ page: 1, limit: 10 } as any);
+		expect(res.total).toBeGreaterThan(0);
+		expect(Array.isArray(res.data)).toBe(true);
+	});
+
+	it("updates a policy and fetches by policy number", async () => {
+		const found = await service.findInsurancePolicyByPolicyNumber("POL-001");
+		const updated = await service.updateInsurancePolicy(found.id, { provider: "Global Insure Ltd" } as any);
+		expect(updated.provider).toBe("Global Insure Ltd");
+	});
+
+	it("creates a claim for a policy", async () => {
+		const policy = await service.findInsurancePolicyByPolicyNumber("POL-001");
+		const claim = await service.createClaim({
+			claimNumber: "CLM-001",
+			claimType: ClaimType.DAMAGE,
+			claimedAmount: 5000,
+			incidentDate: new Date("2024-06-01").toISOString(),
+			claimDate: new Date("2024-06-02").toISOString(),
+			description: "Damaged during transit",
+			insurancePolicyId: policy.id,
+		} as any);
+		expect(claim).toHaveProperty("id");
+		expect(claim.status).toBe(ClaimStatus.SUBMITTED);
+	});
+
+	it("lists claims and updates a claim", async () => {
+		const list = await service.findAllClaims({ page: 1, limit: 10 } as any);
+		expect(list.total).toBeGreaterThan(0);
+
+		const claim = await service.findClaimByClaimNumber("CLM-001");
+		const updated = await service.updateClaim(claim.id, { status: ClaimStatus.APPROVED } as any);
+		expect(updated.status).toBe(ClaimStatus.APPROVED);
+	});
+
+	it("deletes claim and policy", async () => {
+		const claim = await service.findClaimByClaimNumber("CLM-001");
+		await service.deleteClaim(claim.id);
+		await expect(service.findClaimByClaimNumber("CLM-001")).rejects.toBeDefined();
+
+		const policy = await service.findInsurancePolicyByPolicyNumber("POL-001");
+		await service.deleteInsurancePolicy(policy.id);
+		await expect(service.findInsurancePolicyByPolicyNumber("POL-001")).rejects.toBeDefined();
+	});
+});

--- a/backend/src/insurance/services/insurance.service.ts
+++ b/backend/src/insurance/services/insurance.service.ts
@@ -1,0 +1,400 @@
+import { Injectable, NotFoundException, BadRequestException, ConflictException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Between, Like, FindManyOptions } from 'typeorm';
+import { InsurancePolicy, PolicyStatus } from '../entities/insurance-policy.entity';
+import { ClaimHistory, ClaimStatus } from '../entities/claim-history.entity';
+import { CreateInsurancePolicyDto } from '../dto/create-insurance-policy.dto';
+import { UpdateInsurancePolicyDto } from '../dto/update-insurance-policy.dto';
+import { CreateClaimDto } from '../dto/create-claim.dto';
+import { UpdateClaimDto } from '../dto/update-claim.dto';
+import { InsurancePolicyQueryDto, ClaimQueryDto } from '../dto/insurance-query.dto';
+
+@Injectable()
+export class InsuranceService {
+  constructor(
+    @InjectRepository(InsurancePolicy)
+    private readonly insurancePolicyRepository: Repository<InsurancePolicy>,
+    @InjectRepository(ClaimHistory)
+    private readonly claimHistoryRepository: Repository<ClaimHistory>,
+  ) {}
+
+  // Insurance Policy CRUD Operations
+
+  async createInsurancePolicy(createDto: CreateInsurancePolicyDto): Promise<InsurancePolicy> {
+    // Check if policy number already exists
+    const existingPolicy = await this.insurancePolicyRepository.findOne({
+      where: { policyNumber: createDto.policyNumber },
+    });
+
+    if (existingPolicy) {
+      throw new ConflictException('Policy number already exists');
+    }
+
+    // Validate dates
+    const effectiveDate = new Date(createDto.effectiveDate);
+    const expiryDate = new Date(createDto.expiryDate);
+
+    if (expiryDate <= effectiveDate) {
+      throw new BadRequestException('Expiry date must be after effective date');
+    }
+
+    const insurancePolicy = this.insurancePolicyRepository.create({
+      ...createDto,
+      effectiveDate,
+      expiryDate,
+      currency: createDto.currency || 'USD',
+      status: createDto.status || PolicyStatus.PENDING,
+    });
+
+    return await this.insurancePolicyRepository.save(insurancePolicy);
+  }
+
+  async findAllInsurancePolicies(queryDto: InsurancePolicyQueryDto): Promise<{
+    data: InsurancePolicy[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const { page = 1, limit = 10, ...filters } = queryDto;
+    const skip = (page - 1) * limit;
+
+    const where: any = {};
+
+    if (filters.policyNumber) {
+      where.policyNumber = Like(`%${filters.policyNumber}%`);
+    }
+
+    if (filters.provider) {
+      where.provider = Like(`%${filters.provider}%`);
+    }
+
+    if (filters.coverageType) {
+      where.coverageType = filters.coverageType;
+    }
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    if (filters.shipmentId) {
+      where.shipmentId = filters.shipmentId;
+    }
+
+    if (filters.effectiveDateFrom || filters.effectiveDateTo) {
+      where.effectiveDate = {};
+      if (filters.effectiveDateFrom) {
+        where.effectiveDate = Between(new Date(filters.effectiveDateFrom), where.effectiveDate || new Date());
+      }
+      if (filters.effectiveDateTo) {
+        where.effectiveDate = Between(where.effectiveDate || new Date('1900-01-01'), new Date(filters.effectiveDateTo));
+      }
+    }
+
+    if (filters.expiryDateFrom || filters.expiryDateTo) {
+      where.expiryDate = {};
+      if (filters.expiryDateFrom) {
+        where.expiryDate = Between(new Date(filters.expiryDateFrom), where.expiryDate || new Date());
+      }
+      if (filters.expiryDateTo) {
+        where.expiryDate = Between(where.expiryDate || new Date('1900-01-01'), new Date(filters.expiryDateTo));
+      }
+    }
+
+    const findOptions: FindManyOptions<InsurancePolicy> = {
+      where,
+      skip,
+      take: limit,
+      order: { createdAt: 'DESC' },
+      relations: ['shipment', 'claimHistory'],
+    };
+
+    const [data, total] = await this.insurancePolicyRepository.findAndCount(findOptions);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findInsurancePolicyById(id: string): Promise<InsurancePolicy> {
+    const policy = await this.insurancePolicyRepository.findOne({
+      where: { id },
+      relations: ['shipment', 'claimHistory'],
+    });
+
+    if (!policy) {
+      throw new NotFoundException('Insurance policy not found');
+    }
+
+    return policy;
+  }
+
+  async findInsurancePolicyByPolicyNumber(policyNumber: string): Promise<InsurancePolicy> {
+    const policy = await this.insurancePolicyRepository.findOne({
+      where: { policyNumber },
+      relations: ['shipment', 'claimHistory'],
+    });
+
+    if (!policy) {
+      throw new NotFoundException('Insurance policy not found');
+    }
+
+    return policy;
+  }
+
+  async updateInsurancePolicy(id: string, updateDto: UpdateInsurancePolicyDto): Promise<InsurancePolicy> {
+    const policy = await this.findInsurancePolicyById(id);
+
+    // Check if new policy number conflicts with existing ones
+    if (updateDto.policyNumber && updateDto.policyNumber !== policy.policyNumber) {
+      const existingPolicy = await this.insurancePolicyRepository.findOne({
+        where: { policyNumber: updateDto.policyNumber },
+      });
+
+      if (existingPolicy) {
+        throw new ConflictException('Policy number already exists');
+      }
+    }
+
+    // Validate dates if provided
+    if (updateDto.effectiveDate || updateDto.expiryDate) {
+      const effectiveDate = updateDto.effectiveDate ? new Date(updateDto.effectiveDate) : policy.effectiveDate;
+      const expiryDate = updateDto.expiryDate ? new Date(updateDto.expiryDate) : policy.expiryDate;
+
+      if (expiryDate <= effectiveDate) {
+        throw new BadRequestException('Expiry date must be after effective date');
+      }
+    }
+
+    Object.assign(policy, updateDto);
+
+    if (updateDto.effectiveDate) {
+      policy.effectiveDate = new Date(updateDto.effectiveDate);
+    }
+
+    if (updateDto.expiryDate) {
+      policy.expiryDate = new Date(updateDto.expiryDate);
+    }
+
+    return await this.insurancePolicyRepository.save(policy);
+  }
+
+  async deleteInsurancePolicy(id: string): Promise<void> {
+    const policy = await this.findInsurancePolicyById(id);
+    await this.insurancePolicyRepository.remove(policy);
+  }
+
+  async getInsurancePoliciesByShipment(shipmentId: string): Promise<InsurancePolicy[]> {
+    return await this.insurancePolicyRepository.find({
+      where: { shipmentId },
+      relations: ['claimHistory'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // Claim History CRUD Operations
+
+  async createClaim(createDto: CreateClaimDto): Promise<ClaimHistory> {
+    // Check if claim number already exists
+    const existingClaim = await this.claimHistoryRepository.findOne({
+      where: { claimNumber: createDto.claimNumber },
+    });
+
+    if (existingClaim) {
+      throw new ConflictException('Claim number already exists');
+    }
+
+    // Verify insurance policy exists
+    const policy = await this.findInsurancePolicyById(createDto.insurancePolicyId);
+
+    const claim = this.claimHistoryRepository.create({
+      ...createDto,
+      incidentDate: new Date(createDto.incidentDate),
+      claimDate: new Date(createDto.claimDate),
+      settlementDate: createDto.settlementDate ? new Date(createDto.settlementDate) : undefined,
+      currency: createDto.currency || 'USD',
+      status: createDto.status || ClaimStatus.SUBMITTED,
+    });
+
+    return await this.claimHistoryRepository.save(claim);
+  }
+
+  async findAllClaims(queryDto: ClaimQueryDto): Promise<{
+    data: ClaimHistory[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
+    const { page = 1, limit = 10, ...filters } = queryDto;
+    const skip = (page - 1) * limit;
+
+    const where: any = {};
+
+    if (filters.claimNumber) {
+      where.claimNumber = Like(`%${filters.claimNumber}%`);
+    }
+
+    if (filters.claimType) {
+      where.claimType = filters.claimType;
+    }
+
+    if (filters.status) {
+      where.status = filters.status;
+    }
+
+    if (filters.insurancePolicyId) {
+      where.insurancePolicyId = filters.insurancePolicyId;
+    }
+
+    if (filters.incidentDateFrom || filters.incidentDateTo) {
+      where.incidentDate = {};
+      if (filters.incidentDateFrom) {
+        where.incidentDate = Between(new Date(filters.incidentDateFrom), where.incidentDate || new Date());
+      }
+      if (filters.incidentDateTo) {
+        where.incidentDate = Between(where.incidentDate || new Date('1900-01-01'), new Date(filters.incidentDateTo));
+      }
+    }
+
+    if (filters.claimDateFrom || filters.claimDateTo) {
+      where.claimDate = {};
+      if (filters.claimDateFrom) {
+        where.claimDate = Between(new Date(filters.claimDateFrom), where.claimDate || new Date());
+      }
+      if (filters.claimDateTo) {
+        where.claimDate = Between(where.claimDate || new Date('1900-01-01'), new Date(filters.claimDateTo));
+      }
+    }
+
+    const findOptions: FindManyOptions<ClaimHistory> = {
+      where,
+      skip,
+      take: limit,
+      order: { createdAt: 'DESC' },
+      relations: ['insurancePolicy', 'insurancePolicy.shipment'],
+    };
+
+    const [data, total] = await this.claimHistoryRepository.findAndCount(findOptions);
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+    };
+  }
+
+  async findClaimById(id: string): Promise<ClaimHistory> {
+    const claim = await this.claimHistoryRepository.findOne({
+      where: { id },
+      relations: ['insurancePolicy', 'insurancePolicy.shipment'],
+    });
+
+    if (!claim) {
+      throw new NotFoundException('Claim not found');
+    }
+
+    return claim;
+  }
+
+  async findClaimByClaimNumber(claimNumber: string): Promise<ClaimHistory> {
+    const claim = await this.claimHistoryRepository.findOne({
+      where: { claimNumber },
+      relations: ['insurancePolicy', 'insurancePolicy.shipment'],
+    });
+
+    if (!claim) {
+      throw new NotFoundException('Claim not found');
+    }
+
+    return claim;
+  }
+
+  async updateClaim(id: string, updateDto: UpdateClaimDto): Promise<ClaimHistory> {
+    const claim = await this.findClaimById(id);
+
+    // Check if new claim number conflicts with existing ones
+    if (updateDto.claimNumber && updateDto.claimNumber !== claim.claimNumber) {
+      const existingClaim = await this.claimHistoryRepository.findOne({
+        where: { claimNumber: updateDto.claimNumber },
+      });
+
+      if (existingClaim) {
+        throw new ConflictException('Claim number already exists');
+      }
+    }
+
+    Object.assign(claim, updateDto);
+
+    if (updateDto.incidentDate) {
+      claim.incidentDate = new Date(updateDto.incidentDate);
+    }
+
+    if (updateDto.claimDate) {
+      claim.claimDate = new Date(updateDto.claimDate);
+    }
+
+    if (updateDto.settlementDate) {
+      claim.settlementDate = new Date(updateDto.settlementDate);
+    }
+
+    return await this.claimHistoryRepository.save(claim);
+  }
+
+  async deleteClaim(id: string): Promise<void> {
+    const claim = await this.findClaimById(id);
+    await this.claimHistoryRepository.remove(claim);
+  }
+
+  async getClaimsByInsurancePolicy(insurancePolicyId: string): Promise<ClaimHistory[]> {
+    return await this.claimHistoryRepository.find({
+      where: { insurancePolicyId },
+      relations: ['insurancePolicy'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  // Analytics and Reporting
+
+  async getInsuranceStatistics(): Promise<{
+    totalPolicies: number;
+    activePolicies: number;
+    expiredPolicies: number;
+    totalClaims: number;
+    pendingClaims: number;
+    approvedClaims: number;
+    totalClaimAmount: number;
+    totalPaidAmount: number;
+  }> {
+    const [totalPolicies, activePolicies, expiredPolicies] = await Promise.all([
+      this.insurancePolicyRepository.count(),
+      this.insurancePolicyRepository.count({ where: { status: PolicyStatus.ACTIVE } }),
+      this.insurancePolicyRepository.count({ where: { status: PolicyStatus.EXPIRED } }),
+    ]);
+
+    const [totalClaims, pendingClaims, approvedClaims] = await Promise.all([
+      this.claimHistoryRepository.count(),
+      this.claimHistoryRepository.count({ where: { status: ClaimStatus.SUBMITTED } }),
+      this.claimHistoryRepository.count({ where: { status: ClaimStatus.APPROVED } }),
+    ]);
+
+    const claimAmounts = await this.claimHistoryRepository
+      .createQueryBuilder('claim')
+      .select('SUM(claim.claimedAmount)', 'totalClaimAmount')
+      .addSelect('SUM(claim.paidAmount)', 'totalPaidAmount')
+      .getRawOne();
+
+    return {
+      totalPolicies,
+      activePolicies,
+      expiredPolicies,
+      totalClaims,
+      pendingClaims,
+      approvedClaims,
+      totalClaimAmount: parseFloat(claimAmounts.totalClaimAmount) || 0,
+      totalPaidAmount: parseFloat(claimAmounts.totalPaidAmount) || 0,
+    };
+  }
+}

--- a/backend/test/insurance.e2e-spec.ts
+++ b/backend/test/insurance.e2e-spec.ts
@@ -1,0 +1,138 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Shipment } from "../src/shipment/shipment.entity";
+import { ShipmentStatusHistory } from "../src/shipment/shipment-status-history.entity";
+import { InsuranceModule } from "../src/insurance/insurance.module";
+import { InsurancePolicy } from "../src/insurance/entities/insurance-policy.entity";
+import { ClaimHistory } from "../src/insurance/entities/claim-history.entity";
+
+describe("Insurance (e2e)", () => {
+	let app: INestApplication;
+	let shipmentId: string;
+	let policyId: string;
+	let claimId: string;
+
+	beforeAll(async () => {
+		const moduleFixture: TestingModule = await Test.createTestingModule({
+			imports: [
+				TypeOrmModule.forRoot({
+					type: "sqlite",
+					database: ":memory:",
+					dropSchema: true,
+					entities: [Shipment, ShipmentStatusHistory, InsurancePolicy, ClaimHistory],
+					synchronize: true,
+				}),
+				TypeOrmModule.forFeature([Shipment, ShipmentStatusHistory]),
+				InsuranceModule,
+			],
+		}).compile();
+
+		app = moduleFixture.createNestApplication();
+		await app.init();
+
+		// create a shipment directly via repository
+		const dataSource = moduleFixture.get<any>("DataSource");
+		const shipmentRepo = dataSource.getRepository(Shipment);
+		const created = await shipmentRepo.save(
+			shipmentRepo.create({
+				trackingId: "FF-20240101-ABCDE",
+				origin: "NYC",
+				destination: "LA",
+				carrier: "FedEx",
+			})
+		);
+		shipmentId = created.id;
+	});
+
+	afterAll(async () => {
+		await app.close();
+	});
+
+	it("POST /insurance/policies creates policy", async () => {
+		const dto = {
+			policyNumber: "POL-E2E-1",
+			provider: "Global Insure",
+			coverageType: "all_risk",
+			coverageAmount: 100000,
+			premiumAmount: 999.99,
+			effectiveDate: new Date("2024-01-01").toISOString(),
+			expiryDate: new Date("2024-12-31").toISOString(),
+			shipmentId,
+		};
+
+		const res = await request(app.getHttpServer())
+			.post("/insurance/policies")
+			.send(dto)
+			.expect(201);
+
+		policyId = res.body.id;
+		expect(res.body.policyNumber).toBe(dto.policyNumber);
+		expect(res.body.shipmentId).toBe(shipmentId);
+	});
+
+	it("GET /insurance/policies returns list", async () => {
+		const res = await request(app.getHttpServer())
+			.get("/insurance/policies")
+			.expect(200);
+		expect(Array.isArray(res.body.data)).toBe(true);
+		expect(res.body.total).toBeGreaterThan(0);
+	});
+
+	it("GET /insurance/policies/:id returns policy", async () => {
+		const res = await request(app.getHttpServer())
+			.get(`/insurance/policies/${policyId}`)
+			.expect(200);
+		expect(res.body.id).toBe(policyId);
+	});
+
+	it("POST /insurance/claims creates claim", async () => {
+		const dto = {
+			claimNumber: "CLM-E2E-1",
+			claimType: "damage",
+			claimedAmount: 2500.5,
+			incidentDate: new Date("2024-06-10").toISOString(),
+			claimDate: new Date("2024-06-12").toISOString(),
+			description: "Damaged during transit",
+			insurancePolicyId: policyId,
+		};
+
+		const res = await request(app.getHttpServer())
+			.post("/insurance/claims")
+			.send(dto)
+			.expect(201);
+
+		claimId = res.body.id;
+		expect(res.body.claimNumber).toBe(dto.claimNumber);
+		expect(res.body.insurancePolicyId).toBe(policyId);
+	});
+
+	it("GET /insurance/claims returns list", async () => {
+		const res = await request(app.getHttpServer())
+			.get("/insurance/claims")
+			.expect(200);
+		expect(Array.isArray(res.body.data)).toBe(true);
+		expect(res.body.total).toBeGreaterThan(0);
+	});
+
+	it("PATCH /insurance/claims/:id updates claim", async () => {
+		const res = await request(app.getHttpServer())
+			.patch(`/insurance/claims/${claimId}`)
+			.send({ status: "approved" })
+			.expect(200);
+		expect(res.body.status).toBe("approved");
+	});
+
+	it("DELETE /insurance/claims/:id deletes claim", async () => {
+		await request(app.getHttpServer())
+			.delete(`/insurance/claims/${claimId}`)
+			.expect(204);
+	});
+
+	it("DELETE /insurance/policies/:id deletes policy", async () => {
+		await request(app.getHttpServer())
+			.delete(`/insurance/policies/${policyId}`)
+			.expect(204);
+	});
+});


### PR DESCRIPTION
### Title
Add Insurance Module for Shipment Policies and Claims

### Summary
This PR introduces a complete insurance management module for shipments, enabling creation and management of insurance policies (provider, coverage type, amounts, dates, status) and associated claim histories (types, status, amounts, timelines). Includes unit and e2e tests, Swagger docs, and integration into the app.

### Changes
- Insurance domain
  - Entities: `InsurancePolicy`, `ClaimHistory`
  - DTOs: create/update for policies and claims, query DTOs with pagination and filters
  - Service: full CRUD for policies and claims, statistics aggregation
  - Controller: REST endpoints under `api/v1/insurance/*`
  - Module: `InsuranceModule` + import into `AppModule`
- Tests
  - Unit: `InsuranceService` on in-memory SQLite
  - E2E: REST flows for policies and claims
- Docs
  - Swagger: endpoints and schemas appear in `/docs` automatically
  - Module README

### Endpoints
- Policies
  - POST `/api/v1/insurance/policies`
  - GET `/api/v1/insurance/policies`
  - GET `/api/v1/insurance/policies/:id`
  - GET `/api/v1/insurance/policies/policy-number/:policyNumber`
  - PATCH `/api/v1/insurance/policies/:id`
  - DELETE `/api/v1/insurance/policies/:id`
  - GET `/api/v1/insurance/shipments/:shipmentId/policies`
- Claims
  - POST `/api/v1/insurance/claims`
  - GET `/api/v1/insurance/claims`
  - GET `/api/v1/insurance/claims/:id`
  - GET `/api/v1/insurance/claims/claim-number/:claimNumber`
  - PATCH `/api/v1/insurance/claims/:id`
  - DELETE `/api/v1/insurance/claims/:id`
  - GET `/api/v1/insurance/policies/:insurancePolicyId/claims`
- Analytics
  - GET `/api/v1/insurance/statistics`

### How to test
- Unit tests
  - Run project tests; insurance service spec uses in-memory SQLite.
- E2E tests
  - Insurance e2e spec runs a module with in-memory SQLite and exercises endpoints.

### Checklist
- [x] Create `InsurancePolicy` and `ClaimHistory` entities
- [x] Add DTOs for create/update + query filters
- [x] Implement `InsuranceService` CRUD for policies and claims
- [x] Add `InsuranceController` REST endpoints
- [x] Wire `InsuranceModule` and import in `AppModule`
- [x] Add `InsuranceService` unit tests (SQLite in-memory)
- [x] Add insurance e2e tests for policies and claims
- [x] Swagger reflects new endpoints and schemas
- [x] Lint passes for new files
- [x] No breaking changes to existing features

### Linked issue
Closes #402
