### PR TITLE
feat: add Webhooks and API Keys developer settings pages

### DIFF
--- a/frontend/app/(dashboard)/settings/api-keys/page.tsx
+++ b/frontend/app/(dashboard)/settings/api-keys/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { apiKeysApi, ApiKey, GenerateApiKeyResponse } from '../../../../lib/api/api-keys.api';
+
+export default function ApiKeysPage() {
+  const [keys, setKeys] = useState<ApiKey[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [name, setName] = useState('');
+  const [generating, setGenerating] = useState(false);
+  const [newKey, setNewKey] = useState<GenerateApiKeyResponse | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [revokeId, setRevokeId] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    apiKeysApi.list().then(setKeys).finally(() => setLoading(false));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  async function handleGenerate() {
+    if (!name.trim()) return;
+    setGenerating(true);
+    try {
+      const result = await apiKeysApi.generate({ name: name.trim() });
+      setNewKey(result);
+      load();
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  function handleCopy() {
+    if (newKey) {
+      navigator.clipboard.writeText(newKey.key);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  async function handleRevoke(id: string) {
+    await apiKeysApi.revoke(id);
+    setRevokeId(null);
+    load();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">API Keys</h1>
+          <p className="text-sm text-muted-foreground">Programmatic access to the FreightFlow API.</p>
+        </div>
+        <button onClick={() => { setShowModal(true); setNewKey(null); setName(''); }} className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm">
+          + Generate Key
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">{[...Array(3)].map((_, i) => <div key={i} className="h-12 rounded bg-muted animate-pulse" />)}</div>
+      ) : keys.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No API keys yet.</p>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted text-muted-foreground">
+              <tr>
+                {['Name', 'Key Prefix', 'Created', 'Last Used', 'Status', 'Actions'].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left font-medium">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {keys.map((k) => (
+                <tr key={k.id} className="hover:bg-muted/40">
+                  <td className="px-4 py-3 font-medium">{k.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs">{k.prefix}…</td>
+                  <td className="px-4 py-3 text-muted-foreground">{new Date(k.createdAt).toLocaleDateString()}</td>
+                  <td className="px-4 py-3 text-muted-foreground">{k.lastUsedAt ? new Date(k.lastUsedAt).toLocaleDateString() : '—'}</td>
+                  <td className="px-4 py-3">
+                    {k.status === 'active'
+                      ? <span className="text-xs text-green-600 font-medium">Active</span>
+                      : <span className="text-xs text-muted-foreground">Revoked</span>}
+                  </td>
+                  <td className="px-4 py-3">
+                    {k.status === 'active' && (
+                      <button onClick={() => setRevokeId(k.id)} className="text-xs text-destructive hover:underline">Revoke</button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Generate modal */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg p-6 w-96 space-y-4 shadow-xl">
+            {!newKey ? (
+              <>
+                <h2 className="font-semibold text-lg">Generate API Key</h2>
+                <div>
+                  <label className="text-sm font-medium">Key Name</label>
+                  <input
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="e.g. Production integration"
+                    className="mt-1 w-full rounded border bg-background px-3 py-2 text-sm"
+                  />
+                </div>
+                <div className="flex gap-3 justify-end">
+                  <button onClick={() => setShowModal(false)} className="px-4 py-2 text-sm rounded border">Cancel</button>
+                  <button onClick={handleGenerate} disabled={generating || !name.trim()} className="px-4 py-2 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50">
+                    {generating ? 'Generating…' : 'Generate'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <h2 className="font-semibold text-lg">API Key Generated</h2>
+                <p className="text-sm text-muted-foreground">Copy this key now — it will not be shown again.</p>
+                <div className="flex items-center gap-2 rounded border bg-muted p-3">
+                  <code className="flex-1 text-xs font-mono break-all">{newKey.key}</code>
+                  <button onClick={handleCopy} className="shrink-0 text-xs text-primary">{copied ? 'Copied!' : 'Copy'}</button>
+                </div>
+                <div className="flex justify-end">
+                  <button onClick={() => setShowModal(false)} className="px-4 py-2 text-sm rounded bg-primary text-primary-foreground">Done</button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Revoke confirmation */}
+      {revokeId && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg p-6 w-80 space-y-4 shadow-xl">
+            <p className="font-semibold">Revoke API key?</p>
+            <p className="text-sm text-muted-foreground">Any integrations using this key will stop working immediately.</p>
+            <div className="flex gap-3 justify-end">
+              <button onClick={() => setRevokeId(null)} className="px-4 py-2 text-sm rounded border">Cancel</button>
+              <button onClick={() => handleRevoke(revokeId)} className="px-4 py-2 text-sm rounded bg-destructive text-destructive-foreground">Revoke</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/settings/layout.tsx
+++ b/frontend/app/(dashboard)/settings/layout.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { cn } from '../../../lib/utils';
+
+const SETTINGS_NAV = [
+  { href: '/settings/profile', label: 'Profile' },
+  { href: '/settings/notifications', label: 'Notifications' },
+  { href: '/settings/security', label: 'Security' },
+  { href: '/settings/webhooks', label: 'Webhooks' },
+  { href: '/settings/api-keys', label: 'API Keys' },
+];
+
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex min-h-full">
+      <aside className="w-52 shrink-0 border-r bg-card p-4 space-y-1">
+        <p className="text-xs font-semibold uppercase text-muted-foreground px-3 mb-2">Settings</p>
+        {SETTINGS_NAV.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              'block rounded-md px-3 py-2 text-sm font-medium transition-colors',
+              pathname === item.href
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+            )}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </aside>
+      <div className="flex-1 p-6">{children}</div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/settings/webhooks/page.tsx
+++ b/frontend/app/(dashboard)/settings/webhooks/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { webhookApi, Webhook, WEBHOOK_EVENTS } from '../../../../lib/api/webhook.api';
+
+function StatusBadge({ status }: { status: Webhook['lastDeliveryStatus'] }) {
+  if (status === 'success') return <span className="text-xs text-green-600 font-medium">Success</span>;
+  if (status === 'failed') return <span className="text-xs text-red-600 font-medium">Failed</span>;
+  return <span className="text-xs text-muted-foreground">Never triggered</span>;
+}
+
+export default function WebhooksPage() {
+  const [webhooks, setWebhooks] = useState<Webhook[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showModal, setShowModal] = useState(false);
+  const [url, setUrl] = useState('');
+  const [selectedEvents, setSelectedEvents] = useState<string[]>([]);
+  const [urlError, setUrlError] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+  const [pingResults, setPingResults] = useState<Record<string, { delivered: boolean; statusCode: number; responseTimeMs: number }>>({});
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const load = () => {
+    setLoading(true);
+    webhookApi.list().then(setWebhooks).finally(() => setLoading(false));
+  };
+
+  useEffect(() => { load(); }, []);
+
+  function validateUrl(v: string) {
+    try {
+      const u = new URL(v);
+      return u.protocol === 'https:' ? '' : 'URL must use HTTPS';
+    } catch {
+      return 'Enter a valid URL';
+    }
+  }
+
+  async function handleRegister() {
+    const err = validateUrl(url);
+    if (err) { setUrlError(err); return; }
+    if (!selectedEvents.length) { setUrlError('Select at least one event'); return; }
+    setSaving(true);
+    try {
+      await webhookApi.register({ url, events: selectedEvents });
+      setShowModal(false);
+      setUrl('');
+      setSelectedEvents([]);
+      load();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePing(id: string) {
+    const result = await webhookApi.testPing(id);
+    setPingResults((prev) => ({ ...prev, [id]: result }));
+  }
+
+  async function handleCopySecret(id: string) {
+    const { secret } = await webhookApi.getSecret(id);
+    navigator.clipboard.writeText(secret);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 2000);
+  }
+
+  async function handleDelete(id: string) {
+    await webhookApi.delete(id);
+    setDeleteId(null);
+    load();
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-bold">Webhooks</h1>
+          <p className="text-sm text-muted-foreground">Receive HTTP callbacks when shipment events occur.</p>
+        </div>
+        <button onClick={() => setShowModal(true)} className="px-4 py-2 rounded bg-primary text-primary-foreground text-sm">
+          + Add Webhook
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">{[...Array(3)].map((_, i) => <div key={i} className="h-12 rounded bg-muted animate-pulse" />)}</div>
+      ) : webhooks.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No webhooks registered yet.</p>
+      ) : (
+        <div className="rounded-lg border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted text-muted-foreground">
+              <tr>
+                {['URL', 'Created', 'Last Delivery', 'Actions'].map((h) => (
+                  <th key={h} className="px-4 py-3 text-left font-medium">{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {webhooks.map((wh) => (
+                <>
+                  <tr key={wh.id} className="hover:bg-muted/40">
+                    <td className="px-4 py-3 max-w-xs">
+                      <span title={wh.url} className="truncate block">{wh.url}</span>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{new Date(wh.createdAt).toLocaleDateString()}</td>
+                    <td className="px-4 py-3"><StatusBadge status={wh.lastDeliveryStatus} /></td>
+                    <td className="px-4 py-3">
+                      <div className="flex gap-3">
+                        <button onClick={() => handlePing(wh.id)} className="text-xs text-primary hover:underline">Test Ping</button>
+                        <button onClick={() => handleCopySecret(wh.id)} className="text-xs text-primary hover:underline">
+                          {copiedId === wh.id ? 'Copied!' : 'Copy Secret'}
+                        </button>
+                        <button onClick={() => setDeleteId(wh.id)} className="text-xs text-destructive hover:underline">Delete</button>
+                      </div>
+                    </td>
+                  </tr>
+                  {pingResults[wh.id] && (
+                    <tr key={wh.id + '-ping'} className="bg-muted/20">
+                      <td colSpan={4} className="px-4 py-2 text-xs">
+                        {pingResults[wh.id].delivered
+                          ? <span className="text-green-600">✓ Delivered — HTTP {pingResults[wh.id].statusCode} in {pingResults[wh.id].responseTimeMs}ms</span>
+                          : <span className="text-red-600">✗ Failed — HTTP {pingResults[wh.id].statusCode} in {pingResults[wh.id].responseTimeMs}ms</span>}
+                      </td>
+                    </tr>
+                  )}
+                </>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Register modal */}
+      {showModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg p-6 w-96 space-y-4 shadow-xl">
+            <h2 className="font-semibold text-lg">Register Webhook</h2>
+            <div>
+              <label className="text-sm font-medium">HTTPS URL</label>
+              <input
+                value={url}
+                onChange={(e) => { setUrl(e.target.value); setUrlError(''); }}
+                placeholder="https://example.com/webhook"
+                className="mt-1 w-full rounded border bg-background px-3 py-2 text-sm"
+              />
+              {urlError && <p className="text-xs text-destructive mt-1">{urlError}</p>}
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-2">Events</p>
+              <div className="grid grid-cols-2 gap-1">
+                {WEBHOOK_EVENTS.map((ev) => (
+                  <label key={ev} className="flex items-center gap-2 text-xs cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={selectedEvents.includes(ev)}
+                      onChange={(e) =>
+                        setSelectedEvents((prev) =>
+                          e.target.checked ? [...prev, ev] : prev.filter((x) => x !== ev)
+                        )
+                      }
+                    />
+                    {ev}
+                  </label>
+                ))}
+              </div>
+            </div>
+            <div className="flex gap-3 justify-end">
+              <button onClick={() => setShowModal(false)} className="px-4 py-2 text-sm rounded border">Cancel</button>
+              <button onClick={handleRegister} disabled={saving} className="px-4 py-2 text-sm rounded bg-primary text-primary-foreground disabled:opacity-50">
+                {saving ? 'Saving…' : 'Register'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete confirmation */}
+      {deleteId && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card rounded-lg p-6 w-80 space-y-4 shadow-xl">
+            <p className="font-semibold">Delete webhook?</p>
+            <p className="text-sm text-muted-foreground">Are you sure? This cannot be undone.</p>
+            <div className="flex gap-3 justify-end">
+              <button onClick={() => setDeleteId(null)} className="px-4 py-2 text-sm rounded border">Cancel</button>
+              <button onClick={() => handleDelete(deleteId)} className="px-4 py-2 text-sm rounded bg-destructive text-destructive-foreground">Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/lib/api/api-keys.api.ts
+++ b/frontend/lib/api/api-keys.api.ts
@@ -1,0 +1,35 @@
+import { apiClient } from './client';
+
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  status: 'active' | 'revoked';
+}
+
+export interface GenerateApiKeyPayload {
+  name: string;
+  expiresAt?: string;
+}
+
+export interface GenerateApiKeyResponse extends ApiKey {
+  /** Full key shown exactly once at creation time. */
+  key: string;
+}
+
+export const apiKeysApi = {
+  list(): Promise<ApiKey[]> {
+    return apiClient('/api-keys');
+  },
+
+  generate(payload: GenerateApiKeyPayload): Promise<GenerateApiKeyResponse> {
+    return apiClient('/api-keys', { method: 'POST', body: JSON.stringify(payload) });
+  },
+
+  revoke(id: string): Promise<void> {
+    return apiClient(`/api-keys/${id}`, { method: 'DELETE' });
+  },
+};

--- a/frontend/lib/api/webhook.api.ts
+++ b/frontend/lib/api/webhook.api.ts
@@ -1,0 +1,52 @@
+import { apiClient } from './client';
+
+export interface Webhook {
+  id: string;
+  url: string;
+  events: string[];
+  createdAt: string;
+  lastDeliveryStatus: 'never' | 'success' | 'failed' | null;
+}
+
+export interface RegisterWebhookPayload {
+  url: string;
+  events: string[];
+}
+
+export interface TestPingResult {
+  delivered: boolean;
+  statusCode: number;
+  responseTimeMs: number;
+}
+
+export const WEBHOOK_EVENTS = [
+  'shipment_created',
+  'shipment_accepted',
+  'shipment_in_transit',
+  'shipment_delivered',
+  'shipment_completed',
+  'shipment_cancelled',
+  'shipment_disputed',
+] as const;
+
+export const webhookApi = {
+  list(): Promise<Webhook[]> {
+    return apiClient('/webhooks');
+  },
+
+  register(payload: RegisterWebhookPayload): Promise<Webhook> {
+    return apiClient('/webhooks', { method: 'POST', body: JSON.stringify(payload) });
+  },
+
+  delete(id: string): Promise<void> {
+    return apiClient(`/webhooks/${id}`, { method: 'DELETE' });
+  },
+
+  testPing(id: string): Promise<TestPingResult> {
+    return apiClient(`/webhooks/${id}/test`, { method: 'POST' });
+  },
+
+  getSecret(id: string): Promise<{ secret: string }> {
+    return apiClient(`/webhooks/${id}/secret`);
+  },
+};


### PR DESCRIPTION
## Summary

Builds the Webhooks Management UI and API Keys Developer Settings pages.

## Changes

- **`frontend/lib/api/webhook.api.ts`**: Typed API client for `list`, `register`, `delete`, `testPing`, `getSecret`
- **`frontend/lib/api/api-keys.api.ts`**: Typed API client for `list`, `generate`, `revoke`
- **`frontend/app/(dashboard)/settings/layout.tsx`**: New settings sidebar layout with nav links to Profile, Notifications, Security, Webhooks, API Keys
- **`frontend/app/(dashboard)/settings/webhooks/page.tsx`**:
  - Table of registered webhooks with URL, created date, last delivery status badge
  - Register Webhook modal with HTTPS URL validation and event type checkboxes
  - Test Ping â€” calls `POST /webhooks/:id/test`, shows inline delivery result (status code + response time)
  - Copy HMAC Secret â€” calls `GET /webhooks/:id/secret`, copies to clipboard
  - Delete with confirmation dialog
- **`frontend/app/(dashboard)/settings/api-keys/page.tsx`**:
  - Table of API keys with name, prefix, created date, last used, status
  - Generate Key modal â€” shows full key exactly once with copy button
  - Revoke with confirmation dialog, key reflects as Revoked immediately

## Acceptance Criteria Met

- /settings/webhooks lists webhooks with metadata
- Webhook registration modal validates HTTPS URL and saves
- Test Ping shows inline delivery result
- Copy HMAC Secret copies to clipboard
- Webhook delete removes after confirmation
- /settings/api-keys lists keys with prefix, dates, status
- Generate Key modal shows full key once with copy button
- Revoking reflects immediately in table
- Settings sidebar links to all settings sub-pages

Closes #968
