### PR TITLE
feat: [FE-06] Bid System Frontend — Bids Dashboard, Shipment Bids Tab & Counteroffer UI

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -2,8 +2,8 @@
 
 import * as React from 'react'
 import { useRouter } from 'next/navigation'
-import { authApi } from '@/frontend/lib/api/auth.api'
-import { ShieldCheck, ArrowLeft, Loader2, Lock } from 'lucide-react'
+import { authApi } from '@/lib/api/auth.api'
+import { ShieldCheck, ArrowLeft, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -54,8 +54,8 @@ export default function LoginPage() {
         // tokenStore.saveSessionTokens(response.accessToken, response.refreshToken)
         router.push('/dashboard')
       }
-    } catch (err: any) {
-      setGlobalError(err.message || 'Authentication sequence failure.')
+    } catch (err: unknown) {
+      setGlobalError((err as {message?: string}).message || 'Authentication sequence failure.')
     } finally {
       setLoading(false)
     }
@@ -76,9 +76,9 @@ export default function LoginPage() {
       // Successful verification path clears component states before routing
       setTempToken(null)
       router.push('/dashboard')
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Acceptance Criteria: Keep verification fields populated upon input rejections
-      setGlobalError(err.message || 'Invalid confirmation code. Please try again.')
+      setGlobalError((err as {message?: string}).message || 'Invalid confirmation code. Please try again.')
     } finally {
       setLoading(false)
     }

--- a/frontend/app/(dashboard)/bids/page.tsx
+++ b/frontend/app/(dashboard)/bids/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { toast } from 'sonner';
+import { bidApi, Bid, BidStatus } from '../../../lib/api/bid.api';
+import { Card, CardContent, CardHeader, CardTitle } from '../../../components/ui/card';
+import { Button } from '../../../components/ui/button';
+
+function getBidStatusClass(status: BidStatus): string {
+  switch (status) {
+    case 'PENDING': return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300';
+    case 'ACCEPTED':
+    case 'COUNTER_ACCEPTED': return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+    case 'REJECTED':
+    case 'COUNTER_REJECTED': return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+    case 'COUNTER_OFFERED': return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300';
+    case 'EXPIRED': return 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400';
+    default: return 'bg-muted text-muted-foreground';
+  }
+}
+
+function ExpiryCountdown({ expiresAt }: { expiresAt?: string }) {
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    if (!expiresAt) return;
+
+    const update = () => {
+      const diff = new Date(expiresAt).getTime() - Date.now();
+      if (diff <= 0) {
+        setLabel('Expired');
+        return;
+      }
+      const hours = Math.floor(diff / 3_600_000);
+      const mins = Math.floor((diff % 3_600_000) / 60_000);
+      setLabel(`Expires in ${hours}h ${mins}m`);
+    };
+
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  if (!expiresAt) return null;
+  const expired = label === 'Expired';
+  return (
+    <span className={`text-xs ${expired ? 'text-gray-400' : 'text-muted-foreground'}`}>
+      {label}
+    </span>
+  );
+}
+
+export default function BidsDashboardPage() {
+  const [bids, setBids] = useState<Bid[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const confirmRef = useRef<{ bidId: string; action: 'accept' | 'decline' } | null>(null);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const data = await bidApi.listMyBids();
+      setBids(data);
+    } catch {
+      toast.error('Failed to load bids');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const handleCounterAction = (bidId: string, action: 'accept' | 'decline') => {
+    confirmRef.current = { bidId, action };
+    setShowConfirm(true);
+  };
+
+  const confirmAction = async () => {
+    const ref = confirmRef.current;
+    if (!ref) return;
+    const bid = bids.find((b) => b.id === ref.bidId);
+    if (!bid) return;
+
+    setShowConfirm(false);
+    setActionLoading(ref.bidId);
+    try {
+      if (ref.action === 'accept') {
+        await bidApi.acceptCounter(bid.shipmentId, bid.id);
+        toast.success('Counter offer accepted');
+      } else {
+        await bidApi.declineCounter(bid.shipmentId, bid.id);
+        toast.success('Counter offer declined');
+      }
+      await load();
+    } catch {
+      toast.error('Action failed. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 max-w-5xl mx-auto space-y-3">
+        <div className="h-7 w-32 bg-muted rounded animate-pulse" />
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="h-16 bg-muted rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto space-y-6">
+      <h1 className="text-xl font-bold text-foreground">My Bids</h1>
+
+      {bids.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground text-sm">
+            You haven&apos;t submitted any bids yet.
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">All Bids</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-muted-foreground">
+                    <th className="text-left px-4 py-3 font-medium">Route</th>
+                    <th className="text-left px-4 py-3 font-medium">Tracking</th>
+                    <th className="text-right px-4 py-3 font-medium">Your Price</th>
+                    <th className="text-right px-4 py-3 font-medium">Counter</th>
+                    <th className="text-left px-4 py-3 font-medium">Status</th>
+                    <th className="text-left px-4 py-3 font-medium">Expiry</th>
+                    <th className="text-left px-4 py-3 font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bids.map((bid) => (
+                    <tr key={bid.id} className="border-b last:border-0 hover:bg-muted/30">
+                      <td className="px-4 py-3 text-foreground">
+                        {bid.shipment
+                          ? `${bid.shipment.origin} → ${bid.shipment.destination}`
+                          : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        {bid.shipment ? (
+                          <Link
+                            href={`/shipments/${bid.shipmentId}`}
+                            className="font-mono text-xs text-primary hover:underline"
+                          >
+                            {bid.shipment.trackingNumber}
+                          </Link>
+                        ) : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-right font-medium">
+                        ${Number(bid.proposedPrice).toLocaleString()}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {bid.counterPrice != null ? (
+                          <span className="text-amber-600 font-medium">
+                            ${Number(bid.counterPrice).toLocaleString()}
+                          </span>
+                        ) : '—'}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-medium ${getBidStatusClass(bid.status)}`}>
+                          {bid.status.replace('_', ' ')}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <ExpiryCountdown expiresAt={bid.expiresAt} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          {bid.status === 'COUNTER_OFFERED' && (
+                            <>
+                              <Button
+                                size="sm"
+                                disabled={actionLoading === bid.id}
+                                onClick={() => handleCounterAction(bid.id, 'accept')}
+                              >
+                                Accept Counter
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={actionLoading === bid.id}
+                                onClick={() => handleCounterAction(bid.id, 'decline')}
+                              >
+                                Decline Counter
+                              </Button>
+                            </>
+                          )}
+                          <Link
+                            href={`/shipments/${bid.shipmentId}`}
+                            className="text-xs text-primary hover:underline whitespace-nowrap"
+                          >
+                            View Shipment
+                          </Link>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Confirmation dialog */}
+      {showConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        >
+          <Card className="w-full max-w-sm mx-4">
+            <CardHeader>
+              <CardTitle id="confirm-title" className="text-base">
+                {confirmRef.current?.action === 'accept' ? 'Accept Counter Offer?' : 'Decline Counter Offer?'}
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <p className="text-sm text-muted-foreground">
+                {confirmRef.current?.action === 'accept'
+                  ? 'This will accept the counter offer and update the bid status.'
+                  : 'This will decline the counter offer.'}
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setShowConfirm(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={confirmAction}>Confirm</Button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/layout.tsx
+++ b/frontend/app/(dashboard)/layout.tsx
@@ -20,6 +20,7 @@ const CARRIER_NAV = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/shipments', label: 'My Jobs' },
   { href: '/marketplace', label: 'Marketplace' },
+  { href: '/bids', label: 'My Bids' },
 ];
 
 const ADMIN_NAV = [

--- a/frontend/app/(dashboard)/settings/security/page.tsx
+++ b/frontend/app/(dashboard)/settings/security/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import * as React from 'react'
-import { authApi, Setup2FAResponse } from '@/frontend/lib/api/auth.api'
+import { authApi, Setup2FAResponse } from '@/lib/api/auth.api'
 import { 
-  Shield, ShieldAlert, ShieldCheck, Copy, Check, 
+  ShieldAlert, ShieldCheck, Copy, Check, 
   Download, Loader2, KeyRound, Smartphone, AlertTriangle 
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -42,8 +42,8 @@ export default function SecuritySettingsPage() {
       setSetupData(data)
       setStep(1)
       setSetupModalOpen(true)
-    } catch (err: any) {
-      alert(err.message || 'Could not initialize 2FA configuration.')
+    } catch (err: unknown) {
+      alert((err as {message?: string}).message || 'Could not initialize 2FA configuration.')
     } finally {
       setLoading(false)
     }
@@ -59,8 +59,8 @@ export default function SecuritySettingsPage() {
       setRecoveryCodes(data.recoveryCodes)
       setIs2FAEnabled(true)
       setStep(3)
-    } catch (err: any) {
-      setInlineError(err.message)
+    } catch (err: unknown) {
+      setInlineError((err as {message?: string}).message ?? null)
     } finally {
       setLoading(false)
     }
@@ -75,8 +75,8 @@ export default function SecuritySettingsPage() {
       setIs2FAEnabled(false)
       setDisableModalOpen(false)
       setConfirmPassword('')
-    } catch (err: any) {
-      setInlineError(err.message)
+    } catch (err: unknown) {
+      setInlineError((err as {message?: string}).message ?? null)
     } finally {
       setLoading(false)
     }

--- a/frontend/app/(dashboard)/shipments/[id]/page.tsx
+++ b/frontend/app/(dashboard)/shipments/[id]/page.tsx
@@ -2,14 +2,326 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { toast } from 'sonner';
 import { Shipment, ShipmentStatus, ShipmentStatusHistory } from '../../../../types/shipment.types';
 import { shipmentApi } from '../../../../lib/api/shipment.api';
+import { bidApi, Bid, CounterBidPayload } from '../../../../lib/api/bid.api';
 import { useAuthStore } from '../../../../stores/auth.store';
 import { StatusBadge } from '../../../../components/shipment/status-badge';
 import { StatusTimeline } from '../../../../components/shipment/status-timeline';
 import { Button } from '../../../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../../../../components/ui/card';
+
+// ─── Expiry countdown ────────────────────────────────────────────────────────
+function ExpiryCountdown({ expiresAt }: { expiresAt?: string }) {
+  const [label, setLabel] = useState('');
+
+  useEffect(() => {
+    if (!expiresAt) return;
+    const update = () => {
+      const diff = new Date(expiresAt).getTime() - Date.now();
+      if (diff <= 0) { setLabel('Expired'); return; }
+      const hours = Math.floor(diff / 3_600_000);
+      const mins = Math.floor((diff % 3_600_000) / 60_000);
+      setLabel(`Expires in ${hours}h ${mins}m`);
+    };
+    update();
+    const id = setInterval(update, 60_000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  if (!expiresAt) return null;
+  return <span className="text-xs text-muted-foreground">{label}</span>;
+}
+
+// ─── Counter offer modal ─────────────────────────────────────────────────────
+function CounterModal({
+  bid,
+  onClose,
+  onSubmit,
+}: {
+  bid: Bid;
+  onClose: () => void;
+  onSubmit: (payload: CounterBidPayload) => Promise<void>;
+}) {
+  const [price, setPrice] = useState(String(bid.proposedPrice));
+  const [message, setMessage] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const counterPrice = Number(price);
+    if (!counterPrice || counterPrice <= 0) {
+      toast.error('Enter a valid counter price');
+      return;
+    }
+    setLoading(true);
+    try {
+      await onSubmit({ counterPrice, message: message.trim() || undefined });
+      onClose();
+    } catch {
+      toast.error('Failed to submit counter offer');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="counter-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    >
+      <Card className="w-full max-w-sm mx-4">
+        <CardHeader>
+          <CardTitle id="counter-modal-title" className="text-base">Counter Offer</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="counter-price" className="block text-sm font-medium mb-1">
+                Your counter price
+              </label>
+              <input
+                id="counter-price"
+                type="number"
+                min="0"
+                step="0.01"
+                value={price}
+                onChange={(e) => setPrice(e.target.value)}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                required
+              />
+            </div>
+            <div>
+              <label htmlFor="counter-message" className="block text-sm font-medium mb-1">
+                Message to carrier <span className="text-muted-foreground font-normal">(optional)</span>
+              </label>
+              <textarea
+                id="counter-message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                maxLength={500}
+                rows={3}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+              />
+              <p className="text-xs text-muted-foreground text-right">{message.length}/500</p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading ? 'Submitting…' : 'Submit Counter'}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Bids tab ────────────────────────────────────────────────────────────────
+function BidsTab({
+  shipment,
+  onBidAccepted,
+}: {
+  shipment: Shipment;
+  onBidAccepted: () => Promise<void>;
+}) {
+  const [bids, setBids] = useState<Bid[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actionBid, setActionBid] = useState<string | null>(null);
+  const [counterBid, setCounterBid] = useState<Bid | null>(null);
+  const [expandedMessages, setExpandedMessages] = useState<Set<string>>(new Set());
+
+  const loadBids = useCallback(async () => {
+    try {
+      const data = await bidApi.listBids(shipment.id);
+      setBids(data);
+    } catch {
+      toast.error('Failed to load bids');
+    } finally {
+      setLoading(false);
+    }
+  }, [shipment.id]);
+
+  useEffect(() => { loadBids(); }, [loadBids]);
+
+  const act = async (bidId: string, fn: () => Promise<unknown>, successMsg: string) => {
+    setActionBid(bidId);
+    try {
+      await fn();
+      toast.success(successMsg);
+      await loadBids();
+      if (successMsg.toLowerCase().includes('accepted')) await onBidAccepted();
+    } catch {
+      toast.error('Action failed. Please try again.');
+    } finally {
+      setActionBid(null);
+    }
+  };
+
+  const toggleMessage = (bidId: string) => {
+    setExpandedMessages((prev) => {
+      const next = new Set(prev);
+      if (next.has(bidId)) next.delete(bidId); else next.add(bidId);
+      return next;
+    });
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(2)].map((_, i) => (
+          <div key={i} className="h-24 bg-muted rounded animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (bids.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground text-center py-8">
+        No bids received yet. Carriers browsing the marketplace will submit bids here.
+      </p>
+    );
+  }
+
+  const fmt = (amount: number) =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: shipment.currency || 'USD' }).format(amount);
+
+  return (
+    <>
+      <div className="space-y-4">
+        {bids.map((bid) => {
+          const initials = `${bid.carrier.firstName[0]}${bid.carrier.lastName[0]}`;
+          const msgLong = (bid.message?.length ?? 0) > 100;
+          const expanded = expandedMessages.has(bid.id);
+          const busy = actionBid === bid.id;
+
+          return (
+            <Card key={bid.id}>
+              <CardContent className="p-4 space-y-3">
+                {/* Carrier info */}
+                <div className="flex items-center gap-3">
+                  <Link
+                    href={`/carriers/${bid.carrierId}`}
+                    className="flex items-center gap-3 hover:opacity-80"
+                    aria-label={`View carrier ${bid.carrier.firstName} ${bid.carrier.lastName}`}
+                  >
+                    <div className="h-9 w-9 rounded-full bg-primary/20 flex items-center justify-center text-xs font-bold text-primary flex-shrink-0">
+                      {initials}
+                    </div>
+                    <div>
+                      <p className="text-sm font-medium text-foreground">
+                        {bid.carrier.firstName} {bid.carrier.lastName}
+                      </p>
+                      {bid.carrier.rating != null && (
+                        <p className="text-xs text-muted-foreground" aria-label={`Rating: ${bid.carrier.rating} out of 5`}>
+                          {'★'.repeat(Math.round(bid.carrier.rating))}
+                          {'☆'.repeat(5 - Math.round(bid.carrier.rating))}
+                          {' '}({bid.carrier.rating.toFixed(1)})
+                        </p>
+                      )}
+                    </div>
+                  </Link>
+                  <div className="ml-auto text-right">
+                    <p className="text-lg font-bold text-foreground">{fmt(bid.proposedPrice)}</p>
+                    <p className="text-xs text-muted-foreground">
+                      Posted: {fmt(shipment.price)}
+                    </p>
+                  </div>
+                </div>
+
+                {/* Message */}
+                {bid.message && (
+                  <div className="text-sm text-muted-foreground">
+                    {msgLong && !expanded
+                      ? bid.message.slice(0, 100) + '…'
+                      : bid.message}
+                    {msgLong && (
+                      <button
+                        onClick={() => toggleMessage(bid.id)}
+                        className="ml-1 text-primary text-xs hover:underline"
+                      >
+                        {expanded ? 'Show less' : 'Show more'}
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Times */}
+                <div className="flex items-center gap-3 text-xs text-muted-foreground">
+                  <span>Submitted {new Date(bid.createdAt).toLocaleDateString()}</span>
+                  <ExpiryCountdown expiresAt={bid.expiresAt} />
+                </div>
+
+                {/* Actions — only for pending bids on a pending shipment */}
+                {shipment.status === ShipmentStatus.PENDING && bid.status === 'PENDING' && (
+                  <div className="flex flex-wrap gap-2 pt-1">
+                    <Button
+                      size="sm"
+                      disabled={busy}
+                      onClick={() =>
+                        act(bid.id, () => bidApi.acceptBid(shipment.id, bid.id), 'Bid accepted — carrier assigned!')
+                      }
+                    >
+                      Accept
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={busy}
+                      onClick={() => setCounterBid(bid)}
+                    >
+                      Counter Offer
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={busy}
+                      onClick={() =>
+                        act(bid.id, () => bidApi.rejectBid(shipment.id, bid.id), 'Bid rejected')
+                      }
+                    >
+                      Reject
+                    </Button>
+                  </div>
+                )}
+
+                {/* Show COUNTER_OFFERED status label */}
+                {bid.status === 'COUNTER_OFFERED' && (
+                  <p className="text-xs text-amber-600 font-medium">Counter offer sent</p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {counterBid && (
+        <CounterModal
+          bid={counterBid}
+          onClose={() => setCounterBid(null)}
+          onSubmit={async (payload) => {
+            await act(
+              counterBid.id,
+              () => bidApi.counterBid(shipment.id, counterBid.id, payload),
+              'Counter offer submitted',
+            );
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// ─── Main page ───────────────────────────────────────────────────────────────
+type Tab = 'details' | 'bids';
 
 export default function ShipmentDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -20,6 +332,7 @@ export default function ShipmentDetailPage() {
   const [history, setHistory] = useState<ShipmentStatusHistory[]>([]);
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>('details');
 
   const reload = useCallback(async () => {
     const [s, h] = await Promise.all([
@@ -73,6 +386,7 @@ export default function ShipmentDetailPage() {
   const isShipper = user?.id === shipment.shipperId;
   const isCarrier = user?.id === shipment.carrierId;
   const isAdmin = user?.role === 'admin';
+  const showBidsTab = isShipper && shipment.status === ShipmentStatus.PENDING;
 
   const formattedPrice = new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -100,206 +414,230 @@ export default function ShipmentDetailPage() {
         <StatusBadge status={shipment.status} />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-3">
-        {/* Left: details */}
-        <div className="lg:col-span-2 space-y-4">
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Cargo</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3 text-sm">
-              <p className="text-muted-foreground">{shipment.cargoDescription}</p>
-              <div className="grid grid-cols-2 gap-2 text-sm">
-                <div>
-                  <span className="text-muted-foreground">Weight</span>
-                  <p className="font-medium">{Number(shipment.weightKg).toLocaleString()} kg</p>
-                </div>
-                {shipment.volumeCbm && (
+      {/* Tabs */}
+      {showBidsTab && (
+        <div className="flex gap-1 border-b">
+          {(['details', 'bids'] as Tab[]).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-sm font-medium capitalize transition-colors border-b-2 -mb-px ${
+                activeTab === tab
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Bids tab content */}
+      {showBidsTab && activeTab === 'bids' ? (
+        <BidsTab shipment={shipment} onBidAccepted={reload} />
+      ) : (
+        <div className="grid gap-6 lg:grid-cols-3">
+          {/* Left: details */}
+          <div className="lg:col-span-2 space-y-4">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Cargo</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <p className="text-muted-foreground">{shipment.cargoDescription}</p>
+                <div className="grid grid-cols-2 gap-2 text-sm">
                   <div>
-                    <span className="text-muted-foreground">Volume</span>
-                    <p className="font-medium">{Number(shipment.volumeCbm)} m³</p>
+                    <span className="text-muted-foreground">Weight</span>
+                    <p className="font-medium">{Number(shipment.weightKg).toLocaleString()} kg</p>
                   </div>
-                )}
-                <div>
-                  <span className="text-muted-foreground">Price</span>
-                  <p className="font-semibold text-foreground">{formattedPrice}</p>
+                  {shipment.volumeCbm && (
+                    <div>
+                      <span className="text-muted-foreground">Volume</span>
+                      <p className="font-medium">{Number(shipment.volumeCbm)} m³</p>
+                    </div>
+                  )}
+                  <div>
+                    <span className="text-muted-foreground">Price</span>
+                    <p className="font-semibold text-foreground">{formattedPrice}</p>
+                  </div>
                 </div>
-              </div>
-              {shipment.notes && (
-                <p className="text-muted-foreground italic text-sm border-t pt-2">
-                  {shipment.notes}
-                </p>
-              )}
-            </CardContent>
-          </Card>
+                {shipment.notes && (
+                  <p className="text-muted-foreground italic text-sm border-t pt-2">
+                    {shipment.notes}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
 
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Parties</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Shipper</span>
-                <span className="font-medium">
-                  {shipment.shipper.firstName} {shipment.shipper.lastName}
-                </span>
-              </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">Carrier</span>
-                <span className="font-medium">
-                  {shipment.carrier
-                    ? `${shipment.carrier.firstName} ${shipment.carrier.lastName}`
-                    : '—'}
-                </span>
-              </div>
-            </CardContent>
-          </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Parties</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Shipper</span>
+                  <span className="font-medium">
+                    {shipment.shipper.firstName} {shipment.shipper.lastName}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Carrier</span>
+                  <span className="font-medium">
+                    {shipment.carrier
+                      ? `${shipment.carrier.firstName} ${shipment.carrier.lastName}`
+                      : '—'}
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
 
-          {/* Actions */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Actions</CardTitle>
-            </CardHeader>
-            <CardContent className="flex flex-wrap gap-2">
-              {/* Carrier actions */}
-              {shipment.status === ShipmentStatus.PENDING && !isShipper && (
-                <Button
-                  size="sm"
-                  disabled={actionLoading}
-                  onClick={() => act(() => shipmentApi.accept(shipment.id), 'Shipment accepted!')}
-                >
-                  Accept Job
-                </Button>
-              )}
-              {shipment.status === ShipmentStatus.ACCEPTED && isCarrier && (
-                <Button
-                  size="sm"
-                  disabled={actionLoading}
-                  onClick={() => act(() => shipmentApi.pickup(shipment.id), 'Marked as picked up!')}
-                >
-                  Mark Picked Up
-                </Button>
-              )}
-              {shipment.status === ShipmentStatus.IN_TRANSIT && isCarrier && (
-                <Button
-                  size="sm"
-                  disabled={actionLoading}
-                  onClick={() =>
-                    act(() => shipmentApi.markDelivered(shipment.id), 'Marked as delivered!')
-                  }
-                >
-                  Mark Delivered
-                </Button>
-              )}
-
-              {/* Shipper actions */}
-              {shipment.status === ShipmentStatus.DELIVERED && isShipper && (
-                <Button
-                  size="sm"
-                  disabled={actionLoading}
-                  onClick={() =>
-                    act(() => shipmentApi.confirmDelivery(shipment.id), 'Delivery confirmed!')
-                  }
-                >
-                  Confirm Delivery
-                </Button>
-              )}
-
-              {/* Cancel */}
-              {[ShipmentStatus.PENDING, ShipmentStatus.ACCEPTED].includes(shipment.status) &&
-                (isShipper || isCarrier || isAdmin) && (
+            {/* Actions */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Actions</CardTitle>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {/* Carrier actions */}
+                {shipment.status === ShipmentStatus.PENDING && !isShipper && (
                   <Button
                     size="sm"
-                    variant="outline"
+                    disabled={actionLoading}
+                    onClick={() => act(() => shipmentApi.accept(shipment.id), 'Shipment accepted!')}
+                  >
+                    Accept Job
+                  </Button>
+                )}
+                {shipment.status === ShipmentStatus.ACCEPTED && isCarrier && (
+                  <Button
+                    size="sm"
+                    disabled={actionLoading}
+                    onClick={() => act(() => shipmentApi.pickup(shipment.id), 'Marked as picked up!')}
+                  >
+                    Mark Picked Up
+                  </Button>
+                )}
+                {shipment.status === ShipmentStatus.IN_TRANSIT && isCarrier && (
+                  <Button
+                    size="sm"
                     disabled={actionLoading}
                     onClick={() =>
-                      act(() => shipmentApi.cancel(shipment.id, 'Cancelled by user'), 'Shipment cancelled')
+                      act(() => shipmentApi.markDelivered(shipment.id), 'Marked as delivered!')
                     }
                   >
-                    Cancel
+                    Mark Delivered
                   </Button>
                 )}
 
-              {/* Dispute */}
-              {[ShipmentStatus.IN_TRANSIT, ShipmentStatus.DELIVERED].includes(shipment.status) &&
-                (isShipper || isCarrier) && (
+                {/* Shipper actions */}
+                {shipment.status === ShipmentStatus.DELIVERED && isShipper && (
                   <Button
                     size="sm"
-                    variant="destructive"
                     disabled={actionLoading}
                     onClick={() =>
-                      act(
-                        () => shipmentApi.raiseDispute(shipment.id, 'Dispute raised by user'),
-                        'Dispute raised',
-                      )
+                      act(() => shipmentApi.confirmDelivery(shipment.id), 'Delivery confirmed!')
                     }
                   >
-                    Raise Dispute
+                    Confirm Delivery
                   </Button>
                 )}
 
-              {/* Admin resolve */}
-              {shipment.status === ShipmentStatus.DISPUTED && isAdmin && (
-                <>
-                  <Button
-                    size="sm"
-                    disabled={actionLoading}
-                    onClick={() =>
-                      act(
-                        () =>
-                          shipmentApi.resolveDispute(
-                            shipment.id,
-                            ShipmentStatus.COMPLETED,
-                            'Resolved by admin — completed',
-                          ),
-                        'Dispute resolved — completed',
-                      )
-                    }
-                  >
-                    Resolve: Complete
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={actionLoading}
-                    onClick={() =>
-                      act(
-                        () =>
-                          shipmentApi.resolveDispute(
-                            shipment.id,
-                            ShipmentStatus.CANCELLED,
-                            'Resolved by admin — cancelled',
-                          ),
-                        'Dispute resolved — cancelled',
-                      )
-                    }
-                  >
-                    Resolve: Cancel
-                  </Button>
-                </>
-              )}
+                {/* Cancel */}
+                {[ShipmentStatus.PENDING, ShipmentStatus.ACCEPTED].includes(shipment.status) &&
+                  (isShipper || isCarrier || isAdmin) && (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={actionLoading}
+                      onClick={() =>
+                        act(() => shipmentApi.cancel(shipment.id, 'Cancelled by user'), 'Shipment cancelled')
+                      }
+                    >
+                      Cancel
+                    </Button>
+                  )}
 
-              {[ShipmentStatus.COMPLETED, ShipmentStatus.CANCELLED].includes(shipment.status) && (
-                <p className="text-sm text-muted-foreground">
-                  This shipment is {shipment.status} — no further actions available.
-                </p>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                {/* Dispute */}
+                {[ShipmentStatus.IN_TRANSIT, ShipmentStatus.DELIVERED].includes(shipment.status) &&
+                  (isShipper || isCarrier) && (
+                    <Button
+                      size="sm"
+                      variant="destructive"
+                      disabled={actionLoading}
+                      onClick={() =>
+                        act(
+                          () => shipmentApi.raiseDispute(shipment.id, 'Dispute raised by user'),
+                          'Dispute raised',
+                        )
+                      }
+                    >
+                      Raise Dispute
+                    </Button>
+                  )}
 
-        {/* Right: timeline */}
-        <div>
-          <Card>
-            <CardHeader>
-              <CardTitle className="text-base">Status Timeline</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <StatusTimeline history={history} />
-            </CardContent>
-          </Card>
+                {/* Admin resolve */}
+                {shipment.status === ShipmentStatus.DISPUTED && isAdmin && (
+                  <>
+                    <Button
+                      size="sm"
+                      disabled={actionLoading}
+                      onClick={() =>
+                        act(
+                          () =>
+                            shipmentApi.resolveDispute(
+                              shipment.id,
+                              ShipmentStatus.COMPLETED,
+                              'Resolved by admin — completed',
+                            ),
+                          'Dispute resolved — completed',
+                        )
+                      }
+                    >
+                      Resolve: Complete
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      disabled={actionLoading}
+                      onClick={() =>
+                        act(
+                          () =>
+                            shipmentApi.resolveDispute(
+                              shipment.id,
+                              ShipmentStatus.CANCELLED,
+                              'Resolved by admin — cancelled',
+                            ),
+                          'Dispute resolved — cancelled',
+                        )
+                      }
+                    >
+                      Resolve: Cancel
+                    </Button>
+                  </>
+                )}
+
+                {[ShipmentStatus.COMPLETED, ShipmentStatus.CANCELLED].includes(shipment.status) && (
+                  <p className="text-sm text-muted-foreground">
+                    This shipment is {shipment.status} — no further actions available.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+
+          {/* Right: timeline */}
+          <div>
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Status Timeline</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <StatusTimeline history={history} />
+              </CardContent>
+            </Card>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -1,0 +1,25 @@
+import { type VariantProps, cva } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  },
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}

--- a/frontend/components/ui/checkbox.tsx
+++ b/frontend/components/ui/checkbox.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { cn } from '../../lib/utils';
+
+interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  onCheckedChange?: (checked: boolean) => void;
+}
+
+export function Checkbox({ className, onCheckedChange, onChange, ...props }: CheckboxProps) {
+  return (
+    <input
+      type="checkbox"
+      className={cn(
+        'h-4 w-4 rounded border border-input accent-primary cursor-pointer',
+        className,
+      )}
+      onChange={(e) => {
+        onChange?.(e);
+        onCheckedChange?.(e.target.checked);
+      }}
+      {...props}
+    />
+  );
+}

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn } from '../../lib/utils';
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+
+function DialogOverlay({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      className={cn('fixed inset-0 z-50 bg-black/50', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({ className, children, ...props }: React.ComponentProps<typeof DialogPrimitive.Content>) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        className={cn(
+          'fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border bg-background p-6 shadow-lg',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn('flex flex-col gap-1.5 mb-4', className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return <DialogPrimitive.Title className={cn('text-lg font-semibold', className)} {...props} />;
+}
+
+function DialogDescription({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export { Dialog, DialogTrigger, DialogClose, DialogContent, DialogHeader, DialogTitle, DialogDescription };

--- a/frontend/components/ui/separator.tsx
+++ b/frontend/components/ui/separator.tsx
@@ -1,0 +1,20 @@
+import { cn } from '../../lib/utils';
+
+interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: 'horizontal' | 'vertical';
+}
+
+export function Separator({ className, orientation = 'horizontal', ...props }: SeparatorProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px',
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/frontend/lib/api/bid.api.ts
+++ b/frontend/lib/api/bid.api.ts
@@ -1,0 +1,89 @@
+import { apiClient } from './client';
+
+export type BidStatus =
+  | 'PENDING'
+  | 'ACCEPTED'
+  | 'REJECTED'
+  | 'COUNTER_OFFERED'
+  | 'COUNTER_ACCEPTED'
+  | 'COUNTER_REJECTED'
+  | 'EXPIRED';
+
+export interface Bid {
+  id: string;
+  shipmentId: string;
+  carrierId: string;
+  carrier: {
+    id: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    rating?: number;
+  };
+  proposedPrice: number;
+  counterPrice?: number;
+  message?: string;
+  status: BidStatus;
+  expiresAt?: string;
+  createdAt: string;
+  updatedAt: string;
+  shipment?: {
+    id: string;
+    trackingNumber: string;
+    origin: string;
+    destination: string;
+    price: number;
+    currency: string;
+  };
+}
+
+export interface SubmitBidPayload {
+  proposedPrice: number;
+  message?: string;
+  expiresAt?: string;
+}
+
+export interface CounterBidPayload {
+  counterPrice: number;
+  message?: string;
+}
+
+export const bidApi = {
+  listBids(shipmentId: string): Promise<Bid[]> {
+    return apiClient(`/shipments/${shipmentId}/bids`);
+  },
+
+  listMyBids(): Promise<Bid[]> {
+    return apiClient('/bids/my');
+  },
+
+  submitBid(shipmentId: string, payload: SubmitBidPayload): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  acceptBid(shipmentId: string, bidId: string): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids/${bidId}/accept`, { method: 'PATCH' });
+  },
+
+  rejectBid(shipmentId: string, bidId: string): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids/${bidId}/reject`, { method: 'PATCH' });
+  },
+
+  counterBid(shipmentId: string, bidId: string, payload: CounterBidPayload): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids/${bidId}/counter`, {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  },
+
+  acceptCounter(shipmentId: string, bidId: string): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids/${bidId}/accept-counter`, { method: 'PATCH' });
+  },
+
+  declineCounter(shipmentId: string, bidId: string): Promise<Bid> {
+    return apiClient(`/shipments/${shipmentId}/bids/${bidId}/decline-counter`, { method: 'PATCH' });
+  },
+};


### PR DESCRIPTION
## Summary

Implements the bid system frontend as specified in issue #977.

## Implementation Details

### New files
- `frontend/lib/api/bid.api.ts` — Full bid API client: `listBids`, `listMyBids`, `submitBid`, `acceptBid`, `rejectBid`, `counterBid`, `acceptCounter`, `declineCounter`
- `frontend/app/(dashboard)/bids/page.tsx` — Carrier bids dashboard: table with route, tracking number (linked), proposed price, counter offer (amber highlight), status badges, live expiry countdown, Accept Counter / Decline Counter buttons with confirmation dialogs
- `frontend/components/ui/badge.tsx` — Badge component
- `frontend/components/ui/dialog.tsx` — Dialog component (Radix UI)
- `frontend/components/ui/checkbox.tsx` — Checkbox component
- `frontend/components/ui/separator.tsx` — Separator component

### Modified files
- `frontend/app/(dashboard)/layout.tsx` — Added "My Bids" to carrier sidebar nav
- `frontend/app/(dashboard)/shipments/[id]/page.tsx` — Added Bids tab (visible to shipment owner when status=`pending`): bid comparison cards with carrier avatar/initials, star rating, proposed vs posted price, collapsible message, expiry countdown, Accept / Counter Offer / Reject actions; Counter Offer modal with price input and optional message field
- `frontend/app/(auth)/login/page.tsx` — Fixed broken import path (`@/frontend/lib/api/auth.api` → `@/lib/api/auth.api`), fixed `no-explicit-any` lint errors
- `frontend/app/(dashboard)/settings/security/page.tsx` — Fixed broken import path, fixed `no-explicit-any` lint errors

## Validation

- ✅ `npm run build` passes cleanly (0 errors, 0 warnings)
- ✅ TypeScript: 0 errors in new/modified files
- ✅ All acceptance criteria addressed

## Closes

Closes #977