### PR TITLE
feat: [FE-09–12] Disputes, profile settings, CSV export, dark mode

### DIFF
--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -6,6 +6,7 @@ import { cn } from '../../lib/utils';
 import { useAuthStore } from '../../stores/auth.store';
 import { useShipmentSocket } from '../../hooks/useShipmentSocket';
 import { NotificationBell } from '../../components/notifications/notification-bell';
+import { ThemeToggle } from '../../components/ui/ThemeToggle';
 
 const SHIPPER_NAV = [
   { href: '/dashboard', label: 'Dashboard' },
@@ -51,6 +52,7 @@ export default function DashboardLayout({ children }: { children: React.ReactNod
             <span className="text-primary-foreground font-bold text-xs">FF</span>
           </div>
           <span className="font-bold text-foreground flex-1">FreightFlow</span>
+          <ThemeToggle />
           <NotificationBell />
         </div>
 

--- a/frontend/app/(dashboard)/settings/profile/page.tsx
+++ b/frontend/app/(dashboard)/settings/profile/page.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Button } from '../../../../components/ui/button';
+import { Input } from '../../../../components/ui/input';
+import { Label } from '../../../../components/ui/label';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '../../../../components/ui/card';
+import { useAuthStore } from '../../../../stores/auth.store';
+import { updateProfile, changePassword } from '../../../../lib/api/auth.api';
+import { apiClient } from '../../../../lib/api/client';
+
+// Stellar public key: starts with G, 56 chars, base32
+const STELLAR_RE = /^G[A-Z2-7]{55}$/;
+
+const profileSchema = z.object({
+  firstName: z.string().min(1, 'Required').max(50),
+  lastName: z.string().min(1, 'Required').max(50),
+});
+
+const walletSchema = z.object({
+  walletAddress: z
+    .string()
+    .min(1, 'Wallet address is required')
+    .regex(STELLAR_RE, 'Invalid Stellar address (must start with G and be 56 characters)'),
+});
+
+const passwordSchema = z
+  .object({
+    currentPassword: z.string().min(1, 'Required'),
+    newPassword: z.string().min(8, 'Min 8 characters'),
+    confirmPassword: z.string(),
+  })
+  .refine((d) => d.newPassword === d.confirmPassword, {
+    message: 'Passwords do not match',
+    path: ['confirmPassword'],
+  });
+
+type ProfileData = z.infer<typeof profileSchema>;
+type WalletData = z.infer<typeof walletSchema>;
+type PasswordData = z.infer<typeof passwordSchema>;
+
+export default function ProfileSettingsPage() {
+  const { user, setUser, fetchCurrentUser, logout } = useAuthStore();
+
+  const profileForm = useForm<ProfileData>({ resolver: zodResolver(profileSchema) });
+  const walletForm = useForm<WalletData>({ resolver: zodResolver(walletSchema) });
+  const passwordForm = useForm<PasswordData>({ resolver: zodResolver(passwordSchema) });
+
+  useEffect(() => {
+    if (!user) fetchCurrentUser();
+  }, [user, fetchCurrentUser]);
+
+  useEffect(() => {
+    if (user) {
+      profileForm.reset({ firstName: user.firstName, lastName: user.lastName });
+      walletForm.reset({ walletAddress: user.walletAddress ?? '' });
+    }
+  }, [user]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const saveProfile = async (data: ProfileData) => {
+    try {
+      const updated = await updateProfile(data);
+      setUser(updated);
+      profileForm.reset({ firstName: updated.firstName, lastName: updated.lastName });
+      toast.success('Personal info updated.');
+    } catch (err: unknown) {
+      toast.error((err as { message?: string })?.message ?? 'Failed to update profile.');
+    }
+  };
+
+  const saveWallet = async (data: WalletData) => {
+    try {
+      const updated = await apiClient<typeof user>('/auth/profile', {
+        method: 'PATCH',
+        body: JSON.stringify({ walletAddress: data.walletAddress }),
+      });
+      setUser(updated!);
+      toast.success('Wallet address linked.');
+    } catch (err: unknown) {
+      toast.error((err as { message?: string })?.message ?? 'Failed to link wallet.');
+    }
+  };
+
+  const savePassword = async (data: PasswordData) => {
+    try {
+      await changePassword(data.currentPassword, data.newPassword);
+      toast.success('Password changed. Signing you out…');
+      passwordForm.reset();
+      setTimeout(() => logout(), 1500);
+    } catch (err: unknown) {
+      toast.error((err as { message?: string })?.message ?? 'Failed to change password.');
+    }
+  };
+
+  if (!user) {
+    return <div className="p-8 text-muted-foreground">Loading…</div>;
+  }
+
+  return (
+    <div className="p-8 max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Profile Settings</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Manage your personal info, wallet, and security
+        </p>
+      </div>
+
+      {/* Personal Info */}
+      <form onSubmit={profileForm.handleSubmit(saveProfile)}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Personal Info</CardTitle>
+            <CardDescription>Update your display name.</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="firstName">First name</Label>
+              <Input id="firstName" {...profileForm.register('firstName')} />
+              {profileForm.formState.errors.firstName && (
+                <p className="text-sm text-destructive">
+                  {profileForm.formState.errors.firstName.message}
+                </p>
+              )}
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="lastName">Last name</Label>
+              <Input id="lastName" {...profileForm.register('lastName')} />
+              {profileForm.formState.errors.lastName && (
+                <p className="text-sm text-destructive">
+                  {profileForm.formState.errors.lastName.message}
+                </p>
+              )}
+            </div>
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              disabled={profileForm.formState.isSubmitting || !profileForm.formState.isDirty}
+            >
+              {profileForm.formState.isSubmitting ? 'Saving…' : 'Save'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+
+      {/* Wallet */}
+      <form onSubmit={walletForm.handleSubmit(saveWallet)}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Stellar Wallet</CardTitle>
+            <CardDescription>
+              Link your Stellar wallet address for on-chain interactions.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Label htmlFor="walletAddress">Wallet address</Label>
+            <Input
+              id="walletAddress"
+              placeholder="G…"
+              autoComplete="off"
+              {...walletForm.register('walletAddress')}
+            />
+            {walletForm.formState.errors.walletAddress && (
+              <p className="text-sm text-destructive">
+                {walletForm.formState.errors.walletAddress.message}
+              </p>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              disabled={walletForm.formState.isSubmitting || !walletForm.formState.isDirty}
+            >
+              {walletForm.formState.isSubmitting ? 'Linking…' : 'Link Wallet'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+
+      {/* Security */}
+      <form onSubmit={passwordForm.handleSubmit(savePassword)}>
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Security</CardTitle>
+            <CardDescription>
+              Change your password. You will be signed out of all devices.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {(['currentPassword', 'newPassword', 'confirmPassword'] as const).map((field) => (
+              <div key={field} className="space-y-2">
+                <Label htmlFor={field}>
+                  {field === 'currentPassword'
+                    ? 'Current password'
+                    : field === 'newPassword'
+                      ? 'New password'
+                      : 'Confirm new password'}
+                </Label>
+                <Input
+                  id={field}
+                  type="password"
+                  placeholder="••••••••"
+                  autoComplete={field === 'currentPassword' ? 'current-password' : 'new-password'}
+                  {...passwordForm.register(field)}
+                />
+                {passwordForm.formState.errors[field] && (
+                  <p className="text-sm text-destructive">
+                    {passwordForm.formState.errors[field]?.message}
+                  </p>
+                )}
+              </div>
+            ))}
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              variant="destructive"
+              disabled={passwordForm.formState.isSubmitting}
+            >
+              {passwordForm.formState.isSubmitting ? 'Updating…' : 'Change Password'}
+            </Button>
+          </CardFooter>
+        </Card>
+      </form>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/shipments/[id]/dispute/page.tsx
+++ b/frontend/app/(dashboard)/shipments/[id]/dispute/page.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { apiClient } from '../../../../../lib/api/client';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../../../components/ui/card';
+import { Button } from '../../../../../components/ui/button';
+
+interface Dispute {
+  id: string;
+  shipmentId: string;
+  reason: string;
+  status: 'open' | 'resolved' | 'closed';
+  evidenceUrls?: string[];
+  resolutionNotes?: string;
+  createdAt: string;
+  resolvedAt?: string;
+}
+
+export default function DisputeDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [dispute, setDispute] = useState<Dispute | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    apiClient<Dispute>(`/shipments/${id}/dispute`)
+      .then(setDispute)
+      .catch(() => toast.error('Failed to load dispute details.'))
+      .finally(() => setLoading(false));
+  }, [id]);
+
+  if (loading) {
+    return (
+      <div className="p-6 max-w-2xl mx-auto space-y-4">
+        <div className="h-8 w-48 bg-muted rounded animate-pulse" />
+        <div className="h-48 bg-muted rounded animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!dispute) {
+    return (
+      <div className="p-6 text-center">
+        <p className="text-muted-foreground">No dispute found for this shipment.</p>
+        <Button variant="outline" className="mt-4" onClick={() => router.back()}>
+          Go back
+        </Button>
+      </div>
+    );
+  }
+
+  const statusColor =
+    dispute.status === 'resolved'
+      ? 'text-green-600'
+      : dispute.status === 'closed'
+        ? 'text-muted-foreground'
+        : 'text-yellow-600';
+
+  return (
+    <div className="p-6 max-w-2xl mx-auto space-y-6">
+      <div>
+        <button
+          onClick={() => router.back()}
+          className="text-xs text-muted-foreground hover:text-foreground mb-2 block"
+        >
+          ← Back
+        </button>
+        <h1 className="text-xl font-bold text-foreground">Dispute Details</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">Shipment #{id}</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center justify-between">
+            <span>Dispute Reason</span>
+            <span className={`text-sm font-medium capitalize ${statusColor}`}>
+              {dispute.status}
+            </span>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-sm text-foreground whitespace-pre-wrap">{dispute.reason}</p>
+          <p className="text-xs text-muted-foreground">
+            Filed on {new Date(dispute.createdAt).toLocaleString()}
+          </p>
+        </CardContent>
+      </Card>
+
+      {dispute.evidenceUrls && dispute.evidenceUrls.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Submitted Evidence</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {dispute.evidenceUrls.map((url, i) => (
+              <a
+                key={i}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block text-sm text-primary underline underline-offset-4 hover:text-primary/80"
+              >
+                Evidence file {i + 1}
+              </a>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {dispute.status === 'resolved' && dispute.resolutionNotes && (
+        <Card className="border-green-500/30">
+          <CardHeader>
+            <CardTitle className="text-base text-green-600">Admin Resolution</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p className="text-sm text-foreground whitespace-pre-wrap">
+              {dispute.resolutionNotes}
+            </p>
+            {dispute.resolvedAt && (
+              <p className="text-xs text-muted-foreground">
+                Resolved on {new Date(dispute.resolvedAt).toLocaleString()}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/shipments/page.tsx
+++ b/frontend/app/(dashboard)/shipments/page.tsx
@@ -8,6 +8,7 @@ import { ShipmentStatus, PaginatedShipments } from '../../../types/shipment.type
 import { ShipmentCard } from '../../../components/shipment/shipment-card';
 import { Button } from '../../../components/ui/button';
 import { toast } from 'sonner';
+import { apiClient } from '../../../lib/api/client';
 
 const STATUS_TABS: { label: string; value: ShipmentStatus | 'all' }[] = [
   { label: 'All', value: 'all' },
@@ -23,6 +24,26 @@ export default function ShipmentsPage() {
   const [result, setResult] = useState<PaginatedShipments | null>(null);
   const [activeTab, setActiveTab] = useState<ShipmentStatus | 'all'>('all');
   const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+
+  const exportCsv = async () => {
+    setExporting(true);
+    try {
+      const blob = await apiClient<Blob>('/shipments/export?format=csv', {
+        headers: { Accept: 'text/csv' },
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'shipments.csv';
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error('Failed to export CSV. Please try again.');
+    } finally {
+      setExporting(false);
+    }
+  };
 
   useEffect(() => {
     setLoading(true);
@@ -41,11 +62,32 @@ export default function ShipmentsPage() {
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold text-foreground">{pageTitle}</h1>
-        {isShipper && (
-          <Button asChild>
-            <Link href="/shipments/new">+ New Shipment</Link>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={exportCsv}
+            disabled={exporting}
+            aria-label="Export shipments as CSV"
+          >
+            {exporting ? (
+              <>
+                <svg className="animate-spin h-3.5 w-3.5 mr-1.5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                </svg>
+                Exporting…
+              </>
+            ) : (
+              'Export CSV'
+            )}
           </Button>
-        )}
+          {isShipper && (
+            <Button asChild>
+              <Link href="/shipments/new">+ New Shipment</Link>
+            </Button>
+          )}
+        </div>
       </div>
 
       {/* Tabs */}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -26,6 +26,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
+      <head>
+        {/* Inline script to apply theme before first paint — prevents flash */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){var s=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='dark'||(s===null&&d)){document.documentElement.classList.add('dark');}})();`,
+          }}
+        />
+      </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/frontend/components/disputes/DisputeForm.tsx
+++ b/frontend/components/disputes/DisputeForm.tsx
@@ -1,0 +1,118 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { Button } from '../ui/button';
+import { Label } from '../ui/label';
+import { apiClient } from '../../lib/api/client';
+
+const schema = z.object({
+  reason: z.string().min(10, 'Please describe the issue (min 10 characters)'),
+});
+type FormData = z.infer<typeof schema>;
+
+interface Props {
+  shipmentId: string;
+  onSuccess?: () => void;
+  onClose?: () => void;
+}
+
+export function DisputeForm({ shipmentId, onSuccess, onClose }: Props) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormData) => {
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('reason', data.reason);
+      const files = fileRef.current?.files;
+      if (files) {
+        Array.from(files).forEach((f) => formData.append('evidence', f));
+      }
+
+      await apiClient(`/shipments/${shipmentId}/dispute`, {
+        method: 'POST',
+        body: formData,
+        // Let browser set Content-Type with boundary for multipart
+        headers: {},
+      });
+
+      toast.success('Dispute filed successfully.');
+      onSuccess?.();
+    } catch (err: unknown) {
+      const error = err as { message?: string };
+      toast.error(error?.message ?? 'Failed to file dispute.');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="bg-card rounded-lg shadow-lg w-full max-w-md p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-foreground">File a Dispute</h2>
+          {onClose && (
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="text-muted-foreground hover:text-foreground transition-colors"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="reason">Reason</Label>
+            <textarea
+              id="reason"
+              rows={4}
+              placeholder="Describe the issue in detail…"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+              {...register('reason')}
+            />
+            {errors.reason && (
+              <p className="text-sm text-destructive">{errors.reason.message}</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="evidence">Evidence (optional)</Label>
+            <input
+              id="evidence"
+              type="file"
+              multiple
+              accept="image/*,.pdf,.doc,.docx"
+              ref={fileRef}
+              aria-label="Upload evidence files"
+              className="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-xs file:font-medium file:text-primary-foreground hover:file:bg-primary/90 cursor-pointer"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            {onClose && (
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+            )}
+            <Button type="submit" variant="destructive" disabled={isSubmitting || uploading}>
+              {isSubmitting || uploading ? 'Submitting…' : 'Submit Dispute'}
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ui/ThemeToggle.tsx
+++ b/frontend/components/ui/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  // Apply theme before first paint to avoid flash
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = stored ? stored === 'dark' : prefersDark;
+    setDark(isDark);
+    document.documentElement.classList.toggle('dark', isDark);
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle('dark', next);
+    localStorage.setItem('theme', next ? 'dark' : 'light');
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+      className="h-8 w-8 rounded-md flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+    >
+      {dark ? (
+        // Sun icon
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        // Moon icon
+        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+        </svg>
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Implements all four frontend issues assigned to NteinPrecious.

### FE-09 — Dispute filing form and detail page (closes #715)
- `components/disputes/DisputeForm.tsx`: modal with reason textarea + multi-file evidence upload, validated with zod, sonner toasts on success/error
- `app/(dashboard)/shipments/[id]/dispute/page.tsx`: shows dispute reason, submitted evidence links, and admin resolution notes when resolved

### FE-10 — Profile settings page with wallet address linking (closes #716)
- `app/(dashboard)/settings/profile/page.tsx`: three independently-saving sections
  - Personal Info (name)
  - Stellar Wallet (validates G… 56-char base32 format before submit)
  - Security (change password, signs out all devices on success)

### FE-11 — CSV export for shipment history (closes #717)
- Added **Export CSV** button to `app/(dashboard)/shipments/page.tsx`
- Calls `GET /api/v1/shipments/export?format=csv`, triggers browser file download
- Shows loading spinner while in progress; error toast on failure
- Button is keyboard-focusable with ARIA label

### FE-12 — Dark mode toggle with localStorage persistence (closes #718)
- `components/ui/ThemeToggle.tsx`: toggles `.dark` class on `<html>`, persists preference to `localStorage`, defaults to OS `prefers-color-scheme`
- Inline script in `app/layout.tsx` applies theme before first paint to prevent flash
- ThemeToggle placed in sidebar header in `app/(dashboard)/layout.tsx`

## Testing
- All existing dashboard components use CSS variables already defined for both light/dark in `globals.css` — no visual regressions expected
- Each form section saves independently via separate API calls
- CSV export triggers native browser download dialog