### PR TITLE
feat: stellar wave — onboarding, earnings, cancellation fee, cursor pagination

### DIFF
--- a/backend/src/carriers/carrier-earnings.service.ts
+++ b/backend/src/carriers/carrier-earnings.service.ts
@@ -1,0 +1,65 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Shipment } from '../shipments/entities/shipment.entity';
+import { ShipmentStatus } from '../common/enums/shipment-status.enum';
+
+interface MonthlyBreakdown {
+  month: string; // e.g. "2025-03"
+  earnings: number;
+  completedShipments: number;
+}
+
+interface EarningsSummary {
+  lifetimeEarnings: number;
+  currentMonthEarnings: number;
+  monthlyBreakdown: MonthlyBreakdown[];
+}
+
+@Injectable()
+export class CarrierEarningsService {
+  constructor(
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  async getEarningsSummary(carrierId: string): Promise<EarningsSummary> {
+    const completed = await this.shipmentRepo.find({
+      where: { carrierId, status: ShipmentStatus.COMPLETED },
+      select: ['id', 'price', 'actualDeliveryDate'],
+    });
+
+    const lifetimeEarnings = completed.reduce((sum, s) => sum + Number(s.price), 0);
+
+    const now = new Date();
+    const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+    const buckets = new Map<string, { earnings: number; count: number }>();
+
+    // Pre-fill last 12 months
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      buckets.set(key, { earnings: 0, count: 0 });
+    }
+
+    for (const s of completed) {
+      const date = s.actualDeliveryDate ? new Date(s.actualDeliveryDate) : null;
+      if (!date) continue;
+      const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+      if (buckets.has(key)) {
+        const b = buckets.get(key)!;
+        b.earnings += Number(s.price);
+        b.count += 1;
+      }
+    }
+
+    const monthlyBreakdown: MonthlyBreakdown[] = Array.from(buckets.entries()).map(
+      ([month, { earnings, count }]) => ({ month, earnings, completedShipments: count }),
+    );
+
+    const currentMonthEarnings = buckets.get(currentMonthKey)?.earnings ?? 0;
+
+    return { lifetimeEarnings, currentMonthEarnings, monthlyBreakdown };
+  }
+}

--- a/backend/src/common/cursor-pagination.util.ts
+++ b/backend/src/common/cursor-pagination.util.ts
@@ -1,0 +1,80 @@
+import { Repository, FindOptionsWhere, MoreThan, LessThan } from 'typeorm';
+
+export interface CursorPageOptions {
+  cursor?: string;   // opaque base64 cursor from previous response
+  limit?: number;
+  // Legacy offset fallback
+  page?: number;
+  pageSize?: number;
+}
+
+export interface CursorPageResult<T> {
+  data: T[];
+  nextCursor: string | null;
+  total?: number; // only populated for offset fallback
+}
+
+interface CursorPayload {
+  createdAt: string;
+  id: string;
+}
+
+export function encodeCursor(createdAt: Date, id: string): string {
+  const payload: CursorPayload = { createdAt: createdAt.toISOString(), id };
+  return Buffer.from(JSON.stringify(payload)).toString('base64url');
+}
+
+export function decodeCursor(cursor: string): CursorPayload {
+  try {
+    return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as CursorPayload;
+  } catch {
+    throw new Error('Invalid pagination cursor');
+  }
+}
+
+export async function cursorPaginate<T extends { id: string; createdAt: Date }>(
+  repo: Repository<T>,
+  where: FindOptionsWhere<T>,
+  options: CursorPageOptions,
+): Promise<CursorPageResult<T>> {
+  const limit = Math.min(options.limit ?? 20, 100);
+
+  // Offset fallback for backwards compatibility
+  if (!options.cursor && (options.page !== undefined || options.pageSize !== undefined)) {
+    const page = options.page ?? 1;
+    const pageSize = options.pageSize ?? limit;
+    const [data, total] = await repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC', id: 'DESC' } as never,
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+    });
+    return { data, nextCursor: null, total };
+  }
+
+  const cursorWhere = options.cursor
+    ? (() => {
+        const { createdAt, id } = decodeCursor(options.cursor);
+        return [
+          { ...where, createdAt: LessThan(new Date(createdAt)) },
+          { ...where, createdAt: new Date(createdAt), id: LessThan(id) },
+        ] as FindOptionsWhere<T>[];
+      })()
+    : where;
+
+  const data = await repo.find({
+    where: cursorWhere,
+    order: { createdAt: 'DESC', id: 'DESC' } as never,
+    take: limit + 1,
+  });
+
+  const hasMore = data.length > limit;
+  if (hasMore) data.pop();
+
+  const nextCursor =
+    hasMore && data.length > 0
+      ? encodeCursor(data[data.length - 1].createdAt, data[data.length - 1].id)
+      : null;
+
+  return { data, nextCursor };
+}

--- a/backend/src/shipments/cancellation-fee.service.ts
+++ b/backend/src/shipments/cancellation-fee.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Shipment } from './entities/shipment.entity';
+import { ShipmentStatus } from '../common/enums/shipment-status.enum';
+
+const FEE_TIERS: Partial<Record<ShipmentStatus, number>> = {
+  [ShipmentStatus.PENDING]: 0,
+  [ShipmentStatus.ACCEPTED]: 0.1,
+  [ShipmentStatus.IN_TRANSIT]: 0.25,
+};
+
+const CANCELLABLE = new Set<ShipmentStatus>([
+  ShipmentStatus.PENDING,
+  ShipmentStatus.ACCEPTED,
+  ShipmentStatus.IN_TRANSIT,
+]);
+
+export interface CancellationResult {
+  shipmentId: string;
+  cancellationFee: number;
+  currency: string;
+  status: ShipmentStatus.CANCELLED;
+}
+
+@Injectable()
+export class CancellationFeeService {
+  constructor(
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  calculateFee(price: number, status: ShipmentStatus): number {
+    const rate = FEE_TIERS[status] ?? null;
+    if (rate === null) throw new BadRequestException(`Shipment in status "${status}" cannot be cancelled`);
+    return Math.round(price * rate * 100) / 100;
+  }
+
+  async cancelShipment(shipmentId: string): Promise<CancellationResult> {
+    const shipment = await this.shipmentRepo.findOneOrFail({ where: { id: shipmentId } });
+
+    if (!CANCELLABLE.has(shipment.status)) {
+      throw new BadRequestException(`Cannot cancel a shipment with status "${shipment.status}"`);
+    }
+
+    const cancellationFee = this.calculateFee(Number(shipment.price), shipment.status);
+
+    await this.shipmentRepo.update(shipmentId, {
+      status: ShipmentStatus.CANCELLED,
+      notes: `Cancellation fee: ${cancellationFee} ${shipment.currency}`,
+    });
+
+    return {
+      shipmentId,
+      cancellationFee,
+      currency: shipment.currency,
+      status: ShipmentStatus.CANCELLED,
+    };
+  }
+}

--- a/frontend/components/dashboard/OnboardingChecklist.tsx
+++ b/frontend/components/dashboard/OnboardingChecklist.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from '../../lib/api/client';
+
+const DISMISS_KEY = 'onboarding_checklist_dismissed';
+
+interface UserProfile {
+  role: 'SHIPPER' | 'CARRIER';
+  emailVerified: boolean;
+  profileComplete: boolean;
+  hasShipment: boolean;
+  hasDocument: boolean;
+  hasRoutePreferences: boolean;
+  hasCertifications: boolean;
+  hasAcceptedShipment: boolean;
+}
+
+const SHIPPER_STEPS = [
+  { key: 'emailVerified', label: 'Verify email' },
+  { key: 'profileComplete', label: 'Complete profile' },
+  { key: 'hasShipment', label: 'Create first shipment' },
+  { key: 'hasDocument', label: 'Upload a document' },
+] as const;
+
+const CARRIER_STEPS = [
+  { key: 'emailVerified', label: 'Verify email' },
+  { key: 'hasRoutePreferences', label: 'Add route preferences' },
+  { key: 'hasCertifications', label: 'Upload certifications' },
+  { key: 'hasAcceptedShipment', label: 'Accept first shipment' },
+] as const;
+
+export default function OnboardingChecklist() {
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setDismissed(localStorage.getItem(DISMISS_KEY) === 'true');
+  }, []);
+
+  const { data: profile } = useQuery<UserProfile>({
+    queryKey: ['onboarding-profile'],
+    queryFn: () => apiClient.get('/users/me/onboarding').then((r) => r.data),
+  });
+
+  if (dismissed || !profile) return null;
+
+  const steps = profile.role === 'CARRIER' ? CARRIER_STEPS : SHIPPER_STEPS;
+  const completed = steps.filter((s) => profile[s.key]).length;
+
+  if (completed === steps.length) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(DISMISS_KEY, 'true');
+    setDismissed(true);
+  };
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow-sm" role="region" aria-label="Onboarding checklist">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-sm font-semibold">Get started — {completed}/{steps.length} complete</h2>
+        <button onClick={dismiss} aria-label="Dismiss checklist" className="text-gray-400 hover:text-gray-600">✕</button>
+      </div>
+      <div className="mb-3 h-2 w-full rounded-full bg-gray-100">
+        <div
+          className="h-2 rounded-full bg-blue-500 transition-all"
+          style={{ width: `${(completed / steps.length) * 100}%` }}
+          role="progressbar"
+          aria-valuenow={completed}
+          aria-valuemax={steps.length}
+        />
+      </div>
+      <ul className="space-y-1">
+        {steps.map((step) => (
+          <li key={step.key} className="flex items-center gap-2 text-sm">
+            <span className={profile[step.key] ? 'text-green-500' : 'text-gray-300'}>
+              {profile[step.key] ? '✓' : '○'}
+            </span>
+            <span className={profile[step.key] ? 'text-gray-400 line-through' : 'text-gray-700'}>
+              {step.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #741, closes #698, closes #697, closes #696

**#741 — Onboarding checklist widget**
Adds `OnboardingChecklist` component to the dashboard. Shows role-specific setup steps (shipper/carrier), a progress bar, and lets users permanently dismiss it via localStorage.

**#698 — Carrier earnings summary**
`CarrierEarningsService.getEarningsSummary` returns lifetime earnings, current-month earnings, and a monthly breakdown for the last 12 months with completed shipment counts.

**#697 — Shipment cancellation fee**
`CancellationFeeService.cancelShipment` applies fee tiers (0% PENDING / 10% ACCEPTED / 25% IN_TRANSIT), persists the fee in the shipment notes, and returns the amount in the response.

**#696 — Cursor-based pagination**
`cursorPaginate` utility encodes a `createdAt + id` cursor as base64url, returns a `nextCursor` field, and keeps offset params as a backwards-compatible fallback.