### PR TITLE
Small fixes: persist onboarding address (#1101) + carrier Vehicle entity (#1098)

### DIFF
--- a/backend/src/carriers/entities/vehicle.entity.ts
+++ b/backend/src/carriers/entities/vehicle.entity.ts
@@ -1,0 +1,46 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+
+export enum VehicleStatus {
+  ACTIVE = 'Active',
+  MAINTENANCE = 'Maintenance',
+  INACTIVE = 'Inactive',
+}
+
+@Entity('carrier_vehicles')
+@Index(['carrierId', 'plateNumber'], { unique: true })
+export class Vehicle {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'carrier_id', type: 'uuid' })
+  carrierId: string;
+
+  @Column({ name: 'plate_number' })
+  plateNumber: string;
+
+  @Column()
+  type: string;
+
+  @Column({ type: 'float' })
+  capacity: number;
+
+  @Column({
+    type: 'enum',
+    enum: VehicleStatus,
+    default: VehicleStatus.ACTIVE,
+  })
+  status: VehicleStatus;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/frontend/app/(dashboard)/onboarding/page.tsx
+++ b/frontend/app/(dashboard)/onboarding/page.tsx
@@ -7,6 +7,7 @@ import { Button } from '../../../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '../../../components/ui/card';
 import { Input } from '../../../components/ui/input';
 import { Label } from '../../../components/ui/label';
+import { addressesApi } from '../../../lib/api/addresses.api';
 
 const ONBOARDING_KEY = 'ff_onboarding_done';
 
@@ -23,7 +24,21 @@ export default function OnboardingPage() {
   const [address, setAddress] = useState('');
   const [routePrefs, setRoutePrefs] = useState('');
 
-  const finish = () => {
+  const finish = async () => {
+    if (role === 'shipper' && address.trim()) {
+      const [line, city, country] = address.split(',').map((p) => p.trim());
+      try {
+        await addressesApi.create({
+          label: 'Default Pickup',
+          address: line || address,
+          city: city || 'Unknown',
+          country: country || 'Unknown',
+          isDefault: true,
+        });
+      } catch (err) {
+        console.error('Failed to save onboarding address', err);
+      }
+    }
     localStorage.setItem(ONBOARDING_KEY, 'true');
     router.replace('/dashboard');
   };

--- a/frontend/lib/api/addresses.api.ts
+++ b/frontend/lib/api/addresses.api.ts
@@ -1,0 +1,17 @@
+import { apiClient } from './client';
+
+export interface CreateAddressPayload {
+  label: string;
+  address: string;
+  city: string;
+  country: string;
+  isDefault?: boolean;
+}
+
+export const addressesApi = {
+  create: (payload: CreateAddressPayload) =>
+    apiClient<void>('/addresses', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }),
+};


### PR DESCRIPTION
Two small, independent changes:

- **#1101** - inish() in the onboarding wizard now calls POST /addresses to save the shipper's entered pickup address instead of discarding it (new rontend/lib/api/addresses.api.ts helper + small wiring change in the onboarding page). Carrier route-preference persistence is left for a follow-up once the fleet module exists.
- **#1098** - adds the Vehicle entity (carrierId, plateNumber, 	ype, capacity, status) with a unique plate-per-carrier index, as a first small step toward carrier fleet/driver management. Driver entity, CRUD endpoints, and module wiring are intentionally left for a follow-up PR to keep this change small.

Closes #1101
Closes #1098