### PR TITLE
fix: add admin.require_auth() to identity initialize

### DIFF
--- a/contracts/identity/src/lib.rs
+++ b/contracts/identity/src/lib.rs
@@ -31,6 +31,7 @@ impl IdentityContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(IdentityError::AlreadyRegistered);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         Ok(())
     }


### PR DESCRIPTION
## Overview
Adds admin authorization check to the identity initialize function to prevent unauthorized initialization.

## Changes
- Added dmin.require_auth() guard in contracts/identity/src/lib.rs

## Acceptance Criteria
- [x] Only admin can initialize identity contract

Closes #1122
Closes #1123
Closes #1124
Closes #1125