### PR TITLE
Tracking module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -11,6 +11,7 @@ import { CustomsComplianceModule } from './customs/customs-complaince.module';
 import { GoodsTrackingModule } from './goods-tracking/goods-tracking.module';
 import { StellarFreightModule } from './stellar-freight/stellar-freight.module';
 import { FleetModule } from './fleet/fleet.module';
+import { TrackingModule } from './tracking/tracking.module';
 
 
 @Module({
@@ -40,6 +41,7 @@ import { FleetModule } from './fleet/fleet.module';
   GoodsTrackingModule,
   StellarFreightModule,
   FleetModule,
+  TrackingModule,
 
   ],
   controllers: [AppController],

--- a/backend/src/shipment/shipment.controller.ts
+++ b/backend/src/shipment/shipment.controller.ts
@@ -9,13 +9,14 @@ import {
   Query,
   HttpCode,
   HttpStatus,
+  ParseEnumPipe,
 } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiQuery } from "@nestjs/swagger";
 import { ShipmentService } from "./shipment.service";
 import { CreateShipmentDto } from "./dto/create-shipment.dto";
 import { UpdateShipmentDto } from "./dto/update-shipment.dto";
 import { UpdateShipmentStatusDto } from "./dto/update-shipment-status.dto";
-import { Shipment } from "./shipment.entity";
+import { Shipment, ShipmentStatus } from "./shipment.entity";
 import { ShipmentStatusHistory } from "./shipment-status-history.entity";
 
 @ApiTags("shipments")
@@ -33,8 +34,14 @@ export class ShipmentController {
 
   @Get()
   @ApiOperation({ summary: "Get all shipments" })
+  @ApiQuery({ name: "status", required: false, enum: ShipmentStatus, description: "Filter by status" })
   @ApiResponse({ status: 200, description: "List of all shipments", type: [Shipment] })
-  async findAll(): Promise<Shipment[]> {
+  async findAll(
+    @Query("status", new ParseEnumPipe(ShipmentStatus, { optional: true })) status?: ShipmentStatus,
+  ): Promise<Shipment[]> {
+    if (status) {
+      return this.shipmentService.findByStatus(status);
+    }
     return this.shipmentService.findAll();
   }
 

--- a/backend/src/shipment/shipment.entity.ts
+++ b/backend/src/shipment/shipment.entity.ts
@@ -8,6 +8,7 @@ import {
   OneToMany,
 } from 'typeorm';
 import { ShipmentStatusHistory } from './shipment-status-history.entity';
+import { TrackingEvent } from '../tracking/tracking-event.entity';
 
 export enum ShipmentStatus {
   PENDING = 'pending',
@@ -77,6 +78,10 @@ export class Shipment {
   @UpdateDateColumn({ type: 'timestamptz' })
   updatedAt: Date;
 
-  @OneToMany(() => ShipmentStatusHistory, (history) => history.shipment)
+  @OneToMany(() => ShipmentStatusHistory, (history: ShipmentStatusHistory) => history.shipment)
   statusHistory: ShipmentStatusHistory[];
+
+  // Tracking events relation (real-time/historical checkpoints)
+  @OneToMany(() => TrackingEvent, (trackingEvent: TrackingEvent) => trackingEvent.shipment, { cascade: false })
+  trackingEvents: TrackingEvent[];
 }

--- a/backend/src/shipment/shipment.service.ts
+++ b/backend/src/shipment/shipment.service.ts
@@ -54,6 +54,14 @@ export class ShipmentService {
     });
   }
 
+  async findByStatus(status: ShipmentStatus): Promise<Shipment[]> {
+    return this.shipmentRepo.find({
+      where: { status },
+      order: { createdAt: "DESC" },
+      relations: ["statusHistory"],
+    });
+  }
+
   async findOne(id: string): Promise<Shipment> {
     const shipment = await this.shipmentRepo.findOne({
       where: { id },

--- a/backend/src/tracking/dto/create-tracking-event.dto.ts
+++ b/backend/src/tracking/dto/create-tracking-event.dto.ts
@@ -1,0 +1,21 @@
+import { IsUUID, IsString, IsNotEmpty, Length } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateTrackingEventDto {
+  @ApiProperty({ description: 'Shipment ID to attach this tracking event to', format: 'uuid' })
+  @IsUUID()
+  @IsNotEmpty()
+  shipmentId: string;
+
+  @ApiProperty({ description: 'Checkpoint location', example: 'Los Angeles Hub' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 255)
+  location: string;
+
+  @ApiProperty({ description: 'Status update message', example: 'In transit' })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 255)
+  statusUpdate: string;
+}

--- a/backend/src/tracking/tracking-event.entity.ts
+++ b/backend/src/tracking/tracking-event.entity.ts
@@ -1,0 +1,38 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, ManyToOne, Index } from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { Shipment } from '../shipment/shipment.entity';
+
+@Entity({ name: 'tracking_events' })
+export class TrackingEvent {
+  @ApiProperty({
+    description: 'Tracking event unique identifier',
+    format: 'uuid',
+    example: 'a3f2a3a9-3f9f-4b42-9b87-9c8d0d5e2a1b',
+  })
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ApiProperty({
+    description: 'Associated shipment ID',
+    format: 'uuid',
+    example: '5f8d04a5-2a2a-4c51-9c1b-0a8b3d0c1234',
+  })
+  @Index()
+  @Column({ type: 'uuid' })
+  shipmentId: string;
+
+  @ManyToOne(() => Shipment, (shipment: Shipment) => shipment.trackingEvents, { onDelete: 'CASCADE' })
+  shipment: Shipment;
+
+  @ApiProperty({ description: 'Checkpoint location', example: 'Los Angeles Hub' })
+  @Column({ type: 'varchar', length: 255 })
+  location: string;
+
+  @ApiProperty({ description: 'Status update message', example: 'In transit' })
+  @Column({ type: 'varchar', length: 255 })
+  statusUpdate: string;
+
+  @ApiProperty({ description: 'Event timestamp (server-generated)', type: String, format: 'date-time' })
+  @CreateDateColumn({ type: 'timestamptz' })
+  timestamp: Date;
+}

--- a/backend/src/tracking/tracking.controller.ts
+++ b/backend/src/tracking/tracking.controller.ts
@@ -1,0 +1,26 @@
+import { Body, Controller, Get, Param, Post } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { TrackingService } from './tracking.service';
+import { CreateTrackingEventDto } from './dto/create-tracking-event.dto';
+import { TrackingEvent } from './tracking-event.entity';
+
+@ApiTags('tracking')
+@Controller()
+export class TrackingController {
+  constructor(private readonly trackingService: TrackingService) {}
+
+  @Post('tracking')
+  @ApiOperation({ summary: 'Create a tracking event for a shipment' })
+  @ApiResponse({ status: 201, description: 'Tracking event created', type: TrackingEvent })
+  async create(@Body() dto: CreateTrackingEventDto): Promise<TrackingEvent> {
+    return this.trackingService.create(dto);
+  }
+
+  @Get('shipments/:id/tracking')
+  @ApiOperation({ summary: 'Get tracking events for a shipment in chronological order' })
+  @ApiParam({ name: 'id', description: 'Shipment ID' })
+  @ApiResponse({ status: 200, description: 'List of tracking events', type: [TrackingEvent] })
+  async list(@Param('id') shipmentId: string): Promise<TrackingEvent[]> {
+    return this.trackingService.findByShipment(shipmentId);
+  }
+}

--- a/backend/src/tracking/tracking.module.ts
+++ b/backend/src/tracking/tracking.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TrackingEvent } from './tracking-event.entity';
+import { TrackingService } from './tracking.service';
+import { TrackingController } from './tracking.controller';
+import { Shipment } from '../shipment/shipment.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TrackingEvent, Shipment])],
+  controllers: [TrackingController],
+  providers: [TrackingService],
+  exports: [TrackingService],
+})
+export class TrackingModule {}

--- a/backend/src/tracking/tracking.service.ts
+++ b/backend/src/tracking/tracking.service.ts
@@ -1,0 +1,42 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TrackingEvent } from './tracking-event.entity';
+import { CreateTrackingEventDto } from './dto/create-tracking-event.dto';
+import { Shipment } from '../shipment/shipment.entity';
+
+@Injectable()
+export class TrackingService {
+  constructor(
+    @InjectRepository(TrackingEvent)
+    private readonly trackingRepo: Repository<TrackingEvent>,
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  async create(dto: CreateTrackingEventDto): Promise<TrackingEvent> {
+    const shipment = await this.shipmentRepo.findOne({ where: { id: dto.shipmentId } });
+    if (!shipment) {
+      throw new NotFoundException('Shipment not found');
+    }
+
+    const event = this.trackingRepo.create({
+      shipmentId: dto.shipmentId,
+      location: dto.location,
+      statusUpdate: dto.statusUpdate,
+    });
+    return this.trackingRepo.save(event);
+  }
+
+  async findByShipment(shipmentId: string): Promise<TrackingEvent[]> {
+    const shipment = await this.shipmentRepo.findOne({ where: { id: shipmentId } });
+    if (!shipment) {
+      throw new NotFoundException('Shipment not found');
+    }
+
+    return this.trackingRepo.find({
+      where: { shipmentId },
+      order: { timestamp: 'ASC' },
+    });
+  }
+}

--- a/backend/test/tracking.e2e-spec.ts
+++ b/backend/test/tracking.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { INestApplication } from "@nestjs/common";
+import * as request from "supertest";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { ShipmentModule } from "../src/shipment/shipment.module";
+import { TrackingModule } from "../src/tracking/tracking.module";
+import { Shipment } from "../src/shipment/shipment.entity";
+import { ShipmentStatusHistory } from "../src/shipment/shipment-status-history.entity";
+import { TrackingEvent } from "../src/tracking/tracking-event.entity";
+
+describe("Tracking (e2e)", () => {
+  let app: INestApplication;
+  let shipmentId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: "sqlite",
+          database: ":memory:",
+          dropSchema: true,
+          entities: [Shipment, ShipmentStatusHistory, TrackingEvent],
+          synchronize: true,
+        }),
+        ShipmentModule,
+        TrackingModule,
+      ],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it("should create a shipment to attach tracking events to", async () => {
+    const createShipmentDto = {
+      origin: "Austin, TX",
+      destination: "Denver, CO",
+      carrier: "ACME",
+    };
+
+    const res = await request(app.getHttpServer())
+      .post("/shipments")
+      .send(createShipmentDto)
+      .expect(201);
+
+    shipmentId = res.body.id;
+    expect(shipmentId).toBeDefined();
+  });
+
+  describe("/tracking (POST)", () => {
+    it("should fail for non-existent shipment", async () => {
+      await request(app.getHttpServer())
+        .post("/tracking")
+        .send({ shipmentId: "00000000-0000-0000-0000-000000000000", location: "X", statusUpdate: "Test" })
+        .expect(404);
+    });
+
+    it("should create first tracking event", async () => {
+      const dto = { shipmentId, location: "Austin Facility", statusUpdate: "Picked up" };
+      const res = await request(app.getHttpServer())
+        .post("/tracking")
+        .send(dto)
+        .expect(201);
+
+      expect(res.body).toHaveProperty("id");
+      expect(res.body.shipmentId).toBe(shipmentId);
+      expect(res.body.location).toBe(dto.location);
+      expect(res.body.statusUpdate).toBe(dto.statusUpdate);
+      expect(res.body).toHaveProperty("timestamp");
+    });
+
+    it("should create second tracking event", async () => {
+      const dto = { shipmentId, location: "Oklahoma Hub", statusUpdate: "In transit" };
+      await request(app.getHttpServer())
+        .post("/tracking")
+        .send(dto)
+        .expect(201);
+    });
+
+    it("should create third tracking event", async () => {
+      const dto = { shipmentId, location: "Denver Facility", statusUpdate: "Arrived at destination city" };
+      await request(app.getHttpServer())
+        .post("/tracking")
+        .send(dto)
+        .expect(201);
+    });
+  });
+
+  describe("/shipments/:id/tracking (GET)", () => {
+    it("should list tracking events in chronological order", async () => {
+      const res = await request(app.getHttpServer())
+        .get(`/shipments/${shipmentId}/tracking`)
+        .expect(200);
+
+      const events: any[] = res.body;
+      expect(Array.isArray(events)).toBe(true);
+      expect(events.length).toBeGreaterThanOrEqual(3);
+      // Verify ascending by timestamp
+      for (let i = 1; i < events.length; i++) {
+        const prev = new Date(events[i - 1].timestamp).getTime();
+        const curr = new Date(events[i].timestamp).getTime();
+        expect(curr).toBeGreaterThanOrEqual(prev);
+      }
+      // spot-check order ends
+      expect(events[0]).toHaveProperty("location");
+      expect(events[events.length - 1]).toHaveProperty("location");
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR introduces a **tracking module** to support real-time and historical updates for shipments. It allows tracking events such as location updates or status changes to be recorded and retrieved in chronological order for each shipment.

### Problem

There was no way to monitor the progress or historical journey of a shipment. Users need visibility into shipment movement via status updates and location checkpoints.

### Solution

* Created a new `tracking` module, including controller, service, and entity files.
* Defined a `TrackingEvent` entity with the following fields:

  * `id`, `shipmentId`, `location`, `statusUpdate`, `timestamp`
* Established a `ManyToOne` relationship between `TrackingEvent` and `Shipment`.
* Implemented the following endpoints:

  * `POST /tracking` – Add a new tracking event for a shipment
  * `GET /shipments/:id/tracking` – Retrieve all tracking events for a specific shipment, ordered chronologically
* Integrated with PostgreSQL using TypeORM for persistence.

---

# Related Issue

closes #453 

---

## Checklist

* [x] I have tested the changes locally
* [x] I have added/updated documentation as needed
* [x] I have reviewed the code and ensured it follows the project guidelines
* [x] I have added necessary tests (unit/integration)
* [x] My changes generate no new warnings/errors
* [x] I have checked for code formatting issues

---

## Screenshots/Recordings

N/A – Backend functionality; tested using Postman and automated test suite.

---

## Additional Notes

* `TrackingEvent` is linked to `Shipment` via `shipmentId`, enabling event grouping and lookup.
* Events are returned in chronological order using `timestamp ASC`.
* Designed for future scalability (e.g., GPS integration, geofencing alerts).
* Example usage:

  * `POST /tracking` with payload:

    ```json
    {
      "shipmentId": "123",
      "location": "New York, NY",
      "statusUpdate": "Arrived at facility",
      "timestamp": "2025-10-02T14:00:00Z"
    }
    ```
  * `GET /shipments/123/tracking` returns an ordered list of all events for shipment `123`.
closes #453 
