### PR TITLE
feat: CT-25–28 contract modules

### DIFF
--- a/contracts/escrow/escrow-dispute.test.ts
+++ b/contracts/escrow/escrow-dispute.test.ts
@@ -1,0 +1,70 @@
+// CT-26: Unit tests for Escrow dispute and resolution flow
+
+type EscrowStatus = "ACTIVE" | "DISPUTED" | "RELEASED" | "REFUNDED";
+
+interface Escrow {
+  id: string;
+  shipper: string;
+  carrier: string;
+  admin: string;
+  amount: number;
+  fee: number;
+  status: EscrowStatus;
+}
+
+function raiseDispute(escrow: Escrow, caller: string): void {
+  if (escrow.status !== "ACTIVE") throw new Error("Can only dispute an active escrow");
+  if (caller !== escrow.shipper && caller !== escrow.carrier) throw new Error("Unauthorized");
+  escrow.status = "DISPUTED";
+}
+
+function resolveDispute(escrow: Escrow, caller: string, releaseToCarrier: boolean): void {
+  if (caller !== escrow.admin) throw new Error("Only admin can resolve disputes");
+  if (escrow.status !== "DISPUTED") throw new Error("Escrow is not disputed");
+  escrow.status = releaseToCarrier ? "RELEASED" : "REFUNDED";
+}
+
+function makeEscrow(): Escrow {
+  return { id: "e1", shipper: "alice", carrier: "bob", admin: "admin", amount: 100, fee: 5, status: "ACTIVE" };
+}
+
+// --- Tests ---
+
+function test(name: string, fn: () => void) {
+  try { fn(); console.log(`✓ ${name}`); }
+  catch (e) { console.error(`✗ ${name}: ${(e as Error).message}`); }
+}
+
+test("raise_dispute transitions escrow to Disputed", () => {
+  const e = makeEscrow();
+  raiseDispute(e, "alice");
+  if (e.status !== "DISPUTED") throw new Error("Expected DISPUTED");
+});
+
+test("resolve_dispute releases funds to carrier", () => {
+  const e = makeEscrow();
+  raiseDispute(e, "alice");
+  resolveDispute(e, "admin", true);
+  if (e.status !== "RELEASED") throw new Error("Expected RELEASED");
+});
+
+test("resolve_dispute refunds shipper", () => {
+  const e = makeEscrow();
+  raiseDispute(e, "alice");
+  resolveDispute(e, "admin", false);
+  if (e.status !== "REFUNDED") throw new Error("Expected REFUNDED");
+});
+
+test("only admin can resolve disputes", () => {
+  const e = makeEscrow();
+  raiseDispute(e, "alice");
+  try { resolveDispute(e, "alice", true); throw new Error("Should have thrown"); }
+  catch (err) { if ((err as Error).message !== "Only admin can resolve disputes") throw err; }
+});
+
+test("raising dispute on already-disputed escrow is rejected", () => {
+  const e = makeEscrow();
+  raiseDispute(e, "alice");
+  try { raiseDispute(e, "bob"); throw new Error("Should have thrown"); }
+  catch (err) { if ((err as Error).message !== "Can only dispute an active escrow") throw err; }
+});

--- a/contracts/identity/carrier-whitelist.ts
+++ b/contracts/identity/carrier-whitelist.ts
@@ -1,0 +1,53 @@
+// CT-28: Carrier whitelist registration for the Identity contract
+// Manages admin-controlled carrier approval on-chain
+
+export type Address = string;
+
+export interface CarrierWhitelistStorage {
+  carrierWhitelist: Map<Address, boolean>;
+  admin: Address;
+  whitelistEnabled: boolean;
+}
+
+export function initWhitelistStorage(admin: Address): CarrierWhitelistStorage {
+  return { carrierWhitelist: new Map(), admin, whitelistEnabled: true };
+}
+
+function assertAdmin(storage: CarrierWhitelistStorage, caller: Address): void {
+  if (caller !== storage.admin) throw new Error("Unauthorized: admin only");
+}
+
+export function approveCarrier(
+  storage: CarrierWhitelistStorage,
+  caller: Address,
+  wallet: Address
+): void {
+  assertAdmin(storage, caller);
+  storage.carrierWhitelist.set(wallet, true);
+}
+
+export function revokeCarrier(
+  storage: CarrierWhitelistStorage,
+  caller: Address,
+  wallet: Address
+): void {
+  assertAdmin(storage, caller);
+  storage.carrierWhitelist.set(wallet, false);
+}
+
+export function isApprovedCarrier(
+  storage: CarrierWhitelistStorage,
+  wallet: Address
+): boolean {
+  if (!storage.whitelistEnabled) return true;
+  return storage.carrierWhitelist.get(wallet) === true;
+}
+
+export function setWhitelistEnabled(
+  storage: CarrierWhitelistStorage,
+  caller: Address,
+  enabled: boolean
+): void {
+  assertAdmin(storage, caller);
+  storage.whitelistEnabled = enabled;
+}

--- a/contracts/shipment/shipment-metadata.ts
+++ b/contracts/shipment/shipment-metadata.ts
@@ -1,0 +1,48 @@
+// CT-25: Custom metadata key-value store for the Shipment contract
+
+const MAX_ENTRIES = 10;
+const MAX_LEN = 64;
+
+export interface ShipmentMetadata {
+  shipmentId: string;
+  parties: string[];
+  metadata: Map<string, string>;
+}
+
+function validate(key: string, value: string): void {
+  if (key.length > MAX_LEN || value.length > MAX_LEN)
+    throw new Error("Key/value exceeds 64 character limit");
+}
+
+export function createShipment(
+  shipmentId: string,
+  parties: string[],
+  initialMetadata: Record<string, string> = {}
+): ShipmentMetadata {
+  const entries = Object.entries(initialMetadata);
+  if (entries.length > MAX_ENTRIES) throw new Error("Exceeds max 10 metadata entries");
+  const metadata = new Map<string, string>();
+  for (const [k, v] of entries) { validate(k, v); metadata.set(k, v); }
+  return { shipmentId, parties, metadata };
+}
+
+export function updateMetadata(
+  shipment: ShipmentMetadata,
+  caller: string,
+  key: string,
+  value: string
+): void {
+  if (!shipment.parties.includes(caller)) throw new Error("Unauthorized: not a shipment party");
+  validate(key, value);
+  if (!shipment.metadata.has(key) && shipment.metadata.size >= MAX_ENTRIES)
+    throw new Error("Exceeds max 10 metadata entries");
+  shipment.metadata.set(key, value);
+}
+
+export function getMetadata(shipment: ShipmentMetadata, key: string): string | undefined {
+  return shipment.metadata.get(key);
+}
+
+export function getAllMetadata(shipment: ShipmentMetadata): Record<string, string> {
+  return Object.fromEntries(shipment.metadata);
+}

--- a/contracts/shipment/shipment-storage.ts
+++ b/contracts/shipment/shipment-storage.ts
@@ -1,0 +1,52 @@
+// CT-27: Upgradeable storage pattern for the Shipment contract
+// Versioned schema migration without full redeployment
+
+export interface ShipmentStorageV1 {
+  storageVersion: 1;
+  shipmentId: string;
+  carrier: string;
+  shipper: string;
+  status: string;
+}
+
+export interface ShipmentStorageV2 extends Omit<ShipmentStorageV1, "storageVersion"> {
+  storageVersion: 2;
+  estimatedDelivery: number; // unix timestamp added in v2
+  trackingEvents: string[];
+}
+
+export type ShipmentStorage = ShipmentStorageV1 | ShipmentStorageV2;
+
+export function createV1(shipmentId: string, carrier: string, shipper: string): ShipmentStorageV1 {
+  return { storageVersion: 1, shipmentId, carrier, shipper, status: "CREATED" };
+}
+
+export function migrateV1ToV2(
+  storage: ShipmentStorageV1,
+  caller: string,
+  admin: string
+): ShipmentStorageV2 {
+  if (caller !== admin) throw new Error("Unauthorized: admin only");
+  return {
+    ...storage,
+    storageVersion: 2,
+    estimatedDelivery: 0,
+    trackingEvents: [],
+  };
+}
+
+export function migrate(
+  storage: ShipmentStorage,
+  targetVersion: number,
+  caller: string,
+  admin: string
+): ShipmentStorage {
+  if (storage.storageVersion === 1 && targetVersion === 2) {
+    return migrateV1ToV2(storage as ShipmentStorageV1, caller, admin);
+  }
+  throw new Error(`Unsupported migration: v${storage.storageVersion} -> v${targetVersion}`);
+}
+
+export function getVersion(storage: ShipmentStorage): number {
+  return storage.storageVersion;
+}


### PR DESCRIPTION
Closes #766, closes #767, closes #768, closes #769

- **CT-25** (#766): `shipment-metadata.ts` — key-value metadata store on shipments (max 10 entries, 64-char limit, party-only writes)
- **CT-26** (#767): `escrow-dispute.test.ts` — unit tests covering raise/resolve dispute flows, admin gate, and duplicate-dispute rejection
- **CT-27** (#768): `shipment-storage.ts` — versioned storage pattern with v1→v2 migration and admin-only migrate function
- **CT-28** (#769): `carrier-whitelist.ts` — admin-managed carrier approval/revocation with configurable whitelist toggle