### PR TITLE
feat: pagination utility, shipment analytics, document integrity & admin activity feed

### DIFF
--- a/backend/src/package/analytics/analytics.module.ts
+++ b/backend/src/package/analytics/analytics.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Shipment } from '../../shipments/entities/shipment.entity';
+import { ShipmentAnalyticsService } from './shipment-analytics.service';
+import { ShipmentAnalyticsController } from './shipment-analytics.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Shipment])],
+  controllers: [ShipmentAnalyticsController],
+  providers: [ShipmentAnalyticsService],
+})
+export class AnalyticsModule {}

--- a/backend/src/package/analytics/dto/analytics-query.dto.ts
+++ b/backend/src/package/analytics/dto/analytics-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class AnalyticsQueryDto {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/backend/src/package/analytics/shipment-analytics.controller.ts
+++ b/backend/src/package/analytics/shipment-analytics.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../../auth/guards/roles.guard';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { UserRole } from '../../common/enums/role.enum';
+import { ShipmentAnalyticsService, ShipmentAnalyticsResult } from './shipment-analytics.service';
+import { AnalyticsQueryDto } from './dto/analytics-query.dto';
+
+@Controller('api/analytics')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ShipmentAnalyticsController {
+  constructor(private readonly analyticsService: ShipmentAnalyticsService) {}
+
+  @Get('shipments')
+  @Roles(UserRole.ADMIN, UserRole.SHIPPER)
+  getShipmentAnalytics(
+    @Query() query: AnalyticsQueryDto,
+  ): Promise<ShipmentAnalyticsResult> {
+    return this.analyticsService.getAnalytics(query);
+  }
+}

--- a/backend/src/package/analytics/shipment-analytics.service.spec.ts
+++ b/backend/src/package/analytics/shipment-analytics.service.spec.ts
@@ -1,0 +1,86 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ShipmentAnalyticsService } from './shipment-analytics.service';
+import { Shipment } from '../../shipments/entities/shipment.entity';
+
+function makeQb(statusRows: object[], weeklyRows: object[], durationRow: object, routeRows: object[]) {
+  let cloneCallCount = 0;
+  const results = [statusRows, weeklyRows, [durationRow], routeRows];
+
+  const makeClone = () => {
+    const idx = cloneCallCount++;
+    const clone: Record<string, jest.Mock> = {};
+    clone.select = jest.fn().mockReturnValue(clone);
+    clone.addSelect = jest.fn().mockReturnValue(clone);
+    clone.andWhere = jest.fn().mockReturnValue(clone);
+    clone.groupBy = jest.fn().mockReturnValue(clone);
+    clone.orderBy = jest.fn().mockReturnValue(clone);
+    clone.limit = jest.fn().mockReturnValue(clone);
+    clone.getRawMany = jest.fn().mockResolvedValue(results[idx] ?? []);
+    clone.getRawOne = jest.fn().mockResolvedValue(durationRow);
+    return clone;
+  };
+
+  const qb: Record<string, jest.Mock> = {};
+  qb.select = jest.fn().mockReturnValue(qb);
+  qb.addSelect = jest.fn().mockReturnValue(qb);
+  qb.andWhere = jest.fn().mockReturnValue(qb);
+  qb.groupBy = jest.fn().mockReturnValue(qb);
+  qb.orderBy = jest.fn().mockReturnValue(qb);
+  qb.limit = jest.fn().mockReturnValue(qb);
+  qb.clone = jest.fn().mockImplementation(makeClone);
+  qb.getRawMany = jest.fn().mockResolvedValue(statusRows);
+  qb.getRawOne = jest.fn().mockResolvedValue(durationRow);
+  return qb;
+}
+
+describe('ShipmentAnalyticsService', () => {
+  let service: ShipmentAnalyticsService;
+  let mockRepo: { createQueryBuilder: jest.Mock };
+
+  beforeEach(async () => {
+    const qb = makeQb(
+      [{ status: 'completed', count: '10' }, { status: 'pending', count: '5' }],
+      [{ week: '2024-01-01', count: '4' }],
+      { avg_hours: '48.5' },
+      [{ origin: 'Lagos', destination: 'Abuja', count: '8' }],
+    );
+    mockRepo = { createQueryBuilder: jest.fn().mockReturnValue(qb) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShipmentAnalyticsService,
+        { provide: getRepositoryToken(Shipment), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<ShipmentAnalyticsService>(ShipmentAnalyticsService);
+  });
+
+  it('returns statusCounts, weeklyVolume, avgDeliveryDurationHours, topRoutes', async () => {
+    const result = await service.getAnalytics({});
+    expect(result).toHaveProperty('statusCounts');
+    expect(result).toHaveProperty('weeklyVolume');
+    expect(result).toHaveProperty('avgDeliveryDurationHours');
+    expect(result).toHaveProperty('topRoutes');
+  });
+
+  it('converts count strings to numbers', async () => {
+    const result = await service.getAnalytics({});
+    expect(typeof result.statusCounts[0].count).toBe('number');
+  });
+
+  it('applies startDate and endDate filters when provided', async () => {
+    await service.getAnalytics({ startDate: '2024-01-01', endDate: '2024-12-31' });
+    const qb = mockRepo.createQueryBuilder('s') as { andWhere: jest.Mock };
+    expect(qb.andWhere).toHaveBeenCalledWith('s.created_at >= :startDate', { startDate: '2024-01-01' });
+    expect(qb.andWhere).toHaveBeenCalledWith('s.created_at <= :endDate', { endDate: '2024-12-31' });
+  });
+
+  it('returns null avgDeliveryDurationHours when no rows', async () => {
+    const qb = makeQb([], [], { avg_hours: null }, []);
+    mockRepo.createQueryBuilder.mockReturnValue(qb);
+    const result = await service.getAnalytics({});
+    expect(result.avgDeliveryDurationHours).toBeNull();
+  });
+});

--- a/backend/src/package/analytics/shipment-analytics.service.ts
+++ b/backend/src/package/analytics/shipment-analytics.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Shipment } from '../../shipments/entities/shipment.entity';
+import { AnalyticsQueryDto } from './dto/analytics-query.dto';
+
+export interface ShipmentAnalyticsResult {
+  statusCounts: { status: string; count: number }[];
+  weeklyVolume: { week: string; count: number }[];
+  avgDeliveryDurationHours: number | null;
+  topRoutes: { origin: string; destination: string; count: number }[];
+}
+
+@Injectable()
+export class ShipmentAnalyticsService {
+  constructor(
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  async getAnalytics(query: AnalyticsQueryDto): Promise<ShipmentAnalyticsResult> {
+    const baseQb = this.shipmentRepo.createQueryBuilder('s');
+
+    if (query.startDate) {
+      baseQb.andWhere('s.created_at >= :startDate', { startDate: query.startDate });
+    }
+    if (query.endDate) {
+      baseQb.andWhere('s.created_at <= :endDate', { endDate: query.endDate });
+    }
+
+    // Shipment counts by status
+    const statusRows: { status: string; count: string }[] = await baseQb
+      .clone()
+      .select('s.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('s.status')
+      .getRawMany();
+
+    // Weekly volume for last 12 weeks
+    const weeklyRows: { week: string; count: string }[] = await baseQb
+      .clone()
+      .select("TO_CHAR(DATE_TRUNC('week', s.created_at), 'YYYY-MM-DD')", 'week')
+      .addSelect('COUNT(*)', 'count')
+      .andWhere("s.created_at >= NOW() - INTERVAL '12 weeks'")
+      .groupBy("DATE_TRUNC('week', s.created_at)")
+      .orderBy("DATE_TRUNC('week', s.created_at)", 'ASC')
+      .getRawMany();
+
+    // Average delivery duration in hours
+    const durationRow: { avg_hours: string | null } | undefined = await baseQb
+      .clone()
+      .select(
+        "EXTRACT(EPOCH FROM AVG(s.actual_delivery_date - s.pickup_date)) / 3600",
+        'avg_hours',
+      )
+      .andWhere('s.actual_delivery_date IS NOT NULL')
+      .andWhere('s.pickup_date IS NOT NULL')
+      .getRawOne();
+
+    // Top 5 routes by volume
+    const routeRows: { origin: string; destination: string; count: string }[] =
+      await baseQb
+        .clone()
+        .select('s.origin', 'origin')
+        .addSelect('s.destination', 'destination')
+        .addSelect('COUNT(*)', 'count')
+        .groupBy('s.origin, s.destination')
+        .orderBy('count', 'DESC')
+        .limit(5)
+        .getRawMany();
+
+    return {
+      statusCounts: statusRows.map((r) => ({
+        status: r.status,
+        count: Number(r.count),
+      })),
+      weeklyVolume: weeklyRows.map((r) => ({
+        week: r.week,
+        count: Number(r.count),
+      })),
+      avgDeliveryDurationHours: durationRow?.avg_hours != null
+        ? parseFloat(durationRow.avg_hours)
+        : null,
+      topRoutes: routeRows.map((r) => ({
+        origin: r.origin,
+        destination: r.destination,
+        count: Number(r.count),
+      })),
+    };
+  }
+}

--- a/backend/src/package/document-integrity/document-integrity.controller.ts
+++ b/backend/src/package/document-integrity/document-integrity.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Param, Post, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import { DocumentIntegrityService, IntegrityResult } from './document-integrity.service';
+
+@Controller('api/documents')
+@UseGuards(JwtAuthGuard)
+export class DocumentIntegrityController {
+  constructor(private readonly integrityService: DocumentIntegrityService) {}
+
+  @Post(':id/verify-integrity')
+  verifyIntegrity(@Param('id') id: string): Promise<IntegrityResult> {
+    return this.integrityService.verifyIntegrity(id);
+  }
+}

--- a/backend/src/package/document-integrity/document-integrity.module.ts
+++ b/backend/src/package/document-integrity/document-integrity.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Document } from '../../documents/entities/document.entity';
+import { DocumentIntegrityService } from './document-integrity.service';
+import { DocumentIntegrityController } from './document-integrity.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Document])],
+  controllers: [DocumentIntegrityController],
+  providers: [DocumentIntegrityService],
+})
+export class DocumentIntegrityModule {}

--- a/backend/src/package/document-integrity/document-integrity.service.spec.ts
+++ b/backend/src/package/document-integrity/document-integrity.service.spec.ts
@@ -1,0 +1,79 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { NotFoundException } from '@nestjs/common';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import { DocumentIntegrityService } from './document-integrity.service';
+import { Document } from '../../documents/entities/document.entity';
+
+jest.mock('fs');
+const mockFs = fs as jest.Mocked<typeof fs>;
+
+describe('DocumentIntegrityService', () => {
+  let service: DocumentIntegrityService;
+  let mockRepo: { findOne: jest.Mock };
+
+  const fakeDoc = {
+    id: 'doc-1',
+    storedName: '/storage/docs/file.pdf',
+    sha256Hash: 'abc123',
+  } as Document;
+
+  beforeEach(async () => {
+    mockRepo = { findOne: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DocumentIntegrityService,
+        { provide: getRepositoryToken(Document), useValue: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<DocumentIntegrityService>(DocumentIntegrityService);
+  });
+
+  it('returns valid=true when hashes match', async () => {
+    const content = Buffer.from('file content');
+    const hash = crypto.createHash('sha256').update(content).digest('hex');
+    const doc = { ...fakeDoc, sha256Hash: hash } as Document;
+
+    mockRepo.findOne.mockResolvedValue(doc);
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(content);
+
+    const result = await service.verifyIntegrity('doc-1');
+
+    expect(result.valid).toBe(true);
+    expect(result.storedHash).toBe(hash);
+    expect(result.computedHash).toBe(hash);
+  });
+
+  it('returns valid=false when hashes do not match', async () => {
+    mockRepo.findOne.mockResolvedValue(fakeDoc);
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue(Buffer.from('tampered content'));
+
+    const result = await service.verifyIntegrity('doc-1');
+
+    expect(result.valid).toBe(false);
+    expect(result.storedHash).toBe('abc123');
+    expect(result.computedHash).not.toBe('abc123');
+  });
+
+  it('throws NotFoundException when document record does not exist', async () => {
+    mockRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.verifyIntegrity('missing-id')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+
+  it('throws NotFoundException when file does not exist on disk', async () => {
+    mockRepo.findOne.mockResolvedValue(fakeDoc);
+    mockFs.existsSync.mockReturnValue(false);
+
+    await expect(service.verifyIntegrity('doc-1')).rejects.toThrow(
+      NotFoundException,
+    );
+  });
+});

--- a/backend/src/package/document-integrity/document-integrity.service.ts
+++ b/backend/src/package/document-integrity/document-integrity.service.ts
@@ -1,0 +1,58 @@
+import {
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as fs from 'fs';
+import * as crypto from 'crypto';
+import { Document } from '../../documents/entities/document.entity';
+
+export interface IntegrityResult {
+  valid: boolean;
+  storedHash: string;
+  computedHash: string;
+}
+
+@Injectable()
+export class DocumentIntegrityService {
+  private readonly logger = new Logger(DocumentIntegrityService.name);
+
+  constructor(
+    @InjectRepository(Document)
+    private readonly documentRepo: Repository<Document>,
+  ) {}
+
+  async verifyIntegrity(documentId: string): Promise<IntegrityResult> {
+    const doc = await this.documentRepo.findOne({ where: { id: documentId } });
+    if (!doc) {
+      throw new NotFoundException(`Document ${documentId} not found`);
+    }
+
+    const filePath = doc.storedName;
+    if (!fs.existsSync(filePath)) {
+      throw new NotFoundException(
+        `File not found on disk for document ${documentId}`,
+      );
+    }
+
+    const buffer = fs.readFileSync(filePath);
+    const computedHash = crypto
+      .createHash('sha256')
+      .update(buffer)
+      .digest('hex');
+
+    const valid = computedHash === doc.sha256Hash;
+
+    if (!valid) {
+      this.logger.warn('Document integrity mismatch detected', {
+        documentId,
+        storedHash: doc.sha256Hash,
+        computedHash,
+      });
+    }
+
+    return { valid, storedHash: doc.sha256Hash, computedHash };
+  }
+}

--- a/backend/src/package/pagination/dto/paginated-response.dto.ts
+++ b/backend/src/package/pagination/dto/paginated-response.dto.ts
@@ -1,0 +1,15 @@
+export class PaginatedResponseDto<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+
+  constructor(data: T[], total: number, page: number, limit: number) {
+    this.data = data;
+    this.total = total;
+    this.page = page;
+    this.limit = Math.min(limit, 100);
+    this.totalPages = Math.ceil(total / this.limit);
+  }
+}

--- a/backend/src/package/pagination/dto/pagination.dto.ts
+++ b/backend/src/package/pagination/dto/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+
+export class PaginationDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+}

--- a/backend/src/package/pagination/entities/demo-item.entity.ts
+++ b/backend/src/package/pagination/entities/demo-item.entity.ts
@@ -1,0 +1,19 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+/** Minimal demo entity used only within the pagination package module. */
+@Entity('pagination_demo_items')
+export class DemoItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/package/pagination/pagination-demo.controller.ts
+++ b/backend/src/package/pagination/pagination-demo.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { PaginationDto } from './dto/pagination.dto';
+import { PaginatedResponseDto } from './dto/paginated-response.dto';
+import { paginate } from './pagination.util';
+import { DemoItem } from './entities/demo-item.entity';
+
+@Controller('demo/items')
+export class PaginationDemoController {
+  constructor(
+    @InjectRepository(DemoItem)
+    private readonly demoRepo: Repository<DemoItem>,
+  ) {}
+
+  @Get()
+  list(@Query() query: PaginationDto): Promise<PaginatedResponseDto<DemoItem>> {
+    return paginate(this.demoRepo, query);
+  }
+}

--- a/backend/src/package/pagination/pagination.module.ts
+++ b/backend/src/package/pagination/pagination.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DemoItem } from './entities/demo-item.entity';
+import { PaginationDemoController } from './pagination-demo.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([DemoItem])],
+  controllers: [PaginationDemoController],
+  exports: [],
+})
+export class PaginationModule {}

--- a/backend/src/package/pagination/pagination.spec.ts
+++ b/backend/src/package/pagination/pagination.spec.ts
@@ -1,0 +1,68 @@
+import { PaginatedResponseDto } from './dto/paginated-response.dto';
+import { paginate } from './pagination.util';
+import { PaginationDto } from './dto/pagination.dto';
+
+function makeRepo(data: object[], total: number) {
+  return {
+    findAndCount: jest.fn().mockResolvedValue([data, total]),
+  };
+}
+
+describe('PaginatedResponseDto', () => {
+  it('computes totalPages correctly', () => {
+    const dto = new PaginatedResponseDto([], 45, 1, 20);
+    expect(dto.totalPages).toBe(3);
+  });
+
+  it('caps limit at 100', () => {
+    const dto = new PaginatedResponseDto([], 0, 1, 200);
+    expect(dto.limit).toBe(100);
+  });
+
+  it('totalPages is 0 when total is 0', () => {
+    const dto = new PaginatedResponseDto([], 0, 1, 20);
+    expect(dto.totalPages).toBe(0);
+  });
+});
+
+describe('paginate()', () => {
+  it('passes correct skip/take to repository', async () => {
+    const repo = makeRepo([{ id: '1' }], 50);
+    const query: PaginationDto = { page: 3, limit: 10 };
+    await paginate(repo as never, query);
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      where: undefined,
+      skip: 20,
+      take: 10,
+    });
+  });
+
+  it('caps limit at 100', async () => {
+    const repo = makeRepo([], 0);
+    const query: PaginationDto = { page: 1, limit: 150 };
+    const result = await paginate(repo as never, query);
+    expect(result.limit).toBe(100);
+    expect(repo.findAndCount).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 100 }),
+    );
+  });
+
+  it('defaults to page 1, limit 20', async () => {
+    const repo = makeRepo([], 0);
+    const query = {} as PaginationDto;
+    await paginate(repo as never, query);
+    expect(repo.findAndCount).toHaveBeenCalledWith({
+      where: undefined,
+      skip: 0,
+      take: 20,
+    });
+  });
+
+  it('returns correct totalPages math', async () => {
+    const repo = makeRepo(Array(10).fill({}), 55);
+    const result = await paginate(repo as never, { page: 1, limit: 10 });
+    expect(result.totalPages).toBe(6);
+    expect(result.total).toBe(55);
+    expect(result.page).toBe(1);
+  });
+});

--- a/backend/src/package/pagination/pagination.util.ts
+++ b/backend/src/package/pagination/pagination.util.ts
@@ -1,0 +1,20 @@
+import { Repository, FindOptionsWhere, ObjectLiteral } from 'typeorm';
+import { PaginationDto } from './dto/pagination.dto';
+import { PaginatedResponseDto } from './dto/paginated-response.dto';
+
+export async function paginate<T extends ObjectLiteral>(
+  repo: Repository<T>,
+  query: PaginationDto,
+  where?: FindOptionsWhere<T>,
+): Promise<PaginatedResponseDto<T>> {
+  const limit = Math.min(query.limit ?? 20, 100);
+  const page = query.page ?? 1;
+
+  const [data, total] = await repo.findAndCount({
+    where,
+    skip: (page - 1) * limit,
+    take: limit,
+  });
+
+  return new PaginatedResponseDto(data, total, page, limit);
+}

--- a/frontend/app/sandbox/admin/page.tsx
+++ b/frontend/app/sandbox/admin/page.tsx
@@ -1,0 +1,15 @@
+import { AdminActivityFeedDemo } from '../components/AdminActivityFeedDemo';
+
+export default function AdminActivityPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-6 py-12">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="mb-1 text-2xl font-bold text-gray-900">Admin Activity Feed</h1>
+        <p className="mb-8 text-sm text-gray-500">
+          Real-time platform event feed — auto-refreshes every 30 seconds
+        </p>
+        <AdminActivityFeedDemo />
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/sandbox/components/AdminActivityFeed.tsx
+++ b/frontend/app/sandbox/components/AdminActivityFeed.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type EventType =
+  | 'user_registered'
+  | 'shipment_created'
+  | 'dispute_filed'
+  | 'payment_processed'
+  | 'carrier_verified';
+
+export interface ActivityEvent {
+  id: string;
+  type: EventType;
+  description: string;
+  actor: string;
+  timestamp: Date;
+}
+
+// ── Icons ─────────────────────────────────────────────────────────────────────
+
+const EVENT_META: Record<
+  EventType,
+  { label: string; icon: string; color: string }
+> = {
+  user_registered:    { label: 'User Registered',    icon: '👤', color: 'bg-blue-100 text-blue-700'    },
+  shipment_created:   { label: 'Shipment Created',   icon: '📦', color: 'bg-green-100 text-green-700'  },
+  dispute_filed:      { label: 'Dispute Filed',      icon: '⚠️', color: 'bg-red-100 text-red-700'      },
+  payment_processed:  { label: 'Payment Processed',  icon: '💳', color: 'bg-purple-100 text-purple-700' },
+  carrier_verified:   { label: 'Carrier Verified',   icon: '✅', color: 'bg-teal-100 text-teal-700'    },
+};
+
+const ALL_TYPES = Object.keys(EVENT_META) as EventType[];
+
+// ── Relative time ─────────────────────────────────────────────────────────────
+
+function relativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime();
+  const diffSec = Math.floor(diffMs / 1000);
+  if (diffSec < 60) return `${diffSec}s ago`;
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${Math.floor(diffHr / 24)}d ago`;
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface AdminActivityFeedProps {
+  /** Async function that fetches events. Receives offset for load-more. */
+  fetchEvents: (offset: number) => Promise<ActivityEvent[]>;
+  pageSize?: number;
+  /** Interval in ms between auto-refreshes. Defaults to 30 000. */
+  refreshInterval?: number;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function AdminActivityFeed({
+  fetchEvents,
+  pageSize = 10,
+  refreshInterval = 30_000,
+}: AdminActivityFeedProps) {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+  const [filter, setFilter] = useState<EventType | 'all'>('all');
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(
+    async (nextOffset: number, replace: boolean) => {
+      setLoading(true);
+      try {
+        const data = await fetchEvents(nextOffset);
+        setHasMore(data.length >= pageSize);
+        setEvents((prev) => (replace ? data : [...prev, ...data]));
+        setOffset(nextOffset + data.length);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchEvents, pageSize],
+  );
+
+  // Initial load
+  useEffect(() => {
+    void load(0, true);
+  }, [load]);
+
+  // Auto-refresh: reload from top every `refreshInterval` ms
+  useEffect(() => {
+    const id = setInterval(() => void load(0, true), refreshInterval);
+    return () => clearInterval(id);
+  }, [load, refreshInterval]);
+
+  const visible = filter === 'all' ? events : events.filter((e) => e.type === filter);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-2">
+        <FilterChip
+          label="All"
+          active={filter === 'all'}
+          onClick={() => setFilter('all')}
+        />
+        {ALL_TYPES.map((t) => (
+          <FilterChip
+            key={t}
+            label={EVENT_META[t].label}
+            active={filter === t}
+            onClick={() => setFilter(t)}
+          />
+        ))}
+      </div>
+
+      {/* Feed list */}
+      <ul className="flex flex-col gap-2" role="feed" aria-label="Admin activity feed">
+        {visible.length === 0 && !loading && (
+          <li className="rounded-lg border border-gray-200 bg-white px-4 py-6 text-center text-sm text-gray-400">
+            No activity events.
+          </li>
+        )}
+        {visible.map((event) => (
+          <EventRow key={event.id} event={event} />
+        ))}
+      </ul>
+
+      {/* Load more */}
+      {hasMore && filter === 'all' && (
+        <button
+          onClick={() => void load(offset, false)}
+          disabled={loading}
+          className="mx-auto rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function EventRow({ event }: { event: ActivityEvent }) {
+  const meta = EVENT_META[event.type];
+  return (
+    <li className="flex items-start gap-3 rounded-lg border border-gray-100 bg-white px-4 py-3 shadow-sm">
+      <span
+        className={cn('flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-lg', meta.color)}
+        aria-hidden="true"
+      >
+        {meta.icon}
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <span className={cn('rounded-full px-2 py-0.5 text-xs font-medium', meta.color)}>
+            {meta.label}
+          </span>
+          <time
+            dateTime={event.timestamp.toISOString()}
+            className="shrink-0 text-xs text-gray-400"
+            title={event.timestamp.toLocaleString()}
+          >
+            {relativeTime(event.timestamp)}
+          </time>
+        </div>
+        <p className="mt-1 truncate text-sm text-gray-700">{event.description}</p>
+        <p className="mt-0.5 text-xs text-gray-400">by {event.actor}</p>
+      </div>
+    </li>
+  );
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-pressed={active}
+      className={cn(
+        'rounded-full border px-3 py-1 text-xs font-medium transition-colors',
+        active
+          ? 'border-gray-900 bg-gray-900 text-white'
+          : 'border-gray-300 bg-white text-gray-600 hover:border-gray-500',
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/frontend/app/sandbox/components/AdminActivityFeedDemo.tsx
+++ b/frontend/app/sandbox/components/AdminActivityFeedDemo.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { AdminActivityFeed, ActivityEvent, EventType } from './AdminActivityFeed';
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const EVENT_TYPES: EventType[] = [
+  'user_registered',
+  'shipment_created',
+  'dispute_filed',
+  'payment_processed',
+  'carrier_verified',
+];
+
+function generateEvents(count: number, startOffset: number): ActivityEvent[] {
+  return Array.from({ length: count }, (_, i) => {
+    const idx = (startOffset + i) % EVENT_TYPES.length;
+    const type = EVENT_TYPES[idx];
+    const minutesAgo = startOffset + i * 3;
+    return {
+      id: `evt-${startOffset + i}`,
+      type,
+      description: DESCRIPTIONS[type][i % DESCRIPTIONS[type].length],
+      actor: ACTORS[(startOffset + i) % ACTORS.length],
+      timestamp: new Date(Date.now() - minutesAgo * 60 * 1000),
+    };
+  });
+}
+
+const DESCRIPTIONS: Record<EventType, string[]> = {
+  user_registered: [
+    'New shipper account created',
+    'Carrier registration completed',
+    'Enterprise account onboarded',
+  ],
+  shipment_created: [
+    'Shipment FF-00198 created: Lagos → Abuja',
+    'Shipment FF-00199 created: Kano → Port Harcourt',
+    'Batch of 3 shipments created',
+  ],
+  dispute_filed: [
+    'Dispute on shipment FF-00145: damaged cargo',
+    'Dispute on shipment FF-00133: late delivery',
+    'Dispute on shipment FF-00122: missing items',
+  ],
+  payment_processed: [
+    'Payment of $245.00 processed for FF-00198',
+    'Invoice #INV-0041 settled — $1,200.00',
+    'Carrier payout of $180.00 released',
+  ],
+  carrier_verified: [
+    'Carrier SwiftHaul Logistics verified',
+    'Eagle Freight Co. certification approved',
+    'Meridian Cargo KYC completed',
+  ],
+};
+
+const ACTORS = [
+  'admin@freightflow.io',
+  'system',
+  'alice.smith@example.com',
+  'bob.carrier@example.com',
+  'support@freightflow.io',
+];
+
+const PAGE_SIZE = 10;
+
+async function fetchMockEvents(offset: number): Promise<ActivityEvent[]> {
+  // Simulate network latency
+  await new Promise((r) => setTimeout(r, 300));
+  const total = 35;
+  const remaining = total - offset;
+  if (remaining <= 0) return [];
+  return generateEvents(Math.min(PAGE_SIZE, remaining), offset);
+}
+
+// ── Demo wrapper ──────────────────────────────────────────────────────────────
+
+export function AdminActivityFeedDemo() {
+  return (
+    <AdminActivityFeed
+      fetchEvents={fetchMockEvents}
+      pageSize={PAGE_SIZE}
+      refreshInterval={30_000}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

Resolves four tracked issues in a single PR — all changes are self-contained inside `backend/src/package/` and `frontend/app/sandbox/` as specified.

---

### #833 BE-05 — Generic pagination utility
- `PaginationDto` with `page` (default 1) and `limit` (default 20, max 100), validated with `class-validator`
- `PaginatedResponseDto<T>` generic wrapper: `data`, `total`, `page`, `limit`, `totalPages`
- `paginate(repo, query, where?)` helper using TypeORM `findAndCount` (skip/take)
- Demo endpoint `GET /demo/items` applied to `DemoItem` entity
- Unit tests: page calculation, limit capping at 100, totalPages math

### #837 BE-09 — Shipment analytics aggregation service
- `ShipmentAnalyticsService` — all aggregations in SQL via TypeORM query builder
- `GET /api/analytics/shipments` — accessible to `admin` and `shipper` roles
- Returns: total shipments grouped by status, weekly volume (last 12 weeks), avg delivery duration in hours, top 5 routes by volume
- Accepts optional `startDate` / `endDate` query params
- Unit tests mock the repository and verify aggregation logic

### #838 BE-10 — Document file integrity re-verification service
- `DocumentIntegrityService` — reads file from disk path, recomputes SHA-256, compares to stored hash
- `POST /api/documents/:id/verify-integrity`
- Returns `{ valid: boolean, storedHash: string, computedHash: string }`
- 404 on missing document record or missing file on disk
- Structured `Logger.warn()` on hash mismatch including `documentId` and both hashes
- Unit tests: matching hash (valid), mismatched hash (invalid), missing file (404)

### #823 FE-64 — Admin activity feed component
- `AdminActivityFeed.tsx` at `frontend/app/sandbox/components/`
- Event types with distinct icons: User Registered 👤, Shipment Created 📦, Dispute Filed ⚠️, Payment Processed 💳, Carrier Verified ✅
- Each row: icon, event-type badge, description, actor, relative timestamp
- Auto-refreshes every 30 s via `setInterval`
- Filter chips for each event type
- Load more button for older events (offset-based)
- Demo page at `frontend/app/sandbox/admin/page.tsx`

## Testing
- All 15 backend unit tests pass (`npm test -- --testPathPattern src/package`)
- No TypeScript errors in new frontend files

Closes #823
Closes #833
Closes #837
Closes #838