### PR TITLE
feat: sandbox components for FE-48, FE-49, FE-50, FE-51

### DIFF
--- a/frontend/app/sandbox/components/CarrierVerificationBadge.tsx
+++ b/frontend/app/sandbox/components/CarrierVerificationBadge.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/lib/utils';
+import { ShieldCheck, ShieldOff, Star } from 'lucide-react';
+
+export type VerificationTier = 'unverified' | 'verified' | 'trusted' | 'elite';
+
+export interface CarrierVerificationBadgeProps {
+  score: number;
+  deliveries: number;
+  memberSince: string;
+}
+
+function getTier(score: number): VerificationTier {
+  if (score >= 90) return 'elite';
+  if (score >= 70) return 'trusted';
+  if (score >= 40) return 'verified';
+  return 'unverified';
+}
+
+const TIER_CONFIG: Record<VerificationTier, { label: string; icon: React.ElementType; bg: string; text: string; border: string }> = {
+  unverified: { label: 'Unverified', icon: ShieldOff,   bg: 'bg-gray-100',   text: 'text-gray-600',  border: 'border-gray-300'  },
+  verified:   { label: 'Verified',   icon: ShieldCheck, bg: 'bg-blue-100',   text: 'text-blue-700',  border: 'border-blue-300'  },
+  trusted:    { label: 'Trusted',    icon: ShieldCheck, bg: 'bg-green-100',  text: 'text-green-700', border: 'border-green-300' },
+  elite:      { label: 'Elite',      icon: Star,        bg: 'bg-yellow-100', text: 'text-yellow-700',border: 'border-yellow-400'},
+};
+
+export function CarrierVerificationBadge({ score, deliveries, memberSince }: CarrierVerificationBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const tier = getTier(score);
+  const { label, icon: Icon, bg, text, border } = TIER_CONFIG[tier];
+
+  return (
+    <div className="relative inline-block">
+      <span
+        className={cn('inline-flex cursor-default items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold select-none', bg, text, border)}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        <Icon className="h-3.5 w-3.5" />
+        {label}
+      </span>
+      {showTooltip && (
+        <div className="absolute bottom-full left-1/2 z-10 mb-2 w-48 -translate-x-1/2 rounded-lg border border-gray-200 bg-white p-3 shadow-lg text-xs text-gray-700">
+          <p className="font-semibold text-gray-900 mb-1">{label} Carrier</p>
+          <p>Reputation score: <span className="font-medium">{score}</span></p>
+          <p>Total deliveries: <span className="font-medium">{deliveries.toLocaleString()}</span></p>
+          <p>Member since: <span className="font-medium">{memberSince}</span></p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/sandbox/components/WalletConnect.tsx
+++ b/frontend/app/sandbox/components/WalletConnect.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import { Wallet, LogOut, ExternalLink, Loader2 } from 'lucide-react';
+
+interface WalletState { address: string; balance: string | null }
+
+function truncate(addr: string) { return `${addr.slice(0, 6)}...${addr.slice(-6)}`; }
+
+async function fetchBalance(publicKey: string): Promise<string> {
+  const res = await fetch(`https://horizon-testnet.stellar.org/accounts/${publicKey}`);
+  if (!res.ok) return '0';
+  const data = await res.json();
+  const native = (data.balances as { asset_type: string; balance: string }[]).find((b) => b.asset_type === 'native');
+  return native ? parseFloat(native.balance).toFixed(2) : '0';
+}
+
+export function WalletConnect() {
+  const [wallet, setWallet] = useState<WalletState | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const hasFreighter = typeof window !== 'undefined' && Boolean((window as any).freighter);
+
+  async function connect() {
+    setLoading(true); setError(null);
+    try {
+      const { getPublicKey } = await import('@stellar/freighter-api');
+      const address = await getPublicKey();
+      const balance = await fetchBalance(address).catch(() => null);
+      setWallet({ address, balance });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to connect');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (!hasFreighter) {
+    return (
+      <div className="rounded-xl border border-yellow-200 bg-yellow-50 p-6 text-center">
+        <Wallet className="mx-auto mb-3 h-8 w-8 text-yellow-500" />
+        <p className="mb-1 font-semibold text-yellow-900">Freighter not detected</p>
+        <p className="mb-4 text-sm text-yellow-700">Install the Freighter browser extension to connect your Stellar wallet.</p>
+        <a href="https://freighter.app" target="_blank" rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-yellow-500 px-4 py-2 text-sm font-semibold text-white hover:bg-yellow-600">
+          Install Freighter <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      </div>
+    );
+  }
+
+  if (wallet) {
+    return (
+      <div className="rounded-xl border border-green-200 bg-green-50 p-5">
+        <div className="mb-3 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-200">
+            <Wallet className="h-5 w-5 text-green-700" />
+          </div>
+          <div>
+            <p className="text-xs font-medium text-green-700">Connected</p>
+            <p className="font-mono text-sm font-semibold text-green-900">{truncate(wallet.address)}</p>
+          </div>
+        </div>
+        {wallet.balance !== null && (
+          <p className="mb-4 text-sm text-green-800">Balance: <span className="font-bold">{wallet.balance} XLM</span></p>
+        )}
+        <button onClick={() => setWallet(null)}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-green-300 bg-white px-3 py-1.5 text-xs font-semibold text-green-800 hover:bg-green-100">
+          <LogOut className="h-3.5 w-3.5" /> Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white p-6 text-center">
+      <Wallet className="mx-auto mb-3 h-8 w-8 text-gray-400" />
+      <p className="mb-1 font-semibold text-gray-900">Connect Stellar Wallet</p>
+      <p className="mb-4 text-sm text-gray-500">Link your Freighter wallet to view your XLM balance.</p>
+      {error && <p className="mb-3 text-xs text-red-600">{error}</p>}
+      <button onClick={connect} disabled={loading}
+        className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+        {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Wallet className="h-4 w-4" />}
+        {loading ? 'Connecting…' : 'Connect Wallet'}
+      </button>
+    </div>
+  );
+}

--- a/frontend/app/sandbox/page.tsx
+++ b/frontend/app/sandbox/page.tsx
@@ -7,6 +7,7 @@ import type { ShipmentDocument } from './components/DocumentChecklist';
 import type { CostItem } from './components/CostBreakdownChart';
 import { CurrencyToggle } from './components/CurrencyToggle';
 import { useCurrency } from '@/hooks/useCurrency';
+import { CarrierVerificationBadge } from './components/CarrierVerificationBadge';
 
 const STEPPER_DEMOS: {
   title: string;
@@ -231,6 +232,18 @@ export default function SandboxPage() {
             All prices below convert in real time.
           </p>
           <CurrencyDemo />
+        </section>
+
+        {/* Carrier Verification Badge demo */}
+        <section className="mb-10 rounded-xl border border-gray-200 bg-white p-5">
+          <h2 className="mb-1 text-base font-semibold text-gray-900">Carrier Verification Badge</h2>
+          <p className="mb-4 text-sm text-gray-500">Hover each badge to see carrier details.</p>
+          <div className="flex flex-wrap gap-4">
+            <CarrierVerificationBadge score={10}  deliveries={3}    memberSince="Jun 2026" />
+            <CarrierVerificationBadge score={55}  deliveries={120}  memberSince="Jan 2025" />
+            <CarrierVerificationBadge score={78}  deliveries={540}  memberSince="Mar 2024" />
+            <CarrierVerificationBadge score={95}  deliveries={1800} memberSince="Sep 2022" />
+          </div>
         </section>
 
         <SandboxTabs

--- a/frontend/app/sandbox/routes/optimize/page.tsx
+++ b/frontend/app/sandbox/routes/optimize/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, Trash2, GripVertical, MapPin, Route } from 'lucide-react';
+
+interface Stop { id: string; label: string; name: string }
+
+interface Leg { from: string; to: string; distanceKm: number; timeHours: number }
+
+function mockLegs(stops: Stop[]): Leg[] {
+  const legs: Leg[] = [];
+  for (let i = 0; i < stops.length - 1; i++) {
+    const dist = 80 + ((i * 137 + stops[i].name.length * 31) % 420);
+    legs.push({ from: stops[i].name || stops[i].label, to: stops[i + 1].name || stops[i + 1].label, distanceKm: dist, timeHours: parseFloat((dist / 80).toFixed(1)) });
+  }
+  return legs;
+}
+
+let uid = 0;
+function newStop(label: string): Stop { return { id: String(++uid), label, name: '' }; }
+
+const INITIAL: Stop[] = [newStop('Origin'), newStop('Destination')];
+
+export default function RouteOptimizerPage() {
+  const [stops, setStops] = useState<Stop[]>(INITIAL);
+  const [dragIdx, setDragIdx] = useState<number | null>(null);
+
+  const waypoints = stops.slice(1, -1);
+  const canAddWaypoint = waypoints.length < 5;
+
+  function updateName(id: string, name: string) {
+    setStops((prev) => prev.map((s) => (s.id === id ? { ...s, name } : s)));
+  }
+
+  function addWaypoint() {
+    setStops((prev) => [...prev.slice(0, -1), newStop(`Stop ${waypoints.length + 1}`), prev[prev.length - 1]]);
+  }
+
+  function removeStop(id: string) {
+    setStops((prev) => prev.filter((s) => s.id !== id));
+  }
+
+  function onDragStart(idx: number) { setDragIdx(idx); }
+  function onDragOver(e: React.DragEvent, idx: number) {
+    e.preventDefault();
+    if (dragIdx === null || dragIdx === idx) return;
+    // Only allow reordering waypoints (indices 1..len-2)
+    if (idx === 0 || idx === stops.length - 1) return;
+    if (dragIdx === 0 || dragIdx === stops.length - 1) return;
+    setStops((prev) => {
+      const next = [...prev];
+      const [moved] = next.splice(dragIdx, 1);
+      next.splice(idx, 0, moved);
+      return next;
+    });
+    setDragIdx(idx);
+  }
+  function onDragEnd() { setDragIdx(null); }
+
+  const filledStops = stops.filter((s) => s.name.trim());
+  const legs = filledStops.length >= 2 ? mockLegs(filledStops) : [];
+  const totalDist = legs.reduce((a, l) => a + l.distanceKm, 0);
+  const totalTime = legs.reduce((a, l) => a + l.timeHours, 0);
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-6 py-12">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-1 text-2xl font-bold text-gray-900">Freight Route Optimizer</h1>
+        <p className="mb-8 text-sm text-gray-500">Add stops, drag to reorder waypoints, and see estimated distances and transit times.</p>
+
+        {/* Stop inputs */}
+        <section className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
+          <div className="space-y-2">
+            {stops.map((stop, idx) => {
+              const isOrigin = idx === 0;
+              const isDest = idx === stops.length - 1;
+              const isWaypoint = !isOrigin && !isDest;
+              return (
+                <div
+                  key={stop.id}
+                  draggable={isWaypoint}
+                  onDragStart={() => isWaypoint && onDragStart(idx)}
+                  onDragOver={(e) => onDragOver(e, idx)}
+                  onDragEnd={onDragEnd}
+                  className="flex items-center gap-2"
+                >
+                  {isWaypoint
+                    ? <GripVertical className="h-4 w-4 cursor-grab text-gray-400 shrink-0" />
+                    : <MapPin className={`h-4 w-4 shrink-0 ${isOrigin ? 'text-blue-500' : 'text-red-500'}`} />
+                  }
+                  <input
+                    type="text"
+                    placeholder={stop.label}
+                    value={stop.name}
+                    onChange={(e) => updateName(stop.id, e.target.value)}
+                    className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                  {isWaypoint && (
+                    <button onClick={() => removeStop(stop.id)} className="shrink-0 rounded-lg p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-500">
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          {canAddWaypoint && (
+            <button onClick={addWaypoint}
+              className="mt-3 inline-flex items-center gap-1.5 text-xs font-semibold text-blue-600 hover:text-blue-700">
+              <Plus className="h-3.5 w-3.5" /> Add waypoint
+            </button>
+          )}
+        </section>
+
+        {/* Map placeholder */}
+        <div className="mb-6 flex h-48 items-center justify-center rounded-xl border border-dashed border-gray-300 bg-white text-sm text-gray-400">
+          <div className="text-center">
+            <Route className="mx-auto mb-2 h-8 w-8 text-gray-300" />
+            {filledStops.length >= 2
+              ? `Route: ${filledStops.map((s) => s.name).join(' → ')}`
+              : 'Enter at least origin and destination to preview route'}
+          </div>
+        </div>
+
+        {/* Summary table */}
+        {legs.length > 0 && (
+          <>
+            <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white">
+              <table className="w-full text-sm">
+                <thead className="border-b border-gray-200 bg-gray-50 text-xs font-semibold text-gray-500 uppercase">
+                  <tr>
+                    <th className="px-4 py-3 text-left">Leg</th>
+                    <th className="px-4 py-3 text-left">From</th>
+                    <th className="px-4 py-3 text-left">To</th>
+                    <th className="px-4 py-3 text-right">Distance (km)</th>
+                    <th className="px-4 py-3 text-right">Est. Time (hrs)</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {legs.map((leg, i) => (
+                    <tr key={i} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 font-semibold text-gray-700">{i + 1}</td>
+                      <td className="px-4 py-3 text-gray-700">{leg.from}</td>
+                      <td className="px-4 py-3 text-gray-700">{leg.to}</td>
+                      <td className="px-4 py-3 text-right text-gray-900">{leg.distanceKm}</td>
+                      <td className="px-4 py-3 text-right text-gray-900">{leg.timeHours}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <div className="mt-4 rounded-xl border border-blue-100 bg-blue-50 px-5 py-4 flex flex-wrap gap-8 text-sm">
+              <div>
+                <p className="text-xs text-blue-600 font-medium">Total Distance</p>
+                <p className="text-xl font-bold text-blue-900">{totalDist} km</p>
+              </div>
+              <div>
+                <p className="text-xs text-blue-600 font-medium">Est. Transit Time</p>
+                <p className="text-xl font-bold text-blue-900">{totalTime.toFixed(1)} hrs</p>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/sandbox/settings/wallet/page.tsx
+++ b/frontend/app/sandbox/settings/wallet/page.tsx
@@ -1,0 +1,13 @@
+import { WalletConnect } from '../../components/WalletConnect';
+
+export default function WalletDemoPage() {
+  return (
+    <main className="min-h-screen bg-gray-50 px-6 py-12">
+      <div className="mx-auto max-w-md">
+        <h1 className="mb-1 text-2xl font-bold text-gray-900">Stellar Wallet</h1>
+        <p className="mb-8 text-sm text-gray-500">Connect your Freighter wallet to view your XLM balance on the Stellar testnet.</p>
+        <WalletConnect />
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/sandbox/shipments/export/page.tsx
+++ b/frontend/app/sandbox/shipments/export/page.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { Download, FileText, Loader2 } from 'lucide-react';
+
+type Status = 'delivered' | 'in_transit' | 'pending' | 'cancelled';
+
+interface Shipment {
+  id: string; origin: string; destination: string;
+  date: string; status: Status; weight: string; cost: number;
+}
+
+const MOCK: Shipment[] = [
+  { id: 'FF-001', origin: 'Lagos',     destination: 'Abuja',        date: '2026-04-01', status: 'delivered',  weight: '12kg', cost: 245 },
+  { id: 'FF-002', origin: 'Kano',      destination: 'Port Harcourt',date: '2026-04-15', status: 'delivered',  weight: '8kg',  cost: 189 },
+  { id: 'FF-003', origin: 'Ibadan',    destination: 'Enugu',        date: '2026-05-03', status: 'in_transit', weight: '20kg', cost: 310 },
+  { id: 'FF-004', origin: 'Kaduna',    destination: 'Benin City',   date: '2026-05-10', status: 'pending',    weight: '5kg',  cost: 120 },
+  { id: 'FF-005', origin: 'Aba',       destination: 'Jos',          date: '2026-05-20', status: 'cancelled',  weight: '15kg', cost: 275 },
+  { id: 'FF-006', origin: 'Lagos',     destination: 'Calabar',      date: '2026-06-01', status: 'delivered',  weight: '9kg',  cost: 220 },
+  { id: 'FF-007', origin: 'Zaria',     destination: 'Warri',        date: '2026-06-10', status: 'in_transit', weight: '30kg', cost: 450 },
+  { id: 'FF-008', origin: 'Maiduguri', destination: 'Asaba',        date: '2026-06-15', status: 'pending',    weight: '7kg',  cost: 165 },
+];
+
+const ALL_STATUSES: Status[] = ['delivered', 'in_transit', 'pending', 'cancelled'];
+const STATUS_LABEL: Record<Status, string> = { delivered: 'Delivered', in_transit: 'In Transit', pending: 'Pending', cancelled: 'Cancelled' };
+const STATUS_CLS: Record<Status, string> = {
+  delivered: 'bg-green-100 text-green-700', in_transit: 'bg-blue-100 text-blue-700',
+  pending: 'bg-yellow-100 text-yellow-700', cancelled: 'bg-red-100 text-red-700',
+};
+const PAGE_SIZE = 5;
+
+export default function ShipmentExportPage() {
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [statuses, setStatuses] = useState<Set<Status>>(new Set(ALL_STATUSES));
+  const [page, setPage] = useState(1);
+  const [csvLoading, setCsvLoading] = useState(false);
+  const [pdfLoading, setPdfLoading] = useState(false);
+
+  const filtered = useMemo(() => MOCK.filter((s) => {
+    if (from && s.date < from) return false;
+    if (to && s.date > to) return false;
+    return statuses.has(s.status);
+  }), [from, to, statuses]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const rows = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  function toggleStatus(s: Status) {
+    setStatuses((prev) => { const n = new Set(prev); n.has(s) ? n.delete(s) : n.add(s); return n; });
+    setPage(1);
+  }
+
+  function exportCSV() {
+    setCsvLoading(true);
+    setTimeout(() => {
+      const header = 'ID,Origin,Destination,Date,Status,Weight,Cost (USD)';
+      const lines = filtered.map((s) => `${s.id},${s.origin},${s.destination},${s.date},${s.status},${s.weight},${s.cost}`);
+      const blob = new Blob([[header, ...lines].join('\n')], { type: 'text/csv' });
+      const a = Object.assign(document.createElement('a'), { href: URL.createObjectURL(blob), download: 'shipments.csv' });
+      a.click(); URL.revokeObjectURL(a.href);
+      setCsvLoading(false);
+    }, 800);
+  }
+
+  function exportPDF() {
+    setPdfLoading(true);
+    setTimeout(() => setPdfLoading(false), 1200); // simulate API call
+  }
+
+  return (
+    <main className="min-h-screen bg-gray-50 px-6 py-12">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-1 text-2xl font-bold text-gray-900">Shipment History Export</h1>
+        <p className="mb-8 text-sm text-gray-500">Filter shipments and export as CSV or PDF.</p>
+
+        <section className="mb-6 rounded-xl border border-gray-200 bg-white p-5">
+          <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {[['From date', from, setFrom], ['To date', to, setTo]].map(([label, value, setter]) => (
+              <div key={label as string}>
+                <label className="mb-1 block text-xs font-medium text-gray-700">{label as string}</label>
+                <input type="date" value={value as string}
+                  onChange={(e) => { (setter as (v: string) => void)(e.target.value); setPage(1); }}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+            ))}
+          </div>
+          <div>
+            <p className="mb-2 text-xs font-medium text-gray-700">Status</p>
+            <div className="flex flex-wrap gap-3">
+              {ALL_STATUSES.map((s) => (
+                <label key={s} className="flex cursor-pointer items-center gap-1.5 text-sm text-gray-700">
+                  <input type="checkbox" checked={statuses.has(s)} onChange={() => toggleStatus(s)}
+                    className="h-4 w-4 rounded border-gray-300 text-blue-600" />
+                  {STATUS_LABEL[s]}
+                </label>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-gray-600">
+            <span className="font-semibold text-gray-900">{filtered.length}</span> record{filtered.length !== 1 ? 's' : ''} found
+          </p>
+          <div className="flex gap-2">
+            <button onClick={exportCSV} disabled={csvLoading || !filtered.length}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-50">
+              {csvLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
+              Export CSV
+            </button>
+            <button onClick={exportPDF} disabled={pdfLoading || !filtered.length}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-4 py-2 text-xs font-semibold text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+              {pdfLoading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FileText className="h-3.5 w-3.5" />}
+              Export PDF
+            </button>
+          </div>
+        </div>
+
+        <div className="overflow-x-auto rounded-xl border border-gray-200 bg-white">
+          <table className="w-full text-sm">
+            <thead className="border-b border-gray-200 bg-gray-50 text-xs font-semibold text-gray-500 uppercase">
+              <tr>{['ID','Origin','Destination','Date','Status','Weight','Cost'].map((h) => (
+                <th key={h} className="px-4 py-3 text-left">{h}</th>
+              ))}</tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.length === 0 ? (
+                <tr><td colSpan={7} className="px-4 py-8 text-center text-gray-400">No shipments match your filters.</td></tr>
+              ) : rows.map((s) => (
+                <tr key={s.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 font-mono font-semibold text-gray-900">{s.id}</td>
+                  <td className="px-4 py-3 text-gray-700">{s.origin}</td>
+                  <td className="px-4 py-3 text-gray-700">{s.destination}</td>
+                  <td className="px-4 py-3 text-gray-500">{s.date}</td>
+                  <td className="px-4 py-3">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-semibold ${STATUS_CLS[s.status]}`}>{STATUS_LABEL[s.status]}</span>
+                  </td>
+                  <td className="px-4 py-3 text-gray-700">{s.weight}</td>
+                  <td className="px-4 py-3 text-gray-900">${s.cost}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="mt-4 flex items-center justify-end gap-2 text-sm">
+            <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-gray-600 hover:bg-gray-50 disabled:opacity-40">Previous</button>
+            <span className="text-gray-500">Page {page} of {totalPages}</span>
+            <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}
+              className="rounded-lg border border-gray-300 px-3 py-1.5 text-gray-600 hover:bg-gray-50 disabled:opacity-40">Next</button>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-slot": "^1.2.3",
+        "@stellar/freighter-api": "6.0.1",
         "@tanstack/react-query": "^5.90.2",
         "@tanstack/react-table": "^8.21.3",
         "class-variance-authority": "^0.7.1",
@@ -3018,6 +3019,28 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@stellar/freighter-api": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@stellar/freighter-api/-/freighter-api-6.0.1.tgz",
+      "integrity": "sha512-eqwakEqSg+zoLuPpSbKyrX0pG8DQFzL/J5GtbfuMCmJI+h+oiC9pQ5C6QLc80xopZQKdGt8dUAFCmDMNdAG95w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "6.0.3",
+        "semver": "7.7.1"
+      }
+    },
+    "node_modules/@stellar/freighter-api/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/core-darwin-arm64": {
       "version": "1.15.30",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.30.tgz",
@@ -4973,6 +4996,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
@@ -5052,6 +5095,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -7265,6 +7332,26 @@
       "dependencies": {
         "@formatjs/icu-messageformat-parser": "^3.4.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -9727,17 +9814,6 @@
         "@swc/helpers": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-slot": "^1.2.3",
+    "@stellar/freighter-api": "6.0.1",
     "@tanstack/react-query": "^5.90.2",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

Implements all four sandbox issues assigned to @Fahmedo.

### Changes

**#808 – [FE-49] CarrierVerificationBadge**
- `frontend/app/sandbox/components/CarrierVerificationBadge.tsx`
- Four tiers: Unverified (gray), Verified (blue), Trusted (green), Elite (gold)
- Hover tooltip shows reputation score, total deliveries, member since
- Props: `score`, `deliveries`, `memberSince`
- All four tiers demoed in `frontend/app/sandbox/page.tsx`

**#809 – [FE-50] Shipment history export page**
- `frontend/app/sandbox/shipments/export/page.tsx`
- Date range picker (from/to), status filter checkboxes
- Paginated preview table (5 per page) with match count
- Client-side CSV export; PDF export (API stub with loading state)
- Uses mock data

**#810 – [FE-51] Stellar WalletConnect**
- `frontend/app/sandbox/components/WalletConnect.tsx`
- Detects Freighter extension; shows install link if absent
- Connect calls `getPublicKey()` from `@stellar/freighter-api`
- Displays truncated address (first 6 … last 6) and XLM balance from Horizon testnet
- Disconnect clears stored address
- Demo page at `frontend/app/sandbox/settings/wallet/page.tsx`

**#807 – [FE-48] Freight route optimizer UI**
- `frontend/app/sandbox/routes/optimize/page.tsx`
- Origin + up to 5 waypoints + destination inputs
- Drag-to-reorder waypoints, add/remove stops
- Route preview banner
- Per-leg summary table (distance km, est. hours) + totals
- Uses mock route data

### Dependencies
- Added `@stellar/freighter-api` (pinned exact version)

Closes #807, closes #808, closes #809, closes #810