### PR TITLE
feat(fe): FE-21/22/23/24 — password strength, data table, toast system, infinite scroll

### DIFF
--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '../../../components/ui/card';
 import { useAuthStore } from '../../../stores/auth.store';
 import { cn } from '../../../lib/utils';
+import PasswordStrengthBar from '../../../components/auth/PasswordStrengthBar';
 
 const registerSchema = z.object({
   firstName: z.string().min(1, 'First name is required'),
@@ -139,6 +140,7 @@ export default function RegisterPage() {
               autoComplete="new-password"
               {...register('password')}
             />
+            <PasswordStrengthBar password={watch('password') ?? ''} />
             {errors.password && (
               <p className="text-sm text-destructive">{errors.password.message}</p>
             )}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 import { QueryProvider } from "../providers/query-provider";
+import ToastContainer from "../components/ui/ToastContainer";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,6 +33,7 @@ export default function RootLayout({
         <QueryProvider>
           {children}
           <Toaster position="top-right" richColors />
+          <ToastContainer />
         </QueryProvider>
       </body>
     </html>

--- a/frontend/components/auth/PasswordStrengthBar.tsx
+++ b/frontend/components/auth/PasswordStrengthBar.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { cn } from '../../lib/utils';
+
+interface PasswordStrengthBarProps {
+  password: string;
+}
+
+interface StrengthResult {
+  score: number; // 0-4
+  label: 'Weak' | 'Fair' | 'Strong' | 'Very Strong';
+  color: string;
+}
+
+function getStrength(password: string): StrengthResult {
+  if (!password) return { score: 0, label: 'Weak', color: 'bg-red-500' };
+
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (/[A-Z]/.test(password)) score++;
+  if (/[a-z]/.test(password)) score++;
+  if (/[0-9]/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+
+  if (score <= 2) return { score, label: 'Weak', color: 'bg-red-500' };
+  if (score === 3) return { score, label: 'Fair', color: 'bg-orange-400' };
+  if (score === 4) return { score, label: 'Strong', color: 'bg-green-500' };
+  return { score, label: 'Very Strong', color: 'bg-green-600' };
+}
+
+export default function PasswordStrengthBar({ password }: PasswordStrengthBarProps) {
+  const { score, label, color } = getStrength(password);
+  const segments = 4;
+  const filled = Math.min(Math.ceil((score / 5) * segments), segments);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex gap-1">
+        {Array.from({ length: segments }).map((_, i) => (
+          <div
+            key={i}
+            className={cn(
+              'h-1.5 flex-1 rounded-full transition-colors duration-300',
+              i < filled ? color : 'bg-muted',
+            )}
+          />
+        ))}
+      </div>
+      {password && (
+        <p className={cn('text-xs font-medium', {
+          'text-red-500': label === 'Weak',
+          'text-orange-400': label === 'Fair',
+          'text-green-500': label === 'Strong',
+          'text-green-600': label === 'Very Strong',
+        })}>
+          {label}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/shipment/ShipmentsInfiniteList.tsx
+++ b/frontend/components/shipment/ShipmentsInfiniteList.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { Loader2 } from 'lucide-react';
+import { shipmentApi } from '../../lib/api/shipment.api';
+import { ShipmentCard } from './shipment-card';
+import type { QueryShipmentParams } from '../../types/shipment.types';
+
+const PAGE_LIMIT = 10;
+
+interface ShipmentsInfiniteListProps {
+  filters?: Omit<QueryShipmentParams, 'page' | 'limit'>;
+}
+
+export default function ShipmentsInfiniteList({ filters = {} }: ShipmentsInfiniteListProps) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+    isError,
+  } = useInfiniteQuery({
+    queryKey: ['shipments', 'infinite', filters],
+    queryFn: ({ pageParam = 1 }) =>
+      shipmentApi.list({ ...filters, page: pageParam as number, limit: PAGE_LIMIT }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage) => {
+      const fetched = lastPage.page * lastPage.limit;
+      return fetched < lastPage.total ? lastPage.page + 1 : undefined;
+    },
+    staleTime: 30_000,
+  });
+
+  // Intersection Observer to trigger next page
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { rootMargin: '200px' },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  const shipments = data?.pages.flatMap((p) => p.data) ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="py-8 text-center text-sm text-destructive">
+        Failed to load shipments. Please try again.
+      </p>
+    );
+  }
+
+  if (shipments.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">No shipments found.</p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {shipments.map((shipment) => (
+        <ShipmentCard key={shipment.id} shipment={shipment} />
+      ))}
+
+      {/* Sentinel element for IntersectionObserver */}
+      <div ref={sentinelRef} />
+
+      {isFetchingNextPage && (
+        <div className="flex justify-center py-4">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!hasNextPage && shipments.length > 0 && (
+        <p className="py-4 text-center text-sm text-muted-foreground">
+          You&apos;ve reached the end.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/ui/ToastContainer.tsx
+++ b/frontend/components/ui/ToastContainer.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { CheckCircle, XCircle, AlertTriangle, Info, X } from 'lucide-react';
+import { useToastStore, type Toast, type ToastType } from '../../stores/toast.store';
+import { cn } from '../../lib/utils';
+
+const TOAST_STYLES: Record<ToastType, { bg: string; text: string; Icon: React.ElementType }> = {
+  success: { bg: 'bg-green-50 border-green-200', text: 'text-green-800', Icon: CheckCircle },
+  error:   { bg: 'bg-red-50 border-red-200',     text: 'text-red-800',   Icon: XCircle },
+  warning: { bg: 'bg-orange-50 border-orange-200', text: 'text-orange-800', Icon: AlertTriangle },
+  info:    { bg: 'bg-blue-50 border-blue-200',   text: 'text-blue-800',  Icon: Info },
+};
+
+function ToastItem({ toast }: { toast: Toast }) {
+  const dismiss = useToastStore((s) => s.dismiss);
+  const { bg, text, Icon } = TOAST_STYLES[toast.type];
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex items-start gap-3 rounded-lg border px-4 py-3 shadow-md text-sm w-80 animate-in slide-in-from-right-4',
+        bg,
+        text,
+      )}
+    >
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" />
+      <span className="flex-1">{toast.message}</span>
+      <button
+        onClick={() => dismiss(toast.id)}
+        aria-label="Dismiss"
+        className="shrink-0 opacity-60 hover:opacity-100 transition-opacity"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}
+
+export default function ToastContainer() {
+  const toasts = useToastStore((s) => s.toasts);
+
+  return (
+    <div
+      aria-live="polite"
+      className="fixed top-4 right-4 z-50 flex flex-col gap-2"
+    >
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}

--- a/frontend/components/ui/data-table.tsx
+++ b/frontend/components/ui/data-table.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getPaginationRowModel,
+  flexRender,
+  type ColumnDef,
+  type SortingState,
+} from '@tanstack/react-table';
+import { ChevronUp, ChevronDown, ChevronsUpDown } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export interface DataTableColumn<T> {
+  header: string;
+  accessorKey: keyof T & string;
+  render?: (value: T[keyof T], row: T) => React.ReactNode;
+}
+
+interface DataTableProps<T extends object> {
+  columns: DataTableColumn<T>[];
+  data: T[];
+  loading?: boolean;
+  pageSizeOptions?: number[];
+}
+
+const PAGE_SIZE_OPTIONS = [10, 20, 50];
+
+export default function DataTable<T extends object>({
+  columns,
+  data,
+  loading = false,
+  pageSizeOptions = PAGE_SIZE_OPTIONS,
+}: DataTableProps<T>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [pageSize, setPageSize] = useState(pageSizeOptions[0]);
+
+  const tableColumns: ColumnDef<T>[] = columns.map((col) => ({
+    id: col.accessorKey,
+    accessorKey: col.accessorKey,
+    header: col.header,
+    cell: col.render
+      ? ({ row }) => col.render!(row.getValue(col.accessorKey), row.original)
+      : undefined,
+  }));
+
+  const table = useReactTable({
+    data,
+    columns: tableColumns,
+    state: { sorting, pagination: { pageIndex: 0, pageSize } },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    manualPagination: false,
+  });
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50">
+            {table.getHeaderGroups().map((hg) => (
+              <tr key={hg.id}>
+                {hg.headers.map((header) => (
+                  <th
+                    key={header.id}
+                    onClick={header.column.getToggleSortingHandler()}
+                    className={cn(
+                      'px-4 py-3 text-left font-medium text-muted-foreground select-none',
+                      header.column.getCanSort() && 'cursor-pointer hover:text-foreground',
+                    )}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {flexRender(header.column.columnDef.header, header.getContext())}
+                      {header.column.getCanSort() && (
+                        <span className="text-muted-foreground/50">
+                          {header.column.getIsSorted() === 'asc' ? (
+                            <ChevronUp className="h-3.5 w-3.5" />
+                          ) : header.column.getIsSorted() === 'desc' ? (
+                            <ChevronDown className="h-3.5 w-3.5" />
+                          ) : (
+                            <ChevronsUpDown className="h-3.5 w-3.5" />
+                          )}
+                        </span>
+                      )}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {loading
+              ? Array.from({ length: pageSize }).map((_, i) => (
+                  <tr key={i} className="border-t border-border">
+                    {columns.map((col) => (
+                      <td key={col.accessorKey} className="px-4 py-3">
+                        <div className="h-4 w-full animate-pulse rounded bg-muted" />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : table.getRowModel().rows.map((row) => (
+                  <tr key={row.id} className="border-t border-border hover:bg-muted/30 transition-colors">
+                    {row.getVisibleCells().map((cell) => (
+                      <td key={cell.id} className="px-4 py-3 text-foreground">
+                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+            {!loading && table.getRowModel().rows.length === 0 && (
+              <tr>
+                <td colSpan={columns.length} className="px-4 py-8 text-center text-muted-foreground">
+                  No data available.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <span>Rows per page:</span>
+          <select
+            value={pageSize}
+            onChange={(e) => {
+              setPageSize(Number(e.target.value));
+              table.setPageSize(Number(e.target.value));
+            }}
+            className="rounded border border-border bg-background px-2 py-1 text-foreground"
+          >
+            {pageSizeOptions.map((size) => (
+              <option key={size} value={size}>{size}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <span>
+            Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+          </span>
+          <button
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+            className="rounded border border-border px-2 py-1 disabled:opacity-40 hover:bg-muted transition-colors"
+          >
+            Prev
+          </button>
+          <button
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+            className="rounded border border-border px-2 py-1 disabled:opacity-40 hover:bg-muted transition-colors"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/stores/toast.store.ts
+++ b/frontend/stores/toast.store.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { create } from 'zustand';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: string;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastState {
+  toasts: Toast[];
+  add: (type: ToastType, message: string) => void;
+  dismiss: (id: string) => void;
+}
+
+const MAX_TOASTS = 3;
+const AUTO_DISMISS_MS = 4000;
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  toasts: [],
+
+  add: (type, message) => {
+    const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    set((state) => {
+      const toasts = [{ id, type, message }, ...state.toasts].slice(0, MAX_TOASTS);
+      return { toasts };
+    });
+
+    setTimeout(() => {
+      if (get().toasts.some((t) => t.id === id)) {
+        get().dismiss(id);
+      }
+    }, AUTO_DISMISS_MS);
+  },
+
+  dismiss: (id) =>
+    set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
+}));


### PR DESCRIPTION
## Summary

Resolves all four issues assigned to @Tyler7x.

Closes #727
Closes #728
Closes #729
Closes #730

---

## Changes

### FE-21 — Password strength indicator (#727)
- New `PasswordStrengthBar` component at `frontend/components/auth/PasswordStrengthBar.tsx`
- Evaluates: length ≥ 8, uppercase, lowercase, digit, special character (5 criteria)
- Colour-coded segmented bar: red (Weak), orange (Fair), green (Strong / Very Strong)
- Text label shown beneath the bar
- Purely presentational — accepts a `password: string` prop
- Integrated into the register page below the password field

### FE-22 — Reusable DataTable (#728)
- New `DataTable` component at `frontend/components/ui/data-table.tsx`
- Built on `@tanstack/react-table` v8 (already in project)
- Accepts `columns` config (header, accessorKey, optional render fn) and `data` array
- Client-side sorting via column header clicks with asc/desc/unsorted toggle icons
- Pagination controls: prev/next buttons + page-size selector (10/20/50)
- `loading` prop renders animated skeleton rows

### FE-23 — Zustand toast system (#729)
- New `useToastStore` at `frontend/stores/toast.store.ts`
- Types: `success` | `error` | `warning` | `info` — each with distinct colour and icon
- Auto-dismiss after 4 s; manual dismiss via ✕ button
- Max 3 toasts visible; oldest is dropped when a 4th arrives
- New `ToastContainer` component at `frontend/components/ui/ToastContainer.tsx` — fixed top-right, mounted in root layout

### FE-24 — Infinite scroll shipments list (#730)
- New `ShipmentsInfiniteList` component at `frontend/components/shipment/ShipmentsInfiniteList.tsx`
- Uses `useInfiniteQuery` (TanStack Query v5) with `initialPageParam` / `getNextPageParam`
- IntersectionObserver sentinel element triggers next-page fetch 200 px before bottom
- Spinner shown while fetching next page
- "You've reached the end." message when all pages are loaded
- Scroll position preserved by React Query's cache (`staleTime: 30 s`)

## Testing
- `tsc --noEmit` passes with zero errors
- All components follow existing project conventions (Tailwind, `cn()`, `lucide-react`, `'use client'`)