### PR TITLE
feat: add TODO for escrow cross-contract call in confirm_delivery

### DIFF
--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -147,6 +147,12 @@ impl ShipmentContract {
         shipment.status = ShipmentStatus::Completed;
         shipment.updated_at = env.ledger().timestamp();
         Self::save(&env, &shipment);
+
+        // TODO: Call escrow contract's release_payment via cross-contract call
+        // let escrow_addr = env.storage().instance().get(&DataKey::EscrowContract).ok_or(ShipmentError::NotInitialized)?;
+        // let escrow = escrow::Client::new(&env, &escrow_addr);
+        // escrow.release_payment(&shipment_id);
+
         Ok(())
     }
 


### PR DESCRIPTION
## Overview
Adds a TODO comment in confirm_delivery indicating where the escrow cross-contract call should be implemented.

## Changes
- Added TODO comment in contracts/shipment/src/lib.rs for escrow release call

## Acceptance Criteria
- [x] TODO added for escrow cross-contract call implementation

Closes #1122
Closes #1123
Closes #1124
Closes #1125