### PR TITLE
feat(bids): Counteroffer endpoints, bid expiry & notifications [BE-14]

### DIFF
--- a/backend/src/bids/bids-notifications.service.ts
+++ b/backend/src/bids/bids-notifications.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { OnEvent } from '@nestjs/event-emitter';
+import { MailerService } from '@nestjs-modules/mailer';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Bid } from './entities/bid.entity';
+import { Shipment } from '../shipments/entities/shipment.entity';
+import { User } from '../users/entities/user.entity';
+import { BID_COUNTERED, BID_COUNTER_DECLINED } from './bids.service';
+
+interface BidEvent {
+  bid: Bid;
+  shipment: Shipment;
+}
+
+@Injectable()
+export class BidsNotificationsService {
+  private readonly logger = new Logger(BidsNotificationsService.name);
+
+  constructor(
+    private readonly mailerService: MailerService,
+    @InjectRepository(Bid)
+    private readonly bidRepo: Repository<Bid>,
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  private async sendSafe(to: string, subject: string, html: string): Promise<void> {
+    try {
+      await this.mailerService.sendMail({ to, subject, html });
+    } catch (err: unknown) {
+      this.logger.warn(`Failed to send email to ${to}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  private wrap(title: string, body: string): string {
+    return `
+      <div style="font-family:sans-serif;max-width:600px;margin:0 auto;padding:24px;">
+        <h2 style="color:#1e40af;margin-bottom:16px;">${title}</h2>
+        ${body}
+        <hr style="margin:24px 0;border:none;border-top:1px solid #e5e7eb;" />
+        <p style="color:#9ca3af;font-size:12px;">FreightFlow — Decentralized Freight Management</p>
+      </div>`;
+  }
+
+  private async loadRelations(bid: Bid, shipment: Shipment): Promise<{ carrier: User | null; shipper: User | null }> {
+    const fullShipment = await this.shipmentRepo.findOne({
+      where: { id: shipment.id },
+      relations: ['shipper'],
+    });
+    const fullBid = await this.bidRepo.findOne({
+      where: { id: bid.id },
+      relations: ['carrier'],
+    });
+    return {
+      carrier: fullBid?.carrier ?? null,
+      shipper: fullShipment?.shipper ?? null,
+    };
+  }
+
+  @OnEvent(BID_COUNTERED)
+  async onBidCountered({ bid, shipment }: BidEvent): Promise<void> {
+    const { carrier } = await this.loadRelations(bid, shipment);
+    if (!carrier) return;
+
+    await this.sendSafe(
+      carrier.email,
+      `💬 New counteroffer on your bid`,
+      this.wrap(
+        'Shipper made a counteroffer',
+        `<p>Hi ${carrier.firstName},</p>
+         <p>The shipper has made a counteroffer of <strong>$${bid.counterPrice}</strong> on your bid.</p>
+         ${bid.counterMessage ? `<p><strong>Message:</strong> ${bid.counterMessage}</p>` : ''}
+         <p>Log in to FreightFlow to accept or decline this counteroffer.</p>`,
+      ),
+    );
+  }
+
+  @OnEvent(BID_COUNTER_DECLINED)
+  async onCounterDeclined({ bid, shipment }: BidEvent): Promise<void> {
+    const { shipper } = await this.loadRelations(bid, shipment);
+    if (!shipper) return;
+
+    await this.sendSafe(
+      shipper.email,
+      `❌ Carrier declined your counteroffer`,
+      this.wrap(
+        'Counteroffer declined',
+        `<p>Hi ${shipper.firstName},</p>
+         <p>The carrier has declined your counteroffer of <strong>$${bid.counterPrice}</strong>.</p>
+         <p>You may review other bids on your shipment.</p>`,
+      ),
+    );
+  }
+}

--- a/backend/src/bids/bids.controller.ts
+++ b/backend/src/bids/bids.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@nestjs/swagger';
 import { BidsService } from './bids.service';
 import { CreateBidDto } from './dto/create-bid.dto';
+import { CounterBidDto } from './dto/counter-bid.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -70,5 +71,54 @@ export class BidsController {
     @CurrentUser() user: User,
   ) {
     return this.bidsService.acceptBid(shipmentId, bidId, user.id);
+  }
+
+  @Post(':bidId/counter')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.SHIPPER)
+  @ApiOperation({ summary: 'Shipper makes a counteroffer on a bid' })
+  @ApiParam({ name: 'id', description: 'Shipment ID' })
+  @ApiParam({ name: 'bidId', description: 'Bid ID' })
+  @ApiResponse({ status: 200, description: 'Counteroffer submitted' })
+  counterBid(
+    @Param('id', ParseUUIDPipe) shipmentId: string,
+    @Param('bidId', ParseUUIDPipe) bidId: string,
+    @CurrentUser() user: User,
+    @Body() dto: CounterBidDto,
+  ) {
+    return this.bidsService.counterBid(shipmentId, bidId, user.id, dto);
+  }
+
+  @Patch(':bidId/accept-counter')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.CARRIER)
+  @ApiOperation({ summary: 'Carrier accepts the counteroffer' })
+  @ApiParam({ name: 'id', description: 'Shipment ID' })
+  @ApiParam({ name: 'bidId', description: 'Bid ID' })
+  @ApiResponse({ status: 200, description: 'Counter accepted' })
+  acceptCounter(
+    @Param('id', ParseUUIDPipe) shipmentId: string,
+    @Param('bidId', ParseUUIDPipe) bidId: string,
+    @CurrentUser() user: User,
+  ) {
+    return this.bidsService.acceptCounter(shipmentId, bidId, user.id);
+  }
+
+  @Patch(':bidId/decline-counter')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(RolesGuard)
+  @Roles(UserRole.CARRIER)
+  @ApiOperation({ summary: 'Carrier declines the counteroffer' })
+  @ApiParam({ name: 'id', description: 'Shipment ID' })
+  @ApiParam({ name: 'bidId', description: 'Bid ID' })
+  @ApiResponse({ status: 200, description: 'Counter declined' })
+  declineCounter(
+    @Param('id', ParseUUIDPipe) shipmentId: string,
+    @Param('bidId', ParseUUIDPipe) bidId: string,
+    @CurrentUser() user: User,
+  ) {
+    return this.bidsService.declineCounter(shipmentId, bidId, user.id);
   }
 }

--- a/backend/src/bids/bids.module.ts
+++ b/backend/src/bids/bids.module.ts
@@ -4,10 +4,11 @@ import { BidsService } from './bids.service';
 import { BidsController } from './bids.controller';
 import { Bid } from './entities/bid.entity';
 import { Shipment } from '../shipments/entities/shipment.entity';
+import { BidsNotificationsService } from './bids-notifications.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Bid, Shipment])],
   controllers: [BidsController],
-  providers: [BidsService],
+  providers: [BidsService, BidsNotificationsService],
 })
 export class BidsModule {}

--- a/backend/src/bids/bids.service.spec.ts
+++ b/backend/src/bids/bids.service.spec.ts
@@ -5,6 +5,7 @@ import {
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BidsService } from './bids.service';
 import { Bid, BidStatus } from './entities/bid.entity';
 import { Shipment } from '../shipments/entities/shipment.entity';
@@ -23,6 +24,8 @@ const mockShipmentRepo = () => ({
   update: jest.fn(),
 });
 
+const mockEventEmitter = () => ({ emit: jest.fn() });
+
 const pendingShipment = (overrides = {}): Partial<Shipment> => ({
   id: 'ship1',
   shipperId: 'shipper1',
@@ -30,10 +33,24 @@ const pendingShipment = (overrides = {}): Partial<Shipment> => ({
   ...overrides,
 });
 
+const makeBid = (overrides: Partial<Bid> = {}): Bid => {
+  const bid = Object.assign(new Bid(), {
+    id: 'bid1',
+    shipmentId: 'ship1',
+    carrierId: 'carrier1',
+    proposedPrice: 100,
+    status: BidStatus.PENDING,
+    expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    ...overrides,
+  });
+  return bid;
+};
+
 describe('BidsService', () => {
   let service: BidsService;
   let bidRepo: ReturnType<typeof mockBidRepo>;
   let shipmentRepo: ReturnType<typeof mockShipmentRepo>;
+  let eventEmitter: ReturnType<typeof mockEventEmitter>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -41,24 +58,29 @@ describe('BidsService', () => {
         BidsService,
         { provide: getRepositoryToken(Bid), useFactory: mockBidRepo },
         { provide: getRepositoryToken(Shipment), useFactory: mockShipmentRepo },
+        { provide: EventEmitter2, useFactory: mockEventEmitter },
       ],
     }).compile();
 
     service = module.get(BidsService);
     bidRepo = module.get(getRepositoryToken(Bid));
     shipmentRepo = module.get(getRepositoryToken(Shipment));
+    eventEmitter = module.get(EventEmitter2);
   });
 
   describe('submitBid', () => {
-    it('creates a bid on a PENDING shipment', async () => {
+    it('creates a bid with expiresAt on a PENDING shipment', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
       bidRepo.findOne.mockResolvedValue(null);
-      const bid = { id: 'bid1', shipmentId: 'ship1', carrierId: 'carrier1', proposedPrice: 100 };
+      const bid = makeBid();
       bidRepo.create.mockReturnValue(bid);
       bidRepo.save.mockResolvedValue(bid);
 
       const result = await service.submitBid('ship1', 'carrier1', { proposedPrice: 100 });
-      expect(result).toEqual(bid);
+      expect(result).toMatchObject({ id: 'bid1' });
+      expect(bidRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ expiresAt: expect.any(Date) }),
+      );
     });
 
     it('throws if shipment not PENDING', async () => {
@@ -68,7 +90,7 @@ describe('BidsService', () => {
 
     it('throws if carrier already has a pending bid', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
-      bidRepo.findOne.mockResolvedValue({ id: 'existing' });
+      bidRepo.findOne.mockResolvedValue(makeBid());
       await expect(service.submitBid('ship1', 'carrier1', { proposedPrice: 100 })).rejects.toThrow(BadRequestException);
     });
   });
@@ -79,18 +101,19 @@ describe('BidsService', () => {
       await expect(service.getBids('ship1', 'shipper1')).rejects.toThrow(ForbiddenException);
     });
 
-    it('returns bids for the shipment owner', async () => {
+    it('returns bids with isExpired for the shipment owner', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
-      bidRepo.find.mockResolvedValue([]);
+      bidRepo.find.mockResolvedValue([makeBid()]);
       const result = await service.getBids('ship1', 'shipper1');
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toHaveProperty('isExpired');
     });
   });
 
   describe('acceptBid', () => {
     it('accepts bid and rejects others', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
-      const bid = { id: 'bid1', shipmentId: 'ship1', carrierId: 'carrier1', status: BidStatus.PENDING };
+      const bid = makeBid();
       bidRepo.findOne.mockResolvedValue(bid);
       bidRepo.save.mockResolvedValue({ ...bid, status: BidStatus.ACCEPTED });
       bidRepo.update.mockResolvedValue(undefined);
@@ -102,6 +125,13 @@ describe('BidsService', () => {
       expect(shipmentRepo.update).toHaveBeenCalledWith('ship1', expect.objectContaining({ carrierId: 'carrier1' }));
     });
 
+    it('throws BadRequestException for expired bid', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      const expired = makeBid({ expiresAt: new Date(Date.now() - 1000) });
+      bidRepo.findOne.mockResolvedValue(expired);
+      await expect(service.acceptBid('ship1', 'bid1', 'shipper1')).rejects.toThrow(BadRequestException);
+    });
+
     it('throws ForbiddenException if not the shipper', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment({ shipperId: 'other' }));
       await expect(service.acceptBid('ship1', 'bid1', 'shipper1')).rejects.toThrow(ForbiddenException);
@@ -111,6 +141,76 @@ describe('BidsService', () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
       bidRepo.findOne.mockResolvedValue(null);
       await expect(service.acceptBid('ship1', 'bid1', 'shipper1')).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('counterBid', () => {
+    it('sets bid to COUNTER_OFFERED and emits event', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      const bid = makeBid();
+      bidRepo.findOne.mockResolvedValue(bid);
+      bidRepo.save.mockResolvedValue({ ...bid, status: BidStatus.COUNTER_OFFERED, counterPrice: 90 });
+
+      const result = await service.counterBid('ship1', 'bid1', 'shipper1', { counterPrice: 90 });
+      expect(result.status).toBe(BidStatus.COUNTER_OFFERED);
+      expect(eventEmitter.emit).toHaveBeenCalledWith('bid.countered', expect.anything());
+    });
+
+    it('throws if bid is expired', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      bidRepo.findOne.mockResolvedValue(makeBid({ expiresAt: new Date(Date.now() - 1000) }));
+      await expect(service.counterBid('ship1', 'bid1', 'shipper1', { counterPrice: 90 })).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws ForbiddenException if not shipper', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment({ shipperId: 'other' }));
+      await expect(service.counterBid('ship1', 'bid1', 'shipper1', { counterPrice: 90 })).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('acceptCounter', () => {
+    it('accepts the counter, assigns carrier, emits shipment.accepted', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      const bid = makeBid({ status: BidStatus.COUNTER_OFFERED, counterPrice: 90 });
+      bidRepo.findOne.mockResolvedValue(bid);
+      bidRepo.save.mockResolvedValue({ ...bid, status: BidStatus.COUNTER_ACCEPTED });
+      bidRepo.update.mockResolvedValue(undefined);
+      shipmentRepo.update.mockResolvedValue(undefined);
+
+      const result = await service.acceptCounter('ship1', 'bid1', 'carrier1');
+      expect(result.status).toBe(BidStatus.COUNTER_ACCEPTED);
+      expect(eventEmitter.emit).toHaveBeenCalledWith('shipment.accepted', expect.anything());
+    });
+
+    it('throws ForbiddenException if not the bid owner', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      bidRepo.findOne.mockResolvedValue(makeBid({ status: BidStatus.COUNTER_OFFERED }));
+      await expect(service.acceptCounter('ship1', 'bid1', 'other-carrier')).rejects.toThrow(ForbiddenException);
+    });
+
+    it('throws BadRequestException if not in COUNTER_OFFERED status', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      bidRepo.findOne.mockResolvedValue(makeBid({ status: BidStatus.PENDING }));
+      await expect(service.acceptCounter('ship1', 'bid1', 'carrier1')).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  describe('declineCounter', () => {
+    it('sets bid to REJECTED and emits event', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      const bid = makeBid({ status: BidStatus.COUNTER_OFFERED, counterPrice: 90 });
+      bidRepo.findOne.mockResolvedValue(bid);
+      bidRepo.save.mockResolvedValue({ ...bid, status: BidStatus.REJECTED });
+
+      const result = await service.declineCounter('ship1', 'bid1', 'carrier1');
+      expect(result.status).toBe(BidStatus.REJECTED);
+      expect(eventEmitter.emit).toHaveBeenCalledWith('bid.counter_declined', expect.anything());
+    });
+
+    it('throws ForbiddenException if not the bid owner', async () => {
+      shipmentRepo.findOne.mockResolvedValue(pendingShipment());
+      bidRepo.findOne.mockResolvedValue(makeBid({ status: BidStatus.COUNTER_OFFERED }));
+      await expect(service.declineCounter('ship1', 'bid1', 'other')).rejects.toThrow(ForbiddenException);
     });
   });
 });

--- a/backend/src/bids/bids.service.ts
+++ b/backend/src/bids/bids.service.ts
@@ -6,10 +6,21 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Not, Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
 import { Bid, BidStatus } from './entities/bid.entity';
 import { Shipment } from '../shipments/entities/shipment.entity';
 import { ShipmentStatus } from '../common/enums/shipment-status.enum';
 import { CreateBidDto } from './dto/create-bid.dto';
+import { CounterBidDto } from './dto/counter-bid.dto';
+
+const BID_EXPIRY_HOURS = 48;
+
+export const BID_COUNTERED = 'bid.countered';
+export const BID_COUNTER_DECLINED = 'bid.counter_declined';
+
+export interface BidWithExpiry extends Bid {
+  isExpired: boolean;
+}
 
 @Injectable()
 export class BidsService {
@@ -18,6 +29,7 @@ export class BidsService {
     private readonly bidRepo: Repository<Bid>,
     @InjectRepository(Shipment)
     private readonly shipmentRepo: Repository<Shipment>,
+    private readonly eventEmitter: EventEmitter2,
   ) {}
 
   private async getShipment(shipmentId: string): Promise<Shipment> {
@@ -28,11 +40,26 @@ export class BidsService {
     return shipment;
   }
 
+  private async getBidOrFail(bidId: string, shipmentId: string): Promise<Bid> {
+    const bid = await this.bidRepo.findOne({ where: { id: bidId, shipmentId }, relations: ['carrier'] });
+    if (!bid) throw new NotFoundException(`Bid ${bidId} not found`);
+    return bid;
+  }
+
+  private addIsExpired(bid: Bid): BidWithExpiry {
+    const isExpired = !!bid.expiresAt && new Date() > new Date(bid.expiresAt);
+    return { ...bid, isExpired } as BidWithExpiry;
+  }
+
+  private isBidExpired(bid: Bid): boolean {
+    return !!bid.expiresAt && new Date() > new Date(bid.expiresAt);
+  }
+
   async submitBid(
     shipmentId: string,
     carrierId: string,
     dto: CreateBidDto,
-  ): Promise<Bid> {
+  ): Promise<BidWithExpiry> {
     const shipment = await this.getShipment(shipmentId);
     if (shipment.status !== ShipmentStatus.PENDING) {
       throw new BadRequestException('Bids can only be placed on PENDING shipments');
@@ -45,25 +72,31 @@ export class BidsService {
       throw new BadRequestException('You already have a pending bid on this shipment');
     }
 
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + BID_EXPIRY_HOURS);
+
     const bid = this.bidRepo.create({
       shipmentId,
       carrierId,
       proposedPrice: dto.proposedPrice,
       message: dto.message ?? null,
+      expiresAt,
     });
-    return this.bidRepo.save(bid);
+    const saved = await this.bidRepo.save(bid);
+    return this.addIsExpired(saved);
   }
 
-  async getBids(shipmentId: string, requesterId: string): Promise<Bid[]> {
+  async getBids(shipmentId: string, requesterId: string): Promise<BidWithExpiry[]> {
     const shipment = await this.getShipment(shipmentId);
     if (shipment.shipperId !== requesterId) {
       throw new ForbiddenException('Only the shipment owner can view bids');
     }
-    return this.bidRepo.find({
+    const bids = await this.bidRepo.find({
       where: { shipmentId },
       relations: ['carrier'],
       order: { proposedPrice: 'ASC' },
     });
+    return bids.map(b => this.addIsExpired(b));
   }
 
   async acceptBid(
@@ -79,27 +112,113 @@ export class BidsService {
       throw new BadRequestException('Shipment is no longer accepting bids');
     }
 
-    const bid = await this.bidRepo.findOne({ where: { id: bidId, shipmentId } });
-    if (!bid) throw new NotFoundException(`Bid ${bidId} not found`);
+    const bid = await this.getBidOrFail(bidId, shipmentId);
     if (bid.status !== BidStatus.PENDING) {
       throw new BadRequestException('Bid is no longer pending');
     }
+    if (this.isBidExpired(bid)) {
+      throw new BadRequestException('This bid has expired and cannot be accepted');
+    }
 
-    // Accept this bid
     bid.status = BidStatus.ACCEPTED;
     await this.bidRepo.save(bid);
 
-    // Reject all other pending bids for this shipment
     await this.bidRepo.update(
       { shipmentId, status: BidStatus.PENDING, id: Not(bidId) },
       { status: BidStatus.REJECTED },
     );
 
-    // Assign carrier to shipment
     await this.shipmentRepo.update(shipmentId, {
       carrierId: bid.carrierId,
       status: ShipmentStatus.ACCEPTED,
     });
+
+    return bid;
+  }
+
+  async counterBid(
+    shipmentId: string,
+    bidId: string,
+    requesterId: string,
+    dto: CounterBidDto,
+  ): Promise<BidWithExpiry> {
+    const shipment = await this.getShipment(shipmentId);
+    if (shipment.shipperId !== requesterId) {
+      throw new ForbiddenException('Only the shipment owner can make a counteroffer');
+    }
+
+    const bid = await this.getBidOrFail(bidId, shipmentId);
+    if (bid.status !== BidStatus.PENDING) {
+      throw new BadRequestException('Can only counter a PENDING bid');
+    }
+    if (this.isBidExpired(bid)) {
+      throw new BadRequestException('This bid has expired and cannot be countered');
+    }
+
+    bid.counterPrice = dto.counterPrice;
+    bid.counterMessage = dto.counterMessage ?? null;
+    bid.status = BidStatus.COUNTER_OFFERED;
+    bid.counterOfferedAt = new Date();
+    const saved = await this.bidRepo.save(bid);
+
+    this.eventEmitter.emit(BID_COUNTERED, { bid: saved, shipment });
+
+    return this.addIsExpired(saved);
+  }
+
+  async acceptCounter(
+    shipmentId: string,
+    bidId: string,
+    requesterId: string,
+  ): Promise<Bid> {
+    const shipment = await this.getShipment(shipmentId);
+    const bid = await this.getBidOrFail(bidId, shipmentId);
+
+    if (bid.carrierId !== requesterId) {
+      throw new ForbiddenException('Only the bid owner can accept the counter');
+    }
+    if (bid.status !== BidStatus.COUNTER_OFFERED) {
+      throw new BadRequestException('Bid is not in COUNTER_OFFERED status');
+    }
+
+    bid.status = BidStatus.COUNTER_ACCEPTED;
+    bid.proposedPrice = bid.counterPrice!;
+    await this.bidRepo.save(bid);
+
+    await this.bidRepo.update(
+      { shipmentId, status: BidStatus.PENDING, id: Not(bidId) },
+      { status: BidStatus.REJECTED },
+    );
+
+    await this.shipmentRepo.update(shipmentId, {
+      carrierId: bid.carrierId,
+      status: ShipmentStatus.ACCEPTED,
+    });
+
+    this.eventEmitter.emit('shipment.accepted', { shipment, actorId: requesterId });
+
+    return bid;
+  }
+
+  async declineCounter(
+    shipmentId: string,
+    bidId: string,
+    requesterId: string,
+  ): Promise<Bid> {
+    const bid = await this.getBidOrFail(bidId, shipmentId);
+    const shipment = await this.getShipment(shipmentId);
+
+    if (bid.carrierId !== requesterId) {
+      throw new ForbiddenException('Only the bid owner can decline the counter');
+    }
+    if (bid.status !== BidStatus.COUNTER_OFFERED) {
+      throw new BadRequestException('Bid is not in COUNTER_OFFERED status');
+    }
+
+    bid.status = BidStatus.REJECTED;
+    await this.bidRepo.save(bid);
+
+    this.eventEmitter.emit(BID_COUNTER_DECLINED, { bid, shipment });
 
     return bid;
   }

--- a/backend/src/bids/dto/counter-bid.dto.ts
+++ b/backend/src/bids/dto/counter-bid.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsPositive, IsString } from 'class-validator';
+
+export class CounterBidDto {
+  @ApiProperty({ example: 1200.0 })
+  @IsNumber()
+  @IsPositive()
+  counterPrice: number;
+
+  @ApiPropertyOptional({ example: 'We can do it for a lower price.' })
+  @IsString()
+  @IsOptional()
+  counterMessage?: string;
+}

--- a/backend/src/bids/entities/bid.entity.ts
+++ b/backend/src/bids/entities/bid.entity.ts
@@ -14,6 +14,10 @@ export enum BidStatus {
   PENDING = 'PENDING',
   ACCEPTED = 'ACCEPTED',
   REJECTED = 'REJECTED',
+  COUNTER_OFFERED = 'COUNTER_OFFERED',
+  COUNTER_ACCEPTED = 'COUNTER_ACCEPTED',
+  COUNTER_REJECTED = 'COUNTER_REJECTED',
+  EXPIRED = 'EXPIRED',
 }
 
 @Entity('bids')
@@ -44,6 +48,18 @@ export class Bid {
 
   @Column({ type: 'enum', enum: BidStatus, default: BidStatus.PENDING })
   status: BidStatus;
+
+  @Column({ name: 'counter_price', type: 'decimal', precision: 14, scale: 2, nullable: true })
+  counterPrice: number | null;
+
+  @Column({ name: 'counter_message', type: 'text', nullable: true })
+  counterMessage: string | null;
+
+  @Column({ name: 'expires_at', type: 'timestamptz', nullable: true })
+  expiresAt: Date | null;
+
+  @Column({ name: 'counter_offered_at', type: 'timestamptz', nullable: true })
+  counterOfferedAt: Date | null;
 
   @CreateDateColumn({ name: 'created_at' })
   createdAt: Date;

--- a/backend/src/migrations/1750678212610-BidCounterOfferAndExpiry.ts
+++ b/backend/src/migrations/1750678212610-BidCounterOfferAndExpiry.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class BidCounterOfferAndExpiry1750678212610 implements MigrationInterface {
+  name = 'BidCounterOfferAndExpiry1750678212610';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Extend the BidStatus enum with new values
+    await queryRunner.query(`ALTER TYPE "public"."bids_status_enum" ADD VALUE IF NOT EXISTS 'COUNTER_OFFERED'`);
+    await queryRunner.query(`ALTER TYPE "public"."bids_status_enum" ADD VALUE IF NOT EXISTS 'COUNTER_ACCEPTED'`);
+    await queryRunner.query(`ALTER TYPE "public"."bids_status_enum" ADD VALUE IF NOT EXISTS 'COUNTER_REJECTED'`);
+    await queryRunner.query(`ALTER TYPE "public"."bids_status_enum" ADD VALUE IF NOT EXISTS 'EXPIRED'`);
+
+    // Add new columns
+    await queryRunner.query(`ALTER TABLE "bids" ADD "counter_price" numeric(14,2)`);
+    await queryRunner.query(`ALTER TABLE "bids" ADD "counter_message" text`);
+    await queryRunner.query(`ALTER TABLE "bids" ADD "expires_at" TIMESTAMP WITH TIME ZONE`);
+    await queryRunner.query(`ALTER TABLE "bids" ADD "counter_offered_at" TIMESTAMP WITH TIME ZONE`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "bids" DROP COLUMN "counter_offered_at"`);
+    await queryRunner.query(`ALTER TABLE "bids" DROP COLUMN "expires_at"`);
+    await queryRunner.query(`ALTER TABLE "bids" DROP COLUMN "counter_message"`);
+    await queryRunner.query(`ALTER TABLE "bids" DROP COLUMN "counter_price"`);
+
+    // Note: PostgreSQL does not support removing enum values directly.
+    // To revert enum values, recreate the type without the new values if needed.
+  }
+}

--- a/backend/src/users/entities/user.entity.ts
+++ b/backend/src/users/entities/user.entity.ts
@@ -5,6 +5,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  OneToMany,
 } from 'typeorm';
 import { UserRole } from '../../common/enums/role.enum';
 import { TwoFactorRecovery } from './two-factor-recovery.entity';


### PR DESCRIPTION
## Summary

Implements [BE-14] — adds counteroffer negotiation capability and bid expiry to the bid system.

## Changes

### Entity & Enum (`bid.entity.ts`)
- Added 4 new `BidStatus` values: `COUNTER_OFFERED`, `COUNTER_ACCEPTED`, `COUNTER_REJECTED`, `EXPIRED`
- Added columns: `counterPrice`, `counterMessage`, `expiresAt`, `counterOfferedAt`

### New Endpoints (`BidsController` / `BidsService`)
- `POST /shipments/:id/bids/:bidId/counter` (SHIPPER) — submit a counteroffer; validates PENDING status and expiry; emits `bid.countered` event
- `PATCH /shipments/:id/bids/:bidId/accept-counter` (CARRIER) — accept counter; assigns carrier to shipment, rejects other bids; emits `shipment.accepted`
- `PATCH /shipments/:id/bids/:bidId/decline-counter` (CARRIER) — sets status to REJECTED; emits `bid.counter_declined`

### Bid Expiry
- `createBid` sets `expiresAt = NOW + 48 hours`
- Accept and counter actions validate expiry and return 400 with clear message
- `GET /shipments/:id/bids` includes `expiresAt` and computed `isExpired` on each bid

### Email Notifications (`BidsNotificationsService`)
- Carrier emailed when shipper submits a counteroffer
- Shipper emailed when carrier declines the counter

### Migration
- `1750678212610-BidCounterOfferAndExpiry` — adds enum values and 4 new columns

### Bug Fix
- Fixed pre-existing missing `OneToMany` import in `user.entity.ts`

## Validation

- ✅ 17/17 unit tests pass (`BidsService`)
- ✅ Zero TypeScript errors in all bid files
- ⚠️ Pre-existing build failures in `auth/two-factor`, `push`, `sms` modules (missing `otplib`, `ioredis`, `web-push`, `twilio` packages) — unrelated to this PR

Closes #976