### PR TITLE
fix: replace panic in escrow get_balance with Result/error

### DIFF
--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -304,14 +304,14 @@ impl EscrowContract {
         Self::load(&env, shipment_id)
     }
 
-    pub fn get_balance(env: Env) -> i128 {
+    pub fn get_balance(env: Env) -> Result<i128, EscrowError> {
         let token_addr: Address = env
             .storage()
             .instance()
             .get(&DataKey::TokenContract)
-            .unwrap_or_else(|| panic!());
+            .ok_or(EscrowError::NotInitialized)?;
         let token = token::Client::new(&env, &token_addr);
-        token.balance(&env.current_contract_address())
+        Ok(token.balance(&env.current_contract_address()))
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Overview
Returns a proper Result/error instead of panicking in get_balance.

## Changes
- Changed get_balance to return Result<i128, EscrowError> in contracts/escrow/src/lib.rs

## Acceptance Criteria
- [x] get_balance returns error instead of panicking

Closes #1122
Closes #1123
Closes #1124
Closes #1125