### PR TITLE
feat: FE-19/20/27/28 – document viewer, empty states, notification prefs, admin stats

### DIFF
--- a/frontend/app/(dashboard)/admin/stats/page.tsx
+++ b/frontend/app/(dashboard)/admin/stats/page.tsx
@@ -1,0 +1,185 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts';
+import { useAuthStore } from '../../../../stores/auth.store';
+import { adminApi, PlatformStats } from '../../../../lib/api/admin.api';
+import { apiClient } from '../../../../lib/api/client';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../../components/ui/card';
+
+interface DailyCount {
+  date: string;
+  count: number;
+}
+
+interface TopUser {
+  id: string;
+  name: string;
+  role: 'carrier' | 'shipper';
+  shipmentCount: number;
+}
+
+interface AnalyticsData {
+  dailyShipments: DailyCount[];
+  topCarriers: TopUser[];
+  topShippers: TopUser[];
+}
+
+function StatCard({ title, value, highlight = false }: { title: string; value: string | number; highlight?: boolean }) {
+  return (
+    <Card className={highlight ? 'border-destructive/50' : undefined}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className={`text-3xl font-bold ${highlight ? 'text-destructive' : 'text-foreground'}`}>
+          {value}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function AdminStatsPage() {
+  const router = useRouter();
+  const { user } = useAuthStore();
+  const [stats, setStats] = useState<PlatformStats | null>(null);
+  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (user && user.role !== 'admin') {
+      router.replace('/dashboard');
+    }
+  }, [user, router]);
+
+  useEffect(() => {
+    if (!user || user.role !== 'admin') return;
+
+    Promise.all([
+      adminApi.getStats(),
+      apiClient<AnalyticsData>('/shipments/analytics').catch(() => null),
+    ])
+      .then(([s, a]) => {
+        setStats(s);
+        setAnalytics(a);
+      })
+      .catch(() => toast.error('Failed to load statistics'))
+      .finally(() => setLoading(false));
+  }, [user]);
+
+  if (!user || user.role !== 'admin') return null;
+
+  const topUsers: TopUser[] = [
+    ...(analytics?.topCarriers ?? []),
+    ...(analytics?.topShippers ?? []),
+  ]
+    .sort((a, b) => b.shipmentCount - a.shipmentCount)
+    .slice(0, 5);
+
+  return (
+    <div className="p-8 space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Platform Statistics</h1>
+        <p className="text-muted-foreground text-sm mt-1">High-level overview of platform health</p>
+      </div>
+
+      {loading ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-28 rounded-lg bg-muted animate-pulse" />
+          ))}
+        </div>
+      ) : stats ? (
+        <>
+          {/* Stat cards */}
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <StatCard title="Total Users" value={stats.users.total} />
+            <StatCard title="Active Shipments" value={stats.shipments.byStatus.in_transit ?? 0} />
+            <StatCard
+              title="Monthly Revenue"
+              value={`$${stats.revenue.totalCompleted.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+            />
+            <StatCard
+              title="Open Disputes"
+              value={stats.shipments.disputesPending}
+              highlight={stats.shipments.disputesPending > 0}
+            />
+          </div>
+
+          {/* Daily shipments chart */}
+          {analytics?.dailyShipments && analytics.dailyShipments.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Daily Shipment Creations (Last 30 Days)</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ResponsiveContainer width="100%" height={240}>
+                  <LineChart data={analytics.dailyShipments} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fontSize: 11 }}
+                      tickFormatter={(v: string) => v.slice(5)}
+                    />
+                    <YAxis tick={{ fontSize: 11 }} allowDecimals={false} />
+                    <Tooltip
+                      contentStyle={{ fontSize: 12 }}
+                      formatter={(v: number) => [v, 'Shipments']}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="count"
+                      strokeWidth={2}
+                      dot={false}
+                      className="stroke-primary"
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Top carriers & shippers table */}
+          {topUsers.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Top 5 Most Active Carriers & Shippers</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-muted-foreground text-left">
+                      <th className="pb-2 font-medium">Name</th>
+                      <th className="pb-2 font-medium">Role</th>
+                      <th className="pb-2 font-medium text-right">Shipments</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {topUsers.map((u) => (
+                      <tr key={u.id} className="border-b last:border-0">
+                        <td className="py-2">{u.name}</td>
+                        <td className="py-2 capitalize text-muted-foreground">{u.role}</td>
+                        <td className="py-2 text-right font-medium">{u.shipmentCount}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </CardContent>
+            </Card>
+          )}
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/settings/notifications/page.tsx
+++ b/frontend/app/(dashboard)/settings/notifications/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../../../../components/ui/card';
+import { notificationsApi, NotificationPreference } from '../../../../lib/api/notifications.api';
+
+const FALLBACK_PREFERENCES: NotificationPreference[] = [
+  { type: 'shipment_created', label: 'Shipment Created', description: 'When a new shipment is created.', enabled: true },
+  { type: 'shipment_accepted', label: 'Shipment Accepted', description: 'When a carrier accepts your shipment.', enabled: true },
+  { type: 'shipment_in_transit', label: 'Shipment In Transit', description: 'When your shipment is picked up and in transit.', enabled: true },
+  { type: 'shipment_delivered', label: 'Shipment Delivered', description: 'When your shipment is delivered.', enabled: true },
+  { type: 'shipment_disputed', label: 'Dispute Opened', description: 'When a dispute is raised on a shipment.', enabled: true },
+  { type: 'shipment_dispute_resolved', label: 'Dispute Resolved', description: 'When a dispute is resolved.', enabled: true },
+  { type: 'shipment_cancelled', label: 'Shipment Cancelled', description: 'When a shipment is cancelled.', enabled: false },
+  { type: 'document_uploaded', label: 'Document Uploaded', description: 'When a document is added to your shipment.', enabled: false },
+];
+
+export default function NotificationPreferencesPage() {
+  const [prefs, setPrefs] = useState<NotificationPreference[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    notificationsApi
+      .getPreferences()
+      .then(setPrefs)
+      .catch(() => setPrefs(FALLBACK_PREFERENCES))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleToggle = useCallback(
+    async (type: string, enabled: boolean) => {
+      setPrefs((prev) =>
+        prev.map((p) => (p.type === type ? { ...p, enabled } : p)),
+      );
+      setSaving(type);
+      try {
+        await notificationsApi.updatePreferences({ [type]: enabled });
+        toast.success('Preference saved');
+      } catch {
+        // revert
+        setPrefs((prev) =>
+          prev.map((p) => (p.type === type ? { ...p, enabled: !enabled } : p)),
+        );
+        toast.error('Failed to save preference');
+      } finally {
+        setSaving(null);
+      }
+    },
+    [],
+  );
+
+  return (
+    <div className="p-8 max-w-2xl space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold text-foreground">Notification Preferences</h1>
+        <p className="text-muted-foreground text-sm mt-1">
+          Choose which email notifications you receive.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Email notifications</CardTitle>
+          <CardDescription>Toggle each notification type on or off.</CardDescription>
+        </CardHeader>
+        <CardContent className="divide-y">
+          {loading
+            ? Array.from({ length: 5 }).map((_, i) => (
+                <div key={i} className="flex items-center justify-between py-4">
+                  <div className="space-y-1.5">
+                    <div className="h-4 w-40 rounded bg-muted animate-pulse" />
+                    <div className="h-3 w-64 rounded bg-muted animate-pulse" />
+                  </div>
+                  <div className="h-6 w-10 rounded-full bg-muted animate-pulse" />
+                </div>
+              ))
+            : prefs.map((pref) => (
+                <div key={pref.type} className="flex items-center justify-between py-4 gap-4">
+                  <div>
+                    <p className="text-sm font-medium">{pref.label}</p>
+                    <p className="text-xs text-muted-foreground">{pref.description}</p>
+                  </div>
+                  <button
+                    role="switch"
+                    aria-checked={pref.enabled}
+                    aria-label={`Toggle ${pref.label}`}
+                    disabled={saving === pref.type}
+                    onClick={() => handleToggle(pref.type, !pref.enabled)}
+                    className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 ${
+                      pref.enabled ? 'bg-primary' : 'bg-input'
+                    }`}
+                  >
+                    <span
+                      className={`pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform ${
+                        pref.enabled ? 'translate-x-5' : 'translate-x-0'
+                      }`}
+                    />
+                  </button>
+                </div>
+              ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/documents/DocumentViewer.tsx
+++ b/frontend/components/documents/DocumentViewer.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useEffect, useCallback } from 'react';
+import { X, Download } from 'lucide-react';
+import { Button } from '../ui/button';
+
+interface DocumentViewerProps {
+  open: boolean;
+  onClose: () => void;
+  url: string;
+  fileName: string;
+  mimeType?: string;
+}
+
+function getFileType(url: string, mimeType?: string): 'image' | 'pdf' | 'other' {
+  if (mimeType) {
+    if (mimeType.startsWith('image/')) return 'image';
+    if (mimeType === 'application/pdf') return 'pdf';
+    return 'other';
+  }
+  const lower = url.toLowerCase().split('?')[0];
+  if (/\.(png|jpe?g|gif|webp|svg|bmp)$/.test(lower)) return 'image';
+  if (lower.endsWith('.pdf')) return 'pdf';
+  return 'other';
+}
+
+export function DocumentViewer({ open, onClose, url, fileName, mimeType }: DocumentViewerProps) {
+  const fileType = getFileType(url, mimeType);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    if (!open) return;
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, handleKeyDown]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Viewing ${fileName}`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="relative flex flex-col bg-background rounded-xl shadow-xl w-full max-w-4xl max-h-[90vh] overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b shrink-0">
+          <span className="text-sm font-medium truncate max-w-[70%]">{fileName}</span>
+          <div className="flex items-center gap-2">
+            <Button asChild variant="outline" size="sm">
+              <a href={url} download={fileName} aria-label="Download file">
+                <Download className="h-4 w-4 mr-1" />
+                Download
+              </a>
+            </Button>
+            <button
+              onClick={onClose}
+              aria-label="Close viewer"
+              className="rounded-md p-1 hover:bg-muted transition-colors"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto flex items-center justify-center bg-muted/30 min-h-0">
+          {fileType === 'image' && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={url}
+              alt={fileName}
+              className="max-w-full max-h-full object-contain p-4"
+            />
+          )}
+          {fileType === 'pdf' && (
+            <iframe
+              src={url}
+              title={fileName}
+              className="w-full h-full min-h-[60vh]"
+              aria-label={`PDF viewer for ${fileName}`}
+            />
+          )}
+          {fileType === 'other' && (
+            <div className="flex flex-col items-center gap-4 p-8 text-center">
+              <p className="text-muted-foreground text-sm">
+                Preview is not available for this file type.
+              </p>
+              <Button asChild>
+                <a href={url} download={fileName}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Download {fileName}
+                </a>
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/ui/empty-state.tsx
+++ b/frontend/components/ui/empty-state.tsx
@@ -1,0 +1,105 @@
+import { ReactNode } from 'react';
+import { Button } from './button';
+
+interface EmptyStateProps {
+  illustration?: ReactNode;
+  title: string;
+  description?: string;
+  cta?: {
+    label: string;
+    onClick: () => void;
+  };
+}
+
+export function EmptyState({ illustration, title, description, cta }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 px-4 text-center gap-4">
+      {illustration && (
+        <div className="text-muted-foreground/50" aria-hidden="true">
+          {illustration}
+        </div>
+      )}
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold text-foreground">{title}</h3>
+        {description && (
+          <p className="text-sm text-muted-foreground max-w-sm">{description}</p>
+        )}
+      </div>
+      {cta && (
+        <Button onClick={cta.onClick} size="sm">
+          {cta.label}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/* ── Pre-built contextual empty states ── */
+
+export function EmptyShipments({ onCreate }: { onCreate?: () => void }) {
+  return (
+    <EmptyState
+      illustration={
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="10" y="30" width="60" height="36" rx="4" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <path d="M10 42h60" stroke="currentColor" strokeWidth="2.5"/>
+          <path d="M28 42v24" stroke="currentColor" strokeWidth="2"/>
+          <rect x="22" y="18" width="36" height="14" rx="3" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <circle cx="24" cy="70" r="5" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <circle cx="56" cy="70" r="5" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+        </svg>
+      }
+      title="No shipments yet"
+      description="Create your first shipment to get started."
+      cta={onCreate ? { label: 'Create your first shipment', onClick: onCreate } : undefined}
+    />
+  );
+}
+
+export function EmptyMarketplace() {
+  return (
+    <EmptyState
+      illustration={
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <circle cx="40" cy="40" r="28" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <path d="M28 40h24M40 28v24" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"/>
+        </svg>
+      }
+      title="No available shipments"
+      description="Check back later — new shipments will appear here when posted."
+    />
+  );
+}
+
+export function EmptyDocuments({ onUpload }: { onUpload?: () => void }) {
+  return (
+    <EmptyState
+      illustration={
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <rect x="18" y="10" width="44" height="56" rx="4" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <path d="M18 26h44" stroke="currentColor" strokeWidth="2"/>
+          <path d="M28 38h24M28 48h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+          <path d="M44 10v16h18" stroke="currentColor" strokeWidth="2.5"/>
+        </svg>
+      }
+      title="No documents uploaded"
+      description="Upload bills of lading, invoices, and other shipment documents."
+      cta={onUpload ? { label: 'Upload a document', onClick: onUpload } : undefined}
+    />
+  );
+}
+
+export function EmptyNotifications() {
+  return (
+    <EmptyState
+      illustration={
+        <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M40 14a20 20 0 0 1 20 20v10l6 8H14l6-8V34A20 20 0 0 1 40 14z" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+          <path d="M34 62a6 6 0 0 0 12 0" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" fill="none"/>
+        </svg>
+      }
+      title="No notifications"
+      description="You're all caught up! New activity will appear here."
+    />
+  );
+}

--- a/frontend/lib/api/notifications.api.ts
+++ b/frontend/lib/api/notifications.api.ts
@@ -1,0 +1,19 @@
+import { apiClient } from './client';
+
+export interface NotificationPreference {
+  type: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+}
+
+export const notificationsApi = {
+  getPreferences: () =>
+    apiClient<NotificationPreference[]>('/notifications/preferences'),
+
+  updatePreferences: (prefs: Record<string, boolean>) =>
+    apiClient<void>('/notifications/preferences', {
+      method: 'PATCH',
+      body: JSON.stringify(prefs),
+    }),
+};


### PR DESCRIPTION
## Summary

Implements all four issues assigned to @demilade18-git.

Closes #725
Closes #726
Closes #733
Closes #734

---

## Changes

### FE-19 (#725) – Document Viewer Modal
- New `DocumentViewer` component at `frontend/components/documents/DocumentViewer.tsx`
- Renders images via `<img>`, PDFs via `<iframe>` (browser built-in viewer)
- Fallback download button for unsupported file types
- Keyboard accessible: closes on `Escape`, backdrop click closes, `aria-modal` + `role=dialog`

### FE-20 (#726) – Notification Preferences Settings Page
- New page at `frontend/app/(dashboard)/settings/notifications/page.tsx`
- Fetches preferences from `GET /api/v1/notifications/preferences` on load
- Auto-saves on toggle via `PATCH /api/v1/notifications/preferences`
- Optimistic UI with revert on error; success toast on save
- New `frontend/lib/api/notifications.api.ts` API module

### FE-27 (#733) – Empty State Illustrations
- New `EmptyState` component at `frontend/components/ui/empty-state.tsx`
- Props: `illustration` (SVG ReactNode), `title`, `description`, optional `cta`
- Pre-built contextual variants: `EmptyShipments`, `EmptyMarketplace`, `EmptyDocuments`, `EmptyNotifications`
- Each has inline SVG illustration, contextual copy, and relevant CTA

### FE-28 (#734) – Admin Platform Statistics Overview Page
- New page at `frontend/app/(dashboard)/admin/stats/page.tsx`
- Stat cards: Total Users, Active Shipments, Monthly Revenue, Open Disputes
- Line chart of daily shipment creations (last 30 days) via Recharts
- Table of top 5 most active carriers and shippers by shipment count
- Fetches from `GET /api/v1/shipments/analytics` and existing `adminApi.getStats()`

## Testing
- `next build` passes with zero errors or warnings across all new routes