### PR TITLE
[BE-12] Persistent Notification Entity + Read/Inbox Endpoints

### DIFF
--- a/backend/src/notifications/dto/notification-query.dto.ts
+++ b/backend/src/notifications/dto/notification-query.dto.ts
@@ -1,0 +1,30 @@
+import { IsOptional, IsEnum, IsPositive, IsBoolean, Max } from 'class-validator';
+import { Type, Transform } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { NotificationType } from '../entities/notification.entity';
+
+export class NotificationQueryDto {
+  @ApiPropertyOptional({ default: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsPositive()
+  page?: number = 1;
+
+  @ApiPropertyOptional({ default: 20 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsPositive()
+  @Max(100)
+  limit?: number = 20;
+
+  @ApiPropertyOptional({ enum: NotificationType })
+  @IsOptional()
+  @IsEnum(NotificationType)
+  type?: NotificationType;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Transform(({ value }) => value === 'true' || value === true)
+  @IsBoolean()
+  isRead?: boolean;
+}

--- a/backend/src/notifications/entities/notification.entity.ts
+++ b/backend/src/notifications/entities/notification.entity.ts
@@ -1,0 +1,55 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+
+export enum NotificationType {
+  SHIPMENT_CREATED = 'shipment_created',
+  SHIPMENT_ACCEPTED = 'shipment_accepted',
+  SHIPMENT_IN_TRANSIT = 'shipment_in_transit',
+  SHIPMENT_DELIVERED = 'shipment_delivered',
+  SHIPMENT_COMPLETED = 'shipment_completed',
+  SHIPMENT_CANCELLED = 'shipment_cancelled',
+  SHIPMENT_DISPUTED = 'shipment_disputed',
+  SHIPMENT_DISPUTE_RESOLVED = 'shipment_dispute_resolved',
+  GENERAL = 'general',
+}
+
+@Entity('notifications')
+@Index(['userId', 'isRead'])
+@Index(['userId', 'createdAt'])
+export class Notification {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'userId' })
+  user: User;
+
+  @Column({ type: 'enum', enum: NotificationType, default: NotificationType.GENERAL })
+  type: NotificationType;
+
+  @Column({ type: 'varchar', length: 255 })
+  title: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @Column({ type: 'boolean', default: false })
+  isRead: boolean;
+
+  @Column({ type: 'jsonb', nullable: true })
+  metadata: Record<string, unknown> | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/notifications/notification-inbox.controller.ts
+++ b/backend/src/notifications/notification-inbox.controller.ts
@@ -1,0 +1,57 @@
+import {
+  Controller,
+  Get,
+  Patch,
+  Param,
+  Query,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { NotificationInboxService } from './notification-inbox.service';
+import { NotificationQueryDto } from './dto/notification-query.dto';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { User } from '../users/entities/user.entity';
+
+@ApiTags('Notification Inbox')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('notifications/inbox')
+export class NotificationInboxController {
+  constructor(private readonly inboxService: NotificationInboxService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Fetch my notification inbox (paginated)' })
+  async getInbox(@CurrentUser() user: User, @Query() query: NotificationQueryDto) {
+    return this.inboxService.findAll(user.id, query.page, query.limit, query.isRead);
+  }
+
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Get unread notification count' })
+  async unreadCount(@CurrentUser() user: User) {
+    const count = await this.inboxService.unreadCount(user.id);
+    return { unreadCount: count };
+  }
+
+  @Patch(':id/read')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mark a notification as read' })
+  async markRead(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+  ) {
+    await this.inboxService.markRead(id, user.id);
+    return { message: 'Notification marked as read' };
+  }
+
+  @Patch('read-all')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Mark all notifications as read' })
+  async markAllRead(@CurrentUser() user: User) {
+    await this.inboxService.markAllRead(user.id);
+    return { message: 'All notifications marked as read' };
+  }
+}

--- a/backend/src/notifications/notification-inbox.service.ts
+++ b/backend/src/notifications/notification-inbox.service.ts
@@ -1,0 +1,53 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Notification, NotificationType } from './entities/notification.entity';
+
+export interface CreateNotificationInput {
+  userId: string;
+  type: NotificationType;
+  title: string;
+  message: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable()
+export class NotificationInboxService {
+  constructor(
+    @InjectRepository(Notification)
+    private readonly repo: Repository<Notification>,
+  ) {}
+
+  async create(input: CreateNotificationInput): Promise<Notification> {
+    return this.repo.save(this.repo.create(input));
+  }
+
+  async findAll(userId: string, page = 1, limit = 20, isRead?: boolean) {
+    const where: { userId: string; isRead?: boolean } = { userId };
+    if (isRead !== undefined) where.isRead = isRead;
+
+    const [items, total] = await this.repo.findAndCount({
+      where,
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+    const unread = await this.repo.count({ where: { userId, isRead: false } });
+    return { items, total, unread, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async markRead(id: string, userId: string): Promise<void> {
+    const item = await this.repo.findOne({ where: { id, userId } });
+    if (!item) throw new NotFoundException('Notification not found');
+    item.isRead = true;
+    await this.repo.save(item);
+  }
+
+  async markAllRead(userId: string): Promise<void> {
+    await this.repo.update({ userId, isRead: false }, { isRead: true });
+  }
+
+  async unreadCount(userId: string): Promise<number> {
+    return this.repo.count({ where: { userId, isRead: false } });
+  }
+}

--- a/backend/src/notifications/notifications.module.ts
+++ b/backend/src/notifications/notifications.module.ts
@@ -1,12 +1,17 @@
 import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import type { StringValue } from 'ms';
 import { NotificationsService } from './notifications.service';
 import { NotificationsGateway } from './notifications.gateway';
+import { NotificationInboxService } from './notification-inbox.service';
+import { NotificationInboxController } from './notification-inbox.controller';
+import { Notification } from './entities/notification.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([Notification]),
     JwtModule.registerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
@@ -18,6 +23,8 @@ import { NotificationsGateway } from './notifications.gateway';
       }),
     }),
   ],
-  providers: [NotificationsService, NotificationsGateway],
+  controllers: [NotificationInboxController],
+  providers: [NotificationsService, NotificationsGateway, NotificationInboxService],
+  exports: [NotificationInboxService],
 })
 export class NotificationsModule {}


### PR DESCRIPTION
## Summary

Adds a persistent `Notification` database entity and REST inbox endpoints so users can retrieve, read, and manage their notification history - even if they were offline when the event occurred.

## Changes

### New Files

**`backend/src/notifications/entities/notification.entity.ts`**
- `Notification` TypeORM entity with `userId`, `type` (enum), `title`, `message`, `isRead`, `metadata` (jsonb), `createdAt`
- Indexed on `(userId, isRead)` and `(userId, createdAt)` for efficient inbox queries
- `NotificationType` enum covering all existing shipment events

**`backend/src/notifications/notification-inbox.service.ts`**
- `NotificationInboxService` with `create`, `findAll` (paginated + unread count), `markRead`, `markAllRead`, `unreadCount`

**`backend/src/notifications/notification-inbox.controller.ts`**
- `GET /notifications/inbox` - paginated inbox with optional `isRead` filter
- `GET /notifications/inbox/unread-count` - unread badge count
- `PATCH /notifications/inbox/:id/read` - mark single notification read
- `PATCH /notifications/inbox/read-all` - mark all read
- JWT-guarded, user-scoped (never exposes other users' notifications)

**`backend/src/notifications/dto/notification-query.dto.ts`**
- Pagination and filter DTO (`page`, `limit`, `type`, `isRead`)

### Modified Files

**`backend/src/notifications/notifications.module.ts`**
- Added `TypeOrmModule.forFeature([Notification])`
- Registered `NotificationInboxController` and `NotificationInboxService`
- Exports `NotificationInboxService` for use by other modules

## Checklist
- [x] `Notification` entity persisted to Postgres via TypeORM
- [x] Inbox endpoints are user-scoped (`userId` from JWT)
- [x] Pagination + unread count returned on every inbox fetch
- [x] `markAllRead` uses a single bulk `UPDATE` query
- [x] CI lint and build pass

Closes #972