### PR TITLE
feat: migrate document storage to Cloudinary with CRUD endpoints

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,11 @@ MAIL_FROM=noreply@freightflow.io
 # File Upload
 UPLOAD_DIR=./uploads
 
+# Cloudinary
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+
 # SMS Configuration (Twilio)
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 TWILIO_AUTH_TOKEN=your-auth-token

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -990,7 +990,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3330,7 +3329,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
       "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -3388,7 +3386,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -3467,7 +3464,6 @@
       "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3564,7 +3560,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.10.tgz",
       "integrity": "sha512-UVSf0yaWFBC2Zn2FOWABXxCnyG8XNIXrNnvTFpbUFqaJu1YDdwJ7wQBBqxq9CtJT7ILqSmfhOU7HS0d/0EAxpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.0.1",
@@ -3586,7 +3581,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.12.tgz",
       "integrity": "sha512-1itTTYsAZecrq2NbJOkch32y8buLwN7UpcNRdJrhlS+ovJ5GxLx3RyJ3KylwBhbYnO5AeYyL1U/i4W5mg/4qDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3759,7 +3753,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
       "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3773,7 +3766,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.12.tgz",
       "integrity": "sha512-ulSOYcgosx1TqY425cRC5oXtAu1R10+OSmVfgyR9ueR25k4luekURt8dzAZxhxSCI0OsDj9WKCFLTkEuAwg0wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -4687,7 +4679,6 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -4756,10 +4747,9 @@
       "version": "1.10.18",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.18.tgz",
       "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -4799,7 +4789,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4816,7 +4805,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4833,7 +4821,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -4850,7 +4837,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4867,7 +4853,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4884,7 +4869,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4901,7 +4885,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4918,7 +4901,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4935,7 +4917,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4952,7 +4933,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4966,14 +4946,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
       "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5146,7 +5126,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5325,7 +5304,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
       "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -5514,7 +5492,6 @@
       "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.1",
         "@typescript-eslint/types": "8.24.1",
@@ -6053,7 +6030,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6101,7 +6077,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6431,7 +6406,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6660,6 +6634,16 @@
       "integrity": "sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==",
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -6969,7 +6953,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -7331,7 +7314,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7387,15 +7369,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8559,7 +8539,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8621,7 +8600,6 @@
       "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "build/bin/cli.js"
       },
@@ -10709,7 +10687,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13046,7 +13023,6 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
       "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -13469,7 +13445,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13633,7 +13608,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -13740,7 +13714,6 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
       "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -13772,7 +13745,6 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.4.0.tgz",
       "integrity": "sha512-vjQsKBE+VN1LVchjbfLE7B6nBeGASZNRNKsR68VS0DolTm5R3zo+47JX1wjm0O96dcbvA7vnqt8YqOWlG5nN0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^9.0.0",
@@ -13935,7 +13907,6 @@
       "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14049,7 +14020,6 @@
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -14455,8 +14425,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
@@ -14836,7 +14805,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15943,7 +15911,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16318,7 +16285,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16485,7 +16451,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.27.tgz",
       "integrity": "sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -16696,7 +16661,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17117,7 +17081,6 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -17185,7 +17148,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17622,16 +17584,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     }
   }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { NotificationPreferencesModule } from './notification-preferences/notifi
 import { AdminAuditInterceptor } from './audit-log/admin-audit.interceptor';
 import { CarriersModule } from './carriers/carriers.module';
 import { ReviewsModule } from './reviews/reviews.module';
+import { CloudinaryModule } from './cloudinary/cloudinary.module';
 
 const shipmentCreateTracker = (context: ExecutionContext): string => {
   const request = context.switchToHttp().getRequest<{
@@ -73,6 +74,9 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
         MAIL_PASS: Joi.string().required(),
         MAIL_FROM: Joi.string().default('noreply@freightflow.io'),
         UPLOAD_DIR: Joi.string().default('./uploads'),
+        CLOUDINARY_CLOUD_NAME: Joi.string().required(),
+        CLOUDINARY_API_KEY: Joi.string().required(),
+        CLOUDINARY_API_SECRET: Joi.string().required(),
       }),
       validationOptions: {
         allowUnknown: true,
@@ -128,6 +132,7 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
     NotificationPreferencesModule,
     CarriersModule,
     ReviewsModule,
+    CloudinaryModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/cloudinary/cloudinary.module.ts
+++ b/backend/src/cloudinary/cloudinary.module.ts
@@ -1,0 +1,9 @@
+import { Module, Global } from '@nestjs/common';
+import { CloudinaryService } from './cloudinary.service';
+
+@Global()
+@Module({
+  providers: [CloudinaryService],
+  exports: [CloudinaryService],
+})
+export class CloudinaryModule {}

--- a/backend/src/cloudinary/cloudinary.service.ts
+++ b/backend/src/cloudinary/cloudinary.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { v2 as cloudinary, UploadApiResponse } from 'cloudinary';
+
+@Injectable()
+export class CloudinaryService {
+  constructor(private readonly configService: ConfigService) {
+    cloudinary.config({
+      cloud_name: this.configService.get<string>('CLOUDINARY_CLOUD_NAME'),
+      api_key: this.configService.get<string>('CLOUDINARY_API_KEY'),
+      api_secret: this.configService.get<string>('CLOUDINARY_API_SECRET'),
+    });
+  }
+
+  async uploadBuffer(
+    buffer: Buffer,
+    folder: string,
+    publicId: string,
+  ): Promise<UploadApiResponse> {
+    return new Promise((resolve, reject) => {
+      const stream = cloudinary.uploader.upload_stream(
+        { folder, public_id: publicId, resource_type: 'auto' },
+        (error: unknown, result: UploadApiResponse) => {
+          if (error) return reject(error);
+          resolve(result);
+        },
+      );
+      stream.end(buffer);
+    });
+  }
+
+  async destroy(publicId: string): Promise<void> {
+    await cloudinary.uploader.destroy(publicId, { resource_type: 'auto' });
+  }
+
+  getCloudinary() {
+    return cloudinary;
+  }
+}

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -5,13 +5,15 @@ import {
   Delete,
   Param,
   Body,
+  Query,
   UseInterceptors,
   UploadedFile,
   ParseUUIDPipe,
   HttpCode,
   HttpStatus,
-  Res,
   BadRequestException,
+  StreamableFile,
+  Res,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import {
@@ -25,6 +27,7 @@ import {
 import { Response } from 'express';
 import { DocumentsService } from './documents.service';
 import { UploadDocumentDto } from './dto/upload-document.dto';
+import { ListDocumentsQueryDto } from './dto/list-documents-query.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { User } from '../users/entities/user.entity';
 
@@ -64,7 +67,6 @@ export class DocumentsController {
   @ApiResponse({ status: 201, description: 'Document uploaded successfully' })
   @ApiResponse({ status: 400, description: 'Invalid file or payload' })
   @ApiResponse({ status: 403, description: 'Not a party to this shipment' })
-  // Multer options are configured via MulterModule in DocumentsModule
   @UseInterceptors(FileInterceptor('file'))
   async upload(
     @UploadedFile() file: Express.Multer.File,
@@ -82,6 +84,22 @@ export class DocumentsController {
     return this.documentsService.upload(file, dto, user);
   }
 
+  @Get()
+  @ApiOperation({ summary: 'List authenticated user documents (paginated)' })
+  @ApiResponse({ status: 200, description: 'Paginated document list' })
+  listUserDocuments(
+    @Query() query: ListDocumentsQueryDto,
+    @CurrentUser() user: User,
+  ) {
+    return this.documentsService.listUserDocuments(
+      user,
+      query.page,
+      query.limit,
+      query.documentType,
+      query.shipmentId,
+    );
+  }
+
   @Get('shipment/:shipmentId')
   @ApiOperation({ summary: 'List all documents for a shipment' })
   @ApiResponse({ status: 200, description: 'Document list' })
@@ -95,6 +113,7 @@ export class DocumentsController {
   @Get(':id')
   @ApiOperation({ summary: 'Get document metadata by ID' })
   @ApiResponse({ status: 200, description: 'Document metadata' })
+  @ApiResponse({ status: 403, description: 'Not owner or admin' })
   @ApiResponse({ status: 404, description: 'Document not found' })
   findOne(@Param('id', ParseUUIDPipe) id: string, @CurrentUser() user: User) {
     return this.documentsService.findOne(id, user);
@@ -103,23 +122,29 @@ export class DocumentsController {
   @Get(':id/download')
   @ApiOperation({ summary: 'Download a document file' })
   @ApiResponse({ status: 200, description: 'File stream' })
+  @ApiResponse({ status: 403, description: 'Not owner or admin' })
   @ApiResponse({ status: 404, description: 'File not found' })
   async download(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: User,
-    @Res() res: Response,
+    @Res({ passthrough: true }) res: Response,
   ) {
-    const { filePath, originalName } = await this.documentsService.getFilePath(
-      id,
-      user,
-    );
-    res.download(filePath, originalName);
+    const { stream, mimetype, originalName } =
+      await this.documentsService.download(id, user);
+
+    res.set({
+      'Content-Type': mimetype,
+      'Content-Disposition': `attachment; filename="${originalName}"`,
+    });
+
+    return new StreamableFile(stream);
   }
 
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a document (uploader or admin only)' })
   @ApiResponse({ status: 204, description: 'Document deleted' })
+  @ApiResponse({ status: 403, description: 'Not owner or admin' })
   async remove(
     @Param('id', ParseUUIDPipe) id: string,
     @CurrentUser() user: User,

--- a/backend/src/documents/documents.module.ts
+++ b/backend/src/documents/documents.module.ts
@@ -1,11 +1,8 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MulterModule } from '@nestjs/platform-express';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { diskStorage } from 'multer';
-import { extname } from 'path';
-import * as fs from 'fs';
-import { v4 as uuidv4 } from 'uuid';
+import { HttpModule } from '@nestjs/axios';
+import { memoryStorage } from 'multer';
 import { DocumentsService } from './documents.service';
 import { DocumentsController } from './documents.controller';
 import { Document } from './entities/document.entity';
@@ -16,24 +13,10 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 @Module({
   imports: [
     TypeOrmModule.forFeature([Document, Shipment]),
-    MulterModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
-      useFactory: (config: ConfigService) => {
-        const uploadDir = config.get<string>('UPLOAD_DIR', './uploads');
-        fs.mkdirSync(uploadDir, { recursive: true });
-
-        return {
-          storage: diskStorage({
-            destination: uploadDir,
-            filename: (_req, file, cb) => {
-              const unique = `${Date.now()}-${uuidv4()}${extname(file.originalname)}`;
-              cb(null, unique);
-            },
-          }),
-          limits: { fileSize: MAX_FILE_SIZE },
-        };
-      },
+    HttpModule,
+    MulterModule.register({
+      storage: memoryStorage(),
+      limits: { fileSize: MAX_FILE_SIZE },
     }),
   ],
   controllers: [DocumentsController],

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -4,16 +4,19 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { ConfigService } from '@nestjs/config';
+import { Repository, IsNull } from 'typeorm';
 import * as crypto from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 import { Document } from './entities/document.entity';
 import { Shipment } from '../shipments/entities/shipment.entity';
 import { User } from '../users/entities/user.entity';
 import { UserRole } from '../common/enums/role.enum';
 import { UploadDocumentDto } from './dto/upload-document.dto';
+import { CloudinaryService } from '../cloudinary/cloudinary.service';
+import { Readable } from 'stream';
+
+const CLOUDINARY_FOLDER = 'freightflow/documents';
 
 @Injectable()
 export class DocumentsService {
@@ -22,14 +25,9 @@ export class DocumentsService {
     private readonly documentRepo: Repository<Document>,
     @InjectRepository(Shipment)
     private readonly shipmentRepo: Repository<Shipment>,
-    private readonly configService: ConfigService,
+    private readonly cloudinary: CloudinaryService,
+    private readonly httpService: HttpService,
   ) {}
-
-  get uploadDir(): string {
-    return this.configService.get<string>('UPLOAD_DIR', './uploads');
-  }
-
-  // ── Guards ───────────────────────────────────────────────────────────────────
 
   private async getShipmentOrThrow(shipmentId: string): Promise<Shipment> {
     const shipment = await this.shipmentRepo.findOne({
@@ -52,14 +50,17 @@ export class DocumentsService {
     }
   }
 
-  // ── Hash ─────────────────────────────────────────────────────────────────────
-
-  private computeSha256(filePath: string): string {
-    const buffer = fs.readFileSync(filePath);
-    return crypto.createHash('sha256').update(buffer).digest('hex');
+  private assertOwnerOrAdmin(doc: Document, user: User): void {
+    if (doc.uploaderId !== user.id && user.role !== UserRole.ADMIN) {
+      throw new ForbiddenException(
+        'Only the uploader or an admin can access this document',
+      );
+    }
   }
 
-  // ── Upload ───────────────────────────────────────────────────────────────────
+  private computeSha256(buffer: Buffer): string {
+    return crypto.createHash('sha256').update(buffer).digest('hex');
+  }
 
   async upload(
     file: Express.Multer.File,
@@ -69,25 +70,73 @@ export class DocumentsService {
     const shipment = await this.getShipmentOrThrow(dto.shipmentId);
     this.assertIsParty(shipment, uploader);
 
-    const sha256Hash = this.computeSha256(file.path);
+    const sha256Hash = this.computeSha256(file.buffer);
+
+    const result = await this.cloudinary.uploadBuffer(
+      file.buffer,
+      CLOUDINARY_FOLDER,
+      sha256Hash,
+    );
 
     const doc = this.documentRepo.create({
       shipmentId: dto.shipmentId,
       uploaderId: uploader.id,
       documentType: dto.documentType,
       originalName: file.originalname,
-      storedName: file.filename,
+      storedName: result.public_id,
       mimetype: file.mimetype,
       sizeBytes: file.size,
       sha256Hash,
+      storedUrl: result.secure_url,
       ipfsCid: null,
       notes: dto.notes ?? null,
     });
 
-    return this.documentRepo.save(doc);
+    const saved = await this.documentRepo.save(doc);
+
+    this.enqueueIpfsPin(saved.id, saved.storedUrl!).catch(() => {
+      // Silently ignore — job will be retried or handled by worker
+    });
+
+    return saved;
   }
 
-  // ── List ─────────────────────────────────────────────────────────────────────
+  private async enqueueIpfsPin(
+    documentId: string,
+    cloudinaryUrl: string,
+  ): Promise<void> {
+    // TODO: Replace with BullMQ queue.add('ipfs-pin', { documentId, cloudinaryUrl })
+    console.log(
+      `[IPFS Pin] Enqueued: documentId=${documentId}, url=${cloudinaryUrl}`,
+    );
+  }
+
+  async listUserDocuments(
+    user: User,
+    page = 1,
+    limit = 20,
+    documentType?: string,
+    shipmentId?: string,
+  ): Promise<{ data: Document[]; total: number; page: number; limit: number }> {
+    const qb = this.documentRepo
+      .createQueryBuilder('doc')
+      .where('doc.uploader_id = :userId', { userId: user.id })
+      .andWhere('doc.deleted_at IS NULL');
+
+    if (documentType) {
+      qb.andWhere('doc.document_type = :documentType', { documentType });
+    }
+    if (shipmentId) {
+      qb.andWhere('doc.shipment_id = :shipmentId', { shipmentId });
+    }
+
+    qb.orderBy('doc.created_at', 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit };
+  }
 
   async listByShipment(shipmentId: string, user: User): Promise<Document[]> {
     const shipment = await this.getShipmentOrThrow(shipmentId);
@@ -100,53 +149,46 @@ export class DocumentsService {
     });
   }
 
-  // ── Single ───────────────────────────────────────────────────────────────────
-
   async findOne(id: string, user: User): Promise<Document> {
     const doc = await this.documentRepo.findOne({
-      where: { id },
+      where: { id, deletedAt: IsNull() },
       relations: ['uploader'],
     });
     if (!doc) throw new NotFoundException(`Document ${id} not found`);
 
-    const shipment = await this.getShipmentOrThrow(doc.shipmentId);
-    this.assertIsParty(shipment, user);
+    this.assertOwnerOrAdmin(doc, user);
     return doc;
   }
 
-  // ── Download ─────────────────────────────────────────────────────────────────
-
-  async getFilePath(
+  async download(
     id: string,
     user: User,
-  ): Promise<{ filePath: string; originalName: string }> {
+  ): Promise<{ stream: Readable; mimetype: string; originalName: string }> {
     const doc = await this.findOne(id, user);
-    const filePath = path.join(this.uploadDir, doc.storedName);
 
-    if (!fs.existsSync(filePath)) {
-      throw new NotFoundException('File not found on server');
+    if (!doc.storedUrl) {
+      throw new NotFoundException('File URL not available');
     }
 
-    return { filePath, originalName: doc.originalName };
-  }
+    const response = await firstValueFrom(
+      this.httpService.get(doc.storedUrl, { responseType: 'stream' }),
+    );
 
-  // ── Delete ───────────────────────────────────────────────────────────────────
+    return {
+      stream: response.data as Readable,
+      mimetype: doc.mimetype,
+      originalName: doc.originalName,
+    };
+  }
 
   async delete(id: string, user: User): Promise<void> {
     const doc = await this.findOne(id, user);
+    this.assertOwnerOrAdmin(doc, user);
 
-    // Only the uploader or admin can delete
-    if (doc.uploaderId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException(
-        'Only the uploader or an admin can delete this document',
-      );
+    if (doc.storedName) {
+      await this.cloudinary.destroy(doc.storedName);
     }
 
-    const filePath = path.join(this.uploadDir, doc.storedName);
-    if (fs.existsSync(filePath)) {
-      fs.unlinkSync(filePath);
-    }
-
-    await this.documentRepo.remove(doc);
+    await this.documentRepo.softRemove(doc);
   }
 }

--- a/backend/src/documents/dto/list-documents-query.dto.ts
+++ b/backend/src/documents/dto/list-documents-query.dto.ts
@@ -1,0 +1,30 @@
+import { IsOptional, IsEnum, IsUUID, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { DocumentType } from '../enums/document-type.enum';
+
+export class ListDocumentsQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ enum: DocumentType })
+  @IsOptional()
+  @IsEnum(DocumentType)
+  documentType?: DocumentType;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsUUID()
+  shipmentId?: string;
+}

--- a/backend/src/documents/entities/document.entity.ts
+++ b/backend/src/documents/entities/document.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   JoinColumn,
   CreateDateColumn,
+  DeleteDateColumn,
   Index,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
@@ -59,9 +60,16 @@ export class Document {
   @Column({ name: 'ipfs_cid', nullable: true, type: 'varchar' })
   ipfsCid: string | null;
 
+  /** Cloudinary secure_url */
+  @Column({ name: 'stored_url', nullable: true })
+  storedUrl: string | null;
+
   @Column({ type: 'text', nullable: true })
   notes: string | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;
+
+  @DeleteDateColumn({ name: 'deleted_at' })
+  deletedAt: Date | null;
 }

--- a/backend/src/migrations/1718900000000-AddStoredUrlAndDeletedAtToDocuments.ts
+++ b/backend/src/migrations/1718900000000-AddStoredUrlAndDeletedAtToDocuments.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddStoredUrlAndDeletedAtToDocuments1718900000000
+  implements MigrationInterface
+{
+  name = 'AddStoredUrlAndDeletedAtToDocuments1718900000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD "stored_url" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "documents" ADD "deleted_at" TIMESTAMP`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "documents" DROP COLUMN "deleted_at"`);
+    await queryRunner.query(`ALTER TABLE "documents" DROP COLUMN "stored_url"`);
+  }
+}


### PR DESCRIPTION
closes #965
- Replaced Multer diskStorage with memoryStorage + Cloudinary upload
- Added CloudinaryService (global module) for buffer upload and destroy
- Added storedUrl and deletedAt columns to Document entity
- New GET /documents endpoint (paginated, user-scoped, filterable)
- Updated GET /documents/:id with owner/admin access control (403)
- Updated GET /documents/:id/download streams from Cloudinary via StreamableFile
- Updated DELETE /documents/:id soft-deletes DB record and removes from Cloudinary
- Enqueue IPFS pin job after each successful upload (placeholder for BullMQ)
- Add migration for stored_url and deleted_at columns
- Add Cloudinary env vars to .env.example and Joi validation