### PR TITLE
feat: add messaging, cargo insurance, customs compliance, and security hardening

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "class-validator": "^0.14.3",
         "cloudinary": "^2.7.0",
         "dotenv": "^16.4.7",
+        "helmet": "^8.0.0",
         "joi": "^17.13.3",
         "nestjs-pino": "^4.4.0",
         "nodemailer": "^6.10.1",
@@ -10073,6 +10074,18 @@
         "he": "bin/he"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/EvanHahn"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -17622,16 +17635,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
       }
     }
   }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,7 +32,6 @@
         "class-validator": "^0.14.3",
         "cloudinary": "^2.7.0",
         "dotenv": "^16.4.7",
-        "helmet": "^8.0.0",
         "joi": "^17.13.3",
         "nestjs-pino": "^4.4.0",
         "nodemailer": "^6.10.1",
@@ -10074,18 +10073,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/helmet": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
-      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/EvanHahn"
-      }
-    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -17636,6 +17623,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT",
+      "dependencies": {}
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,6 +47,7 @@
     "class-validator": "^0.14.3",
     "cloudinary": "^2.7.0",
     "dotenv": "^16.4.7",
+    "helmet": "^8.0.0",
     "joi": "^17.13.3",
     "nestjs-pino": "^4.4.0",
     "nodemailer": "^6.10.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,6 +1,7 @@
-import { Module } from '@nestjs/common';
+import { Module, NestModule, MiddlewareConsumer } from '@nestjs/common';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { ExecutionContext } from '@nestjs/common';
+import helmet from 'helmet';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule, ConfigService } from '@nestjs/config';
@@ -22,6 +23,7 @@ import { NotificationPreferencesModule } from './notification-preferences/notifi
 import { AdminAuditInterceptor } from './audit-log/admin-audit.interceptor';
 import { CarriersModule } from './carriers/carriers.module';
 import { ReviewsModule } from './reviews/reviews.module';
+import { MessagingModule } from './messaging/messaging.module';
 
 const shipmentCreateTracker = (context: ExecutionContext): string => {
   const request = context.switchToHttp().getRequest<{
@@ -128,6 +130,7 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
     NotificationPreferencesModule,
     CarriersModule,
     ReviewsModule,
+    MessagingModule,
   ],
   controllers: [AppController],
   providers: [
@@ -142,4 +145,8 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(helmet()).forRoutes('*');
+  }
+}

--- a/backend/src/carriers/carriers.service.spec.ts
+++ b/backend/src/carriers/carriers.service.spec.ts
@@ -22,6 +22,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     currency: 'USD',
     cargoCategory: null,
     isInsured: false,
+    declaredValue: null,
+    coverageAmount: null,
     insurancePremium: null,
     status: ShipmentStatus.COMPLETED,
     notes: null,

--- a/backend/src/common/throttle.constants.ts
+++ b/backend/src/common/throttle.constants.ts
@@ -1,0 +1,12 @@
+export const THROTTLE_LIMITS = {
+  default: { ttl: 60_000, limit: 60 },
+  auth: { ttl: 60_000, limit: 5 },
+  passwordReset: { ttl: 900_000, limit: 3 },
+  shipmentCreate: { ttl: 60_000, limit: 10 },
+  documentUpload: { ttl: 3_600_000, limit: 10 },
+  bidSubmission: { ttl: 3_600_000, limit: 20 },
+  messageSend: { ttl: 60_000, limit: 30 },
+  csvExport: { ttl: 3_600_000, limit: 5 },
+  escrow: { ttl: 3_600_000, limit: 10 },
+  admin: { ttl: 60_000, limit: 60 },
+} as const;

--- a/backend/src/documents/documents.controller.ts
+++ b/backend/src/documents/documents.controller.ts
@@ -92,6 +92,16 @@ export class DocumentsController {
     return this.documentsService.listByShipment(shipmentId, user);
   }
 
+  @Get('shipment/:shipmentId/compliance-status')
+  @ApiOperation({ summary: 'Get compliance status for a shipment' })
+  @ApiResponse({ status: 200, description: 'Compliance status' })
+  complianceStatus(
+    @Param('shipmentId', ParseUUIDPipe) shipmentId: string,
+    @CurrentUser() user: User,
+  ) {
+    return this.documentsService.getComplianceStatus(shipmentId, user);
+  }
+
   @Get(':id')
   @ApiOperation({ summary: 'Get document metadata by ID' })
   @ApiResponse({ status: 200, description: 'Document metadata' })

--- a/backend/src/documents/documents.service.ts
+++ b/backend/src/documents/documents.service.ts
@@ -10,6 +10,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Document } from './entities/document.entity';
+import { DocumentType } from './enums/document-type.enum';
 import { Shipment } from '../shipments/entities/shipment.entity';
 import { User } from '../users/entities/user.entity';
 import { UserRole } from '../common/enums/role.enum';
@@ -128,6 +129,31 @@ export class DocumentsService {
     }
 
     return { filePath, originalName: doc.originalName };
+  }
+
+  // ── Compliance Status ──────────────────────────────────────────────────────
+
+  async getComplianceStatus(
+    shipmentId: string,
+    user: User,
+  ): Promise<Record<string, unknown>> {
+    const shipment = await this.getShipmentOrThrow(shipmentId);
+    this.assertIsParty(shipment, user);
+
+    const requiredTypes = [DocumentType.CUSTOMS_DECLARATION];
+    const docs = await this.documentRepo.find({ where: { shipmentId } });
+    const presentTypes = new Set(docs.map((d) => d.documentType));
+
+    return {
+      shipmentId,
+      isInternational: shipment.origin !== shipment.destination,
+      required: requiredTypes.map((t) => ({
+        type: t,
+        present: presentTypes.has(t),
+      })),
+      missing: requiredTypes.filter((t) => !presentTypes.has(t)),
+      allUploaded: requiredTypes.every((t) => presentTypes.has(t)),
+    };
   }
 
   // ── Delete ───────────────────────────────────────────────────────────────────

--- a/backend/src/documents/enums/document-type.enum.ts
+++ b/backend/src/documents/enums/document-type.enum.ts
@@ -3,6 +3,8 @@ export enum DocumentType {
   PROOF_OF_DELIVERY = 'proof_of_delivery',
   INVOICE = 'invoice',
   CUSTOMS_DECLARATION = 'customs_declaration',
+  COMMERCIAL_INVOICE = 'commercial_invoice',
+  CERTIFICATE_OF_ORIGIN = 'certificate_of_origin',
   INSURANCE_CERTIFICATE = 'insurance_certificate',
   PHOTO = 'photo',
   OTHER = 'other',

--- a/backend/src/messaging/entities/conversation.entity.ts
+++ b/backend/src/messaging/entities/conversation.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Shipment } from '../../shipments/entities/shipment.entity';
+
+@Entity('conversations')
+export class Conversation {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Shipment, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'shipment_id' })
+  shipment: Shipment;
+
+  @Column({ name: 'shipment_id' })
+  shipmentId: string;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'shipper_id' })
+  shipper: User;
+
+  @Column({ name: 'shipper_id' })
+  shipperId: string;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'carrier_id' })
+  carrier: User;
+
+  @Column({ name: 'carrier_id' })
+  carrierId: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/messaging/entities/message.entity.ts
+++ b/backend/src/messaging/entities/message.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import { User } from '../../users/entities/user.entity';
+import { Conversation } from './conversation.entity';
+
+@Entity('messages')
+export class Message {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Conversation, { nullable: false, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'conversation_id' })
+  conversation: Conversation;
+
+  @Column({ name: 'conversation_id' })
+  conversationId: string;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'sender_id' })
+  sender: User;
+
+  @Column({ name: 'sender_id' })
+  senderId: string;
+
+  @Column({ type: 'text' })
+  body: string;
+
+  @Column({ name: 'read_at', type: 'timestamptz', nullable: true })
+  readAt: Date | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+}

--- a/backend/src/messaging/messaging.controller.ts
+++ b/backend/src/messaging/messaging.controller.ts
@@ -1,0 +1,87 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Body,
+  Query,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiBearerAuth,
+  ApiOperation,
+  ApiProperty,
+} from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+import { MessagingService } from './messaging.service';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+
+class StartConversationDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  shipmentId: string;
+
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  carrierId: string;
+}
+
+class SendMessageDto {
+  @ApiProperty()
+  @IsString()
+  @IsNotEmpty()
+  body: string;
+}
+
+@ApiTags('messaging')
+@ApiBearerAuth()
+@Controller('conversations')
+export class MessagingController {
+  constructor(private readonly messagingService: MessagingService) {}
+
+  @Post()
+  @ApiOperation({ summary: 'Start or fetch a conversation for a shipment' })
+  async startConversation(
+    @CurrentUser() user: User,
+    @Body() dto: StartConversationDto,
+  ) {
+    return this.messagingService.findOrCreateConversation(
+      dto.shipmentId,
+      user.id,
+      dto.carrierId,
+    );
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List current user conversations' })
+  async listConversations(@CurrentUser() user: User) {
+    return this.messagingService.listConversations(user.id);
+  }
+
+  @Post(':id/messages')
+  @ApiOperation({ summary: 'Send a message in a conversation' })
+  async sendMessage(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+    @Body() dto: SendMessageDto,
+  ) {
+    return this.messagingService.sendMessage(id, user.id, dto.body);
+  }
+
+  @Get(':id/messages')
+  @ApiOperation({ summary: 'Get paginated message history' })
+  async getMessages(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: User,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    const p = page ? Math.max(1, parseInt(page, 10)) : 1;
+    const l = limit ? Math.min(100, Math.max(1, parseInt(limit, 10))) : 50;
+    return this.messagingService.getMessages(id, user.id, p, l);
+  }
+}

--- a/backend/src/messaging/messaging.module.ts
+++ b/backend/src/messaging/messaging.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MessagingService } from './messaging.service';
+import { MessagingController } from './messaging.controller';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from './entities/message.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Conversation, Message])],
+  controllers: [MessagingController],
+  providers: [MessagingService],
+  exports: [MessagingService],
+})
+export class MessagingModule {}

--- a/backend/src/messaging/messaging.service.ts
+++ b/backend/src/messaging/messaging.service.ts
@@ -1,0 +1,103 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Conversation } from './entities/conversation.entity';
+import { Message } from './entities/message.entity';
+
+@Injectable()
+export class MessagingService {
+  constructor(
+    @InjectRepository(Conversation)
+    private readonly conversationRepo: Repository<Conversation>,
+    @InjectRepository(Message)
+    private readonly messageRepo: Repository<Message>,
+    private readonly eventEmitter: EventEmitter2,
+  ) {}
+
+  async findOrCreateConversation(
+    shipmentId: string,
+    shipperId: string,
+    carrierId: string,
+  ): Promise<Conversation> {
+    let convo = await this.conversationRepo.findOne({
+      where: { shipmentId, shipperId, carrierId },
+    });
+    if (!convo) {
+      convo = this.conversationRepo.create({
+        shipmentId,
+        shipperId,
+        carrierId,
+      });
+      convo = await this.conversationRepo.save(convo);
+    }
+    return convo;
+  }
+
+  async listConversations(userId: string): Promise<Conversation[]> {
+    return this.conversationRepo.find({
+      where: [{ shipperId: userId }, { carrierId: userId }],
+      relations: ['shipment', 'shipper', 'carrier'],
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async sendMessage(
+    conversationId: string,
+    senderId: string,
+    body: string,
+  ): Promise<Message> {
+    const convo = await this.conversationRepo.findOne({
+      where: { id: conversationId },
+    });
+    if (!convo) throw new NotFoundException('Conversation not found');
+    if (convo.shipperId !== senderId && convo.carrierId !== senderId) {
+      throw new ForbiddenException('Not a participant in this conversation');
+    }
+
+    const msg = this.messageRepo.create({
+      conversationId,
+      senderId,
+      body,
+    });
+    const saved = await this.messageRepo.save(msg);
+
+    const recipientId =
+      convo.shipperId === senderId ? convo.carrierId : convo.shipperId;
+    this.eventEmitter.emit('message.created', {
+      recipientId,
+      message: saved,
+    });
+
+    return saved;
+  }
+
+  async getMessages(
+    conversationId: string,
+    userId: string,
+    page = 1,
+    limit = 50,
+  ): Promise<{ data: Message[]; total: number }> {
+    const convo = await this.conversationRepo.findOne({
+      where: { id: conversationId },
+    });
+    if (!convo) throw new NotFoundException('Conversation not found');
+    if (convo.shipperId !== userId && convo.carrierId !== userId) {
+      throw new ForbiddenException('Not a participant in this conversation');
+    }
+
+    const [data, total] = await this.messageRepo.findAndCount({
+      where: { conversationId },
+      relations: ['sender'],
+      order: { createdAt: 'DESC' },
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return { data, total };
+  }
+}

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -47,6 +47,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     currency: 'USD',
     cargoCategory: null,
     isInsured: false,
+    declaredValue: null,
+    coverageAmount: null,
     insurancePremium: null,
     status: ShipmentStatus.COMPLETED,
     notes: null,

--- a/backend/src/shipments/dto/create-shipment.dto.ts
+++ b/backend/src/shipments/dto/create-shipment.dto.ts
@@ -36,7 +36,10 @@ export class CreateShipmentDto {
   @MaxLength(2000)
   cargoDescription: string;
 
-  @ApiPropertyOptional({ enum: CargoCategory, example: CargoCategory.ELECTRONICS })
+  @ApiPropertyOptional({
+    enum: CargoCategory,
+    example: CargoCategory.ELECTRONICS,
+  })
   @IsOptional()
   @IsEnum(CargoCategory)
   cargoCategory?: CargoCategory;
@@ -93,4 +96,24 @@ export class CreateShipmentDto {
   @IsOptional()
   @IsBoolean()
   isInsured?: boolean;
+
+  @ApiPropertyOptional({
+    example: 50000,
+    description: 'Declared value of the cargo for insurance purposes',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  declaredValue?: number;
+
+  @ApiPropertyOptional({
+    example: 50000,
+    description: 'Requested insurance coverage amount',
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  coverageAmount?: number;
 }

--- a/backend/src/shipments/entities/shipment.entity.ts
+++ b/backend/src/shipments/entities/shipment.entity.ts
@@ -82,6 +82,24 @@ export class Shipment {
   isInsured: boolean;
 
   @Column({
+    name: 'declared_value',
+    type: 'decimal',
+    precision: 14,
+    scale: 2,
+    nullable: true,
+  })
+  declaredValue: number | null;
+
+  @Column({
+    name: 'coverage_amount',
+    type: 'decimal',
+    precision: 14,
+    scale: 2,
+    nullable: true,
+  })
+  coverageAmount: number | null;
+
+  @Column({
     name: 'insurance_premium',
     type: 'decimal',
     precision: 14,

--- a/backend/src/shipments/shipments.service.spec.ts
+++ b/backend/src/shipments/shipments.service.spec.ts
@@ -55,6 +55,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     price: 5000,
     currency: 'USD',
     isInsured: false,
+    declaredValue: null,
+    coverageAmount: null,
     insurancePremium: null,
     status: ShipmentStatus.PENDING,
     notes: null,
@@ -526,7 +528,7 @@ describe('ShipmentsService', () => {
   });
 
   describe('insurance premium calculation', () => {
-    it('calculates insurance premium as 1.5% of price when isInsured is true', async () => {
+    it('calculates insurance premium from declaredValue when isInsured is true', async () => {
       const shipment = makeShipment();
       shipmentRepo.create.mockReturnValue(shipment);
       shipmentRepo.save.mockResolvedValue(shipment);
@@ -541,12 +543,14 @@ describe('ShipmentsService', () => {
         weightKg: 100,
         price: 10000,
         isInsured: true,
+        declaredValue: 10000,
       });
 
       expect(shipmentRepo.create).toHaveBeenCalledWith(
         expect.objectContaining({
           isInsured: true,
-          insurancePremium: 150, // 1.5% of 10000
+          declaredValue: 10000,
+          insurancePremium: 150, // 1.5% of 10000 (default risk rate)
         }),
       );
     });

--- a/backend/src/shipments/shipments.service.ts
+++ b/backend/src/shipments/shipments.service.ts
@@ -180,12 +180,36 @@ export class ShipmentsService {
     await this.historyRepo.save(entry);
   }
 
+  // ── Insurance premium calculation ────────────────────────────────────────────
+
+  private calculatePremium(
+    declaredValue: number,
+    cargoCategory: string | null,
+  ): number {
+    const riskRates: Record<string, number> = {
+      HAZARDOUS: 0.04,
+      PHARMACEUTICALS: 0.03,
+      ELECTRONICS: 0.025,
+      PERISHABLES: 0.025,
+      AUTOMOTIVE: 0.02,
+      MACHINERY: 0.02,
+      FURNITURE: 0.015,
+      TEXTILES: 0.015,
+      FOOD_AND_BEVERAGE: 0.015,
+      CONSTRUCTION_MATERIALS: 0.015,
+      GENERAL_CARGO: 0.01,
+    };
+    const rate = riskRates[cargoCategory ?? ''] ?? 0.015;
+    return Math.round(declaredValue * rate * 100) / 100;
+  }
+
   // ── CRUD ─────────────────────────────────────────────────────────────────────
 
   async create(shipperId: string, dto: CreateShipmentDto): Promise<Shipment> {
-    const insurancePremium = dto.isInsured
-      ? Math.round(dto.price * 0.015 * 100) / 100
-      : null;
+    const insurancePremium =
+      dto.isInsured && dto.declaredValue
+        ? this.calculatePremium(dto.declaredValue, dto.cargoCategory ?? null)
+        : null;
 
     const shipment = this.shipmentRepo.create({
       trackingNumber: this.generateTrackingNumber(),
@@ -202,6 +226,8 @@ export class ShipmentsService {
       notes: dto.notes ?? null,
       status: ShipmentStatus.PENDING,
       isInsured: dto.isInsured ?? false,
+      declaredValue: dto.declaredValue ?? null,
+      coverageAmount: dto.coverageAmount ?? null,
       insurancePremium,
       pickupDate: dto.pickupDate ? new Date(dto.pickupDate) : null,
       estimatedDeliveryDate: dto.estimatedDeliveryDate
@@ -233,15 +259,20 @@ export class ShipmentsService {
     const createdIds: string[] = [];
 
     // Use TypeORM transaction
-    const queryRunner = this.shipmentRepo.manager.connection.createQueryRunner();
+    const queryRunner =
+      this.shipmentRepo.manager.connection.createQueryRunner();
     await queryRunner.connect();
     await queryRunner.startTransaction();
 
     try {
       for (const shipmentDto of dto.shipments) {
-        const insurancePremium = shipmentDto.isInsured
-          ? Math.round(shipmentDto.price * 0.015 * 100) / 100
-          : null;
+        const insurancePremium =
+          shipmentDto.isInsured && shipmentDto.declaredValue
+            ? this.calculatePremium(
+                shipmentDto.declaredValue,
+                shipmentDto.cargoCategory ?? null,
+              )
+            : null;
 
         const shipment = this.shipmentRepo.create({
           trackingNumber: this.generateTrackingNumber(),
@@ -258,6 +289,8 @@ export class ShipmentsService {
           notes: shipmentDto.notes ?? null,
           status: ShipmentStatus.PENDING,
           isInsured: shipmentDto.isInsured ?? false,
+          declaredValue: shipmentDto.declaredValue ?? null,
+          coverageAmount: shipmentDto.coverageAmount ?? null,
           insurancePremium,
           pickupDate: shipmentDto.pickupDate
             ? new Date(shipmentDto.pickupDate)
@@ -303,7 +336,14 @@ export class ShipmentsService {
     user: User,
     query: QueryShipmentDto,
   ): Promise<PaginatedShipments> {
-    const { page = 1, limit = 20, status, origin, destination, cargoCategory } = query;
+    const {
+      page = 1,
+      limit = 20,
+      status,
+      origin,
+      destination,
+      cargoCategory,
+    } = query;
     const skip = (page - 1) * limit;
 
     const where: FindOptionsWhere<Shipment> = {};

--- a/backend/src/webhooks/webhooks.service.spec.ts
+++ b/backend/src/webhooks/webhooks.service.spec.ts
@@ -47,6 +47,8 @@ function makeShipment(): Shipment {
     currency: 'USD',
     cargoCategory: null,
     isInsured: false,
+    declaredValue: null,
+    coverageAmount: null,
     insurancePremium: null,
     status: ShipmentStatus.IN_TRANSIT,
     notes: null,


### PR DESCRIPTION
## Changes

### In-App Messaging (#1097)
- Added `Conversation` and `Message` entities
- Added messaging module with CRUD endpoints
- POST /conversations — start or fetch conversation for a shipment
- GET /conversations — list user conversations
- POST /conversations/:id/messages — send a message
- GET /conversations/:id/messages — paginated message history

### Customs/Compliance Documents (#1095)
- Extended `DocumentType` enum with `COMMERCIAL_INVOICE` and `CERTIFICATE_OF_ORIGIN`
- Added `GET /documents/shipment/:id/compliance-status` endpoint to check required vs present document types

### Cargo Insurance (#1094)
- Added `declaredValue` and `coverageAmount` fields to Shipment entity
- Added premium calculation based on declared value and cargo category risk tiers
- Insurance fields accepted in shipment creation DTO

### Security Hardening (#1016)
- Added `throttle.constants.ts` with rate limit values for all route categories
- Added Helmet security headers via NestJS middleware
- Installed `helmet` package

Closes #1097
Closes #1095
Closes #1094
Closes #1016