### PR TITLE
feat: contract logic for CT-17 through CT-20

### DIFF
--- a/opsr/contracts/document/document-registry.ts
+++ b/opsr/contracts/document/document-registry.ts
@@ -1,0 +1,64 @@
+import { createHash } from "crypto";
+
+type DocId = string;
+type Hash = string;
+
+interface DocumentRecord {
+  docId: DocId;
+  hash: Hash;
+  owner: string;
+  registeredAt: number;
+}
+
+const docStore = new Map<DocId, DocumentRecord>();
+const hashIndex = new Map<Hash, DocId>();
+
+export class AlreadyRegisteredError extends Error {
+  existingDocId: DocId;
+  constructor(existingDocId: DocId) {
+    super(`AlreadyRegistered(${existingDocId})`);
+    this.existingDocId = existingDocId;
+  }
+}
+
+export function sha256(content: string): Hash {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function registerDocument(docId: DocId, content: string, owner: string): DocumentRecord {
+  const hash = sha256(content);
+
+  const existing = hashIndex.get(hash);
+  if (existing) throw new AlreadyRegisteredError(existing);
+
+  const record: DocumentRecord = { docId, hash, owner, registeredAt: Date.now() };
+  docStore.set(docId, record);
+  hashIndex.set(hash, docId);
+  return record;
+}
+
+export function findDocumentByHash(hash: Hash): DocumentRecord | undefined {
+  const docId = hashIndex.get(hash);
+  return docId ? docStore.get(docId) : undefined;
+}
+
+// --- tests ---
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+const doc = registerDocument("doc-1", "freight manifest A", "shipper-1");
+assert(doc.docId === "doc-1", "doc registered");
+
+const found = findDocumentByHash(sha256("freight manifest A"));
+assert(found?.docId === "doc-1", "find by hash works");
+
+try {
+  registerDocument("doc-2", "freight manifest A", "shipper-2");
+  assert(false, "should have thrown");
+} catch (e: unknown) {
+  assert(e instanceof AlreadyRegisteredError, "duplicate rejected");
+  assert((e as AlreadyRegisteredError).existingDocId === "doc-1", "returns existing id");
+}
+
+console.log("CT-17: all tests passed");

--- a/opsr/contracts/escrow/partial-release.ts
+++ b/opsr/contracts/escrow/partial-release.ts
@@ -1,0 +1,68 @@
+type ShipmentId = string;
+
+interface Milestone {
+  amount: number;
+  released: boolean;
+}
+
+interface EscrowRecord {
+  shipmentId: ShipmentId;
+  total: number;
+  milestones: Milestone[];
+  fullyReleased: boolean;
+}
+
+const escrows = new Map<ShipmentId, EscrowRecord>();
+
+export function fundEscrow(shipmentId: ShipmentId, milestones: number[]): EscrowRecord {
+  const total = milestones.reduce((s, a) => s + a, 0);
+  const record: EscrowRecord = {
+    shipmentId,
+    total,
+    milestones: milestones.map((amount) => ({ amount, released: false })),
+    fullyReleased: false,
+  };
+  escrows.set(shipmentId, record);
+  return record;
+}
+
+export function releaseMilestone(shipmentId: ShipmentId, index: number): void {
+  const escrow = escrows.get(shipmentId);
+  if (!escrow) throw new Error("EscrowNotFound");
+  if (index < 0 || index >= escrow.milestones.length) throw new Error("InvalidMilestoneIndex");
+  if (escrow.milestones[index].released) throw new Error("MilestoneAlreadyReleased");
+  escrow.milestones[index].released = true;
+}
+
+export function releasePayment(shipmentId: ShipmentId): void {
+  const escrow = escrows.get(shipmentId);
+  if (!escrow) throw new Error("EscrowNotFound");
+  if (escrow.milestones.length > 0) {
+    escrow.milestones.forEach((m) => (m.released = true));
+  }
+  escrow.fullyReleased = true;
+}
+
+// --- tests ---
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+const e = fundEscrow("ship-1", [100, 200, 300]);
+assert(e.total === 600, "total correct");
+
+releaseMilestone("ship-1", 0);
+assert(e.milestones[0].released, "milestone 0 released");
+assert(!e.milestones[1].released, "milestone 1 still locked");
+
+try {
+  releaseMilestone("ship-1", 0);
+  assert(false, "should throw on double release");
+} catch (err: any) {
+  assert(err.message === "MilestoneAlreadyReleased", "double release blocked");
+}
+
+releasePayment("ship-1");
+assert(e.fullyReleased, "full release works");
+
+console.log("CT-18: all tests passed");

--- a/opsr/contracts/reputation/fuzz-score.ts
+++ b/opsr/contracts/reputation/fuzz-score.ts
@@ -1,0 +1,48 @@
+// Reputation score: always in [0, 1000]
+// Formula: base from positive ratings, penalised by disputes
+export function computeScore(ratings: number, shipments: number, disputes: number): number {
+  if (shipments === 0) return 0;
+  const base = Math.min(1000, Math.round((ratings / shipments) * 1000));
+  const penalty = Math.min(base, Math.round((disputes / shipments) * 500));
+  return Math.max(0, base - penalty);
+}
+
+// --- property-based fuzz ---
+function randU32(): number {
+  return Math.floor(Math.random() * 0xffffffff);
+}
+
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+const RUNS = 10_000;
+
+for (let i = 0; i < RUNS; i++) {
+  const shipments = randU32() % 10_000 + 1; // avoid 0
+  const ratings = randU32() % (shipments + 1);
+  const disputes = randU32() % (shipments + 1);
+
+  const score = computeScore(ratings, shipments, disputes);
+
+  assert(score >= 0 && score <= 1000, `score out of range: ${score} (r=${ratings},s=${shipments},d=${disputes})`);
+}
+
+// score increases with more positive ratings (no disputes)
+const low = computeScore(100, 1000, 0);
+const high = computeScore(900, 1000, 0);
+assert(high > low, "higher ratings → higher score");
+
+// score decreases with more disputes (same ratings)
+const clean = computeScore(500, 1000, 0);
+const disputed = computeScore(500, 1000, 400);
+assert(disputed < clean, "more disputes → lower score");
+
+// edge: zero shipments
+assert(computeScore(0, 0, 0) === 0, "zero shipments → 0");
+
+// edge: max disputes equals shipments
+const maxDispute = computeScore(500, 1000, 1000);
+assert(maxDispute >= 0, "max disputes still non-negative");
+
+console.log(`CT-20: fuzz passed (${RUNS} runs)`);

--- a/opsr/contracts/shipment/pause-control.ts
+++ b/opsr/contracts/shipment/pause-control.ts
@@ -1,0 +1,73 @@
+type Address = string;
+
+interface ShipmentState {
+  paused: boolean;
+  admin: Address;
+  shipments: Map<string, { status: string }>;
+}
+
+const state: ShipmentState = {
+  paused: false,
+  admin: "admin-0x1",
+  shipments: new Map(),
+};
+
+function requireAdmin(caller: Address) {
+  if (caller !== state.admin) throw new Error("Unauthorized");
+}
+
+function requireNotPaused() {
+  if (state.paused) throw new Error("ContractPaused");
+}
+
+export function pause(caller: Address): void {
+  requireAdmin(caller);
+  state.paused = true;
+}
+
+export function unpause(caller: Address): void {
+  requireAdmin(caller);
+  state.paused = false;
+}
+
+export function createShipment(caller: Address, id: string): void {
+  requireNotPaused();
+  state.shipments.set(id, { status: "created" });
+}
+
+export function updateShipment(caller: Address, id: string, status: string): void {
+  requireNotPaused();
+  if (!state.shipments.has(id)) throw new Error("NotFound");
+  state.shipments.get(id)!.status = status;
+}
+
+// read-only — allowed while paused
+export function getShipment(id: string) {
+  return state.shipments.get(id);
+}
+
+// --- tests ---
+function assert(cond: boolean, msg: string) {
+  if (!cond) throw new Error(`FAIL: ${msg}`);
+}
+
+createShipment("user-1", "s1");
+assert(getShipment("s1")?.status === "created", "shipment created");
+
+pause("admin-0x1");
+assert(state.paused, "contract paused");
+
+try {
+  createShipment("user-1", "s2");
+  assert(false, "should be blocked");
+} catch (e: any) {
+  assert(e.message === "ContractPaused", "mutation blocked while paused");
+}
+
+assert(getShipment("s1") !== undefined, "reads allowed while paused");
+
+unpause("admin-0x1");
+createShipment("user-1", "s2");
+assert(getShipment("s2")?.status === "created", "works after unpause");
+
+console.log("CT-19: all tests passed");


### PR DESCRIPTION
Closes #758, closes #759, closes #760, closes #761

- **CT-17**: Added hash-to-docId index in Document Registry to reject duplicate hashes and expose `findDocumentByHash`
- **CT-18**: Added milestone vector to Escrow with `releaseMilestone` for partial releases; full `releasePayment` still works when no milestones are set
- **CT-19**: Added `paused` flag with `pause`/`unpause` (admin-only); all mutating functions gate on the flag while reads remain open
- **CT-20**: Property-based fuzz runner (10 000 random inputs) asserting score stays in [0, 1000] and moves correctly with ratings/disputes