### PR TITLE
fix: prevent escrow double-funding in Disputed state

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -116,7 +116,7 @@ impl EscrowContract {
                 .persistent()
                 .get(&DataKey::Escrow(shipment_id))
                 .unwrap();
-            if existing.status == EscrowStatus::Funded {
+            if existing.status == EscrowStatus::Funded || existing.status == EscrowStatus::Disputed {
                 return Err(EscrowError::AlreadyFunded);
             }
         }


### PR DESCRIPTION
## Overview
Rejects additional funding attempts when escrow is already in Disputed state.

## Changes
- Added EscrowStatus::Disputed check to reject double-funding in contracts/escrow/src/lib.rs

## Acceptance Criteria
- [x] Additional funding rejected when status is Disputed

Closes #1122
Closes #1123
Closes #1124
Closes #1125