### PR TITLE
Fix marketplace filters and add cargoCategory to shipment creation

### DIFF
--- a/backend/src/shipments/dto/query-shipment.dto.ts
+++ b/backend/src/shipments/dto/query-shipment.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsEnum, IsString, IsInt, Min, Max } from 'class-validator';
+import { IsOptional, IsEnum, IsString, IsInt, IsNumber, Min, Max } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ShipmentStatus } from '../../common/enums/shipment-status.enum';
@@ -24,6 +24,20 @@ export class QueryShipmentDto {
   @IsOptional()
   @IsEnum(CargoCategory)
   cargoCategory?: CargoCategory;
+
+  @ApiPropertyOptional({ example: 100, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  minPrice?: number;
+
+  @ApiPropertyOptional({ example: 5000, minimum: 0 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber()
+  @Min(0)
+  maxPrice?: number;
 
   @ApiPropertyOptional({ default: 1, minimum: 1 })
   @IsOptional()

--- a/backend/src/shipments/shipments.service.ts
+++ b/backend/src/shipments/shipments.service.ts
@@ -11,6 +11,9 @@ import {
   Repository,
   FindOptionsWhere,
   ILike,
+  Between,
+  MoreThanOrEqual,
+  LessThanOrEqual,
   SelectQueryBuilder,
 } from 'typeorm';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
@@ -333,7 +336,7 @@ export class ShipmentsService {
   }
 
   async findMarketplace(query: QueryShipmentDto): Promise<PaginatedShipments> {
-    const { page = 1, limit = 20, origin, destination, cargoCategory } = query;
+    const { page = 1, limit = 20, origin, destination, cargoCategory, minPrice, maxPrice } = query;
     const skip = (page - 1) * limit;
 
     const where: FindOptionsWhere<Shipment> = {
@@ -342,6 +345,9 @@ export class ShipmentsService {
     if (origin) where.origin = ILike(`%${origin}%`);
     if (destination) where.destination = ILike(`%${destination}%`);
     if (cargoCategory) where.cargoCategory = cargoCategory;
+    if (minPrice != null && maxPrice != null) where.price = Between(minPrice, maxPrice);
+    else if (minPrice != null) where.price = MoreThanOrEqual(minPrice);
+    else if (maxPrice != null) where.price = LessThanOrEqual(maxPrice);
 
     const [data, total] = await this.shipmentRepo.findAndCount({
       where,

--- a/frontend/app/(dashboard)/shipments/[id]/page.tsx
+++ b/frontend/app/(dashboard)/shipments/[id]/page.tsx
@@ -124,6 +124,12 @@ export default function ShipmentDetailPage() {
                   <span className="text-muted-foreground">Price</span>
                   <p className="font-semibold text-foreground">{formattedPrice}</p>
                 </div>
+                {shipment.cargoCategory && (
+                  <div>
+                    <span className="text-muted-foreground">Category</span>
+                    <p className="font-medium">{shipment.cargoCategory}</p>
+                  </div>
+                )}
               </div>
               {shipment.notes && (
                 <p className="text-muted-foreground italic text-sm border-t pt-2">

--- a/frontend/app/(dashboard)/shipments/new/page.tsx
+++ b/frontend/app/(dashboard)/shipments/new/page.tsx
@@ -14,6 +14,21 @@ import { Card, CardContent, CardHeader, CardTitle } from '../../../../components
 
 // ── Schemas per step ──────────────────────────────────────────────────────────
 
+// Mirrors backend/src/common/enums/cargo-category.enum.ts
+const CARGO_CATEGORIES = [
+  'Electronics',
+  'Perishables',
+  'Hazardous',
+  'Furniture',
+  'Machinery',
+  'Textiles',
+  'Food & Beverage',
+  'Automotive',
+  'Pharmaceuticals',
+  'Construction Materials',
+  'General Cargo',
+] as const;
+
 const step1Schema = z.object({
   origin: z.string().min(2, 'Origin is required'),
   destination: z.string().min(2, 'Destination is required'),
@@ -21,6 +36,7 @@ const step1Schema = z.object({
 
 const step2Schema = z.object({
   cargoDescription: z.string().min(10, 'Describe the cargo (min 10 chars)'),
+  cargoCategory: z.enum(CARGO_CATEGORIES, 'Select a cargo category'),
   weightKg: z.coerce.number().positive('Weight must be positive'),
   volumeCbm: z.coerce.number().positive().optional().or(z.literal('')),
 });
@@ -65,7 +81,7 @@ export default function NewShipmentPage() {
   // Validate only the fields belonging to the current step before advancing
   const stepFields: (keyof FormValues)[][] = [
     ['origin', 'destination'],
-    ['cargoDescription', 'weightKg', 'volumeCbm'],
+    ['cargoDescription', 'cargoCategory', 'weightKg', 'volumeCbm'],
     ['price', 'currency', 'pickupDate', 'estimatedDeliveryDate'],
     ['notes'],
   ];
@@ -165,6 +181,21 @@ export default function NewShipmentPage() {
                 />
                 {errors.cargoDescription && <p className="text-xs text-destructive">{errors.cargoDescription.message}</p>}
               </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="cargoCategory">Cargo Category *</Label>
+                <select
+                  id="cargoCategory"
+                  className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground"
+                  defaultValue=""
+                  {...register('cargoCategory')}
+                >
+                  <option value="" disabled>Select a category</option>
+                  {CARGO_CATEGORIES.map((c) => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
+                {errors.cargoCategory && <p className="text-xs text-destructive">{errors.cargoCategory.message}</p>}
+              </div>
               <div className="grid gap-4 sm:grid-cols-2">
                 <div className="space-y-1.5">
                   <Label htmlFor="weightKg">Weight (kg) *</Label>
@@ -228,6 +259,8 @@ export default function NewShipmentPage() {
                   <span className="font-medium">{values.destination}</span>
                   <span className="text-muted-foreground">Cargo</span>
                   <span className="font-medium">{values.cargoDescription}</span>
+                  <span className="text-muted-foreground">Category</span>
+                  <span className="font-medium">{values.cargoCategory}</span>
                   <span className="text-muted-foreground">Weight</span>
                   <span className="font-medium">{values.weightKg} kg</span>
                   {values.volumeCbm && (

--- a/frontend/components/shipment/shipment-card.tsx
+++ b/frontend/components/shipment/shipment-card.tsx
@@ -28,6 +28,9 @@ export function ShipmentCard({ shipment }: ShipmentCardProps) {
               <p className="font-semibold text-foreground truncate mt-0.5">
                 {shipment.origin} → {shipment.destination}
               </p>
+              {shipment.cargoCategory && (
+                <p className="text-xs text-muted-foreground mt-0.5">{shipment.cargoCategory}</p>
+              )}
             </div>
             <StatusBadge status={shipment.status} className="shrink-0 mt-0.5" />
           </div>

--- a/frontend/lib/api/shipment.api.ts
+++ b/frontend/lib/api/shipment.api.ts
@@ -13,6 +13,9 @@ function buildQuery(params: QueryShipmentParams): string {
   if (params.status) q.set('status', params.status);
   if (params.origin) q.set('origin', params.origin);
   if (params.destination) q.set('destination', params.destination);
+  if (params.cargoCategory) q.set('cargoCategory', params.cargoCategory);
+  if (params.minPrice != null) q.set('minPrice', String(params.minPrice));
+  if (params.maxPrice != null) q.set('maxPrice', String(params.maxPrice));
   if (params.page) q.set('page', String(params.page));
   if (params.limit) q.set('limit', String(params.limit));
   const str = q.toString();

--- a/frontend/types/shipment.types.ts
+++ b/frontend/types/shipment.types.ts
@@ -20,6 +20,7 @@ export interface Shipment {
   origin: string;
   destination: string;
   cargoDescription: string;
+  cargoCategory: string | null;
   weightKg: number;
   volumeCbm: number | null;
   price: number;
@@ -48,6 +49,7 @@ export interface CreateShipmentPayload {
   origin: string;
   destination: string;
   cargoDescription: string;
+  cargoCategory: string;
   weightKg: number;
   volumeCbm?: number;
   price: number;


### PR DESCRIPTION
## Summary

- **Marketplace filters (#1099):** `buildQuery()` was silently dropping `cargoCategory`, `minPrice`, and `maxPrice` before the request was ever sent. Fixed the query serialization, and also found that the backend `findMarketplace` only filtered by `cargoCategory` — `minPrice`/`maxPrice` weren't supported at all, so even a fixed frontend would have no effect on price. Added `minPrice`/`maxPrice` to `QueryShipmentDto` and wired price-range filtering (`Between`/`MoreThanOrEqual`/`LessThanOrEqual`) into `findMarketplace`. The active-filters indicator and clear-filters control already existed on the marketplace page, so no change was needed there.
- **cargoCategory on shipment creation (#1100):** The shipment creation wizard never collected `cargoCategory`, even though the backend DTO/entity already supports it (used by #1099's filter). Added a required category select (values mirrored from `backend/src/common/enums/cargo-category.enum.ts`) to the Cargo Details step, included it in the create payload, and displayed it on the shipment card and shipment detail page.

## Test plan
- [x] `npm run lint` clean on all changed files (both backend and frontend)
- [x] `npm run build` passes for both `backend` and `frontend`
- [x] `npm run test` passes: 105/105 backend tests, no frontend test regressions
- [x] Manually traced the marketplace filter query params end-to-end into the new backend `where` clause

closes #1099
closes #1100