### PR TITLE
Authorization-audit—require_auth-coverage-on-every-sensitive-entrypoin

### DIFF
--- a/contracts/document/src/lib.rs
+++ b/contracts/document/src/lib.rs
@@ -81,6 +81,7 @@ impl DocumentContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(DocumentError::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::Counter, &0u64);
         Ok(())
@@ -100,7 +101,7 @@ impl DocumentContract {
         content_hash: BytesN<32>,
         ipfs_cid: Bytes,
     ) -> Result<u64, DocumentError> {
-        uploader.require_auth();
+        uploader.require_auth_for_args(&[&shipment_id, &doc_type, &content_hash, &ipfs_cid]);
 
         let id = Self::next_id(&env);
         let now = env.ledger().timestamp();
@@ -152,7 +153,7 @@ impl DocumentContract {
         if verifier != admin {
             return Err(DocumentError::Unauthorized);
         }
-        verifier.require_auth();
+        verifier.require_auth_for_args(&[&doc_id]);
 
         let mut doc = Self::load(&env, doc_id)?;
 
@@ -279,6 +280,45 @@ mod tests {
             &fake_cid(env),
         );
         (id, hash)
+    }
+
+    #[test]
+    fn test_initialize_requires_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(DocumentContract {}, ());
+        let client = DocumentContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&admin);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_register_document_requires_auth() {
+        let env = Env::default();
+        let uploader = Address::generate(&env);
+        let contract_id = env.register(DocumentContract {}, ());
+        let client = DocumentContractClient::new(&env, &contract_id);
+
+        let result = client.try_register_document(
+            &uploader,
+            &1u64,
+            &DocumentType::BillOfLading,
+            &fake_hash(&env),
+            &fake_cid(&env),
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_document_requires_auth() {
+        let env = Env::default();
+        let verifier = Address::generate(&env);
+        let contract_id = env.register(DocumentContract {}, ());
+        let client = DocumentContractClient::new(&env, &contract_id);
+
+        let result = client.try_verify_document(&verifier, &1u64);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/contracts/escrow/src/lib.rs
+++ b/contracts/escrow/src/lib.rs
@@ -77,6 +77,7 @@ impl EscrowContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(EscrowError::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
             .instance()
@@ -99,7 +100,7 @@ impl EscrowContract {
         shipment_id: u64,
         amount: i128,
     ) -> Result<(), EscrowError> {
-        shipper.require_auth();
+        shipper.require_auth_for_args(&[&carrier, &shipment_id, &amount]);
 
         if amount <= 0 {
             return Err(EscrowError::InvalidAmount);
@@ -235,7 +236,7 @@ impl EscrowContract {
     /// Raise a dispute for the escrow (mirrors the shipment dispute).
     /// Either party can call this; admin then resolves via release or refund.
     pub fn raise_dispute(env: Env, caller: Address, shipment_id: u64) -> Result<(), EscrowError> {
-        caller.require_auth();
+        caller.require_auth_for_args(&[&shipment_id]);
 
         let mut record = Self::load(&env, shipment_id)?;
 
@@ -401,6 +402,70 @@ mod tests {
             &(env.ledger().sequence() + 1000),
         );
         client.fund_escrow(shipper, carrier, &SHIPMENT_ID, &AMOUNT);
+    }
+
+    #[test]
+    fn test_initialize_requires_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&admin, &Address::generate(&env));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_fund_escrow_requires_auth() {
+        let env = Env::default();
+        let shipper = Address::generate(&env);
+        let carrier = Address::generate(&env);
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_fund_escrow(&shipper, &carrier, &SHIPMENT_ID, &AMOUNT);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_release_payment_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_release_payment(&SHIPMENT_ID);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_refund_payment_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_refund_payment(&SHIPMENT_ID);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raise_dispute_requires_auth() {
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_raise_dispute(&caller, &SHIPMENT_ID);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_dispute_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(EscrowContract {}, ());
+        let client = EscrowContractClient::new(&env, &contract_id);
+
+        let result = client.try_resolve_dispute(&SHIPMENT_ID, &true);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/contracts/identity/src/lib.rs
+++ b/contracts/identity/src/lib.rs
@@ -42,7 +42,7 @@ impl IdentityContract {
         user_id_hash: BytesN<32>,
         wallet: Address,
     ) -> Result<(), IdentityError> {
-        wallet.require_auth();
+        wallet.require_auth_for_args(&[&user_id_hash]);
 
         if env
             .storage()
@@ -111,6 +111,39 @@ mod tests {
         testutils::{Address as _, BytesN as _},
         Env,
     };
+
+    #[test]
+    fn test_initialize_requires_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(IdentityContract {}, ());
+        let client = IdentityContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&admin);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_register_identity_requires_auth() {
+        let env = Env::default();
+        let wallet = Address::generate(&env);
+        let contract_id = env.register(IdentityContract {}, ());
+        let client = IdentityContractClient::new(&env, &contract_id);
+
+        let result = client.try_register_identity(&BytesN::random(&env), &wallet);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_revoke_identity_requires_auth() {
+        let env = Env::default();
+        let wallet = Address::generate(&env);
+        let contract_id = env.register(IdentityContract {}, ());
+        let client = IdentityContractClient::new(&env, &contract_id);
+
+        let result = client.try_revoke_identity(&wallet);
+        assert!(result.is_err());
+    }
 
     #[test]
     fn test_register_and_verify() {

--- a/contracts/reputation/src/lib.rs
+++ b/contracts/reputation/src/lib.rs
@@ -110,6 +110,7 @@ impl ReputationContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(ReputationError::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage()
             .instance()
@@ -128,7 +129,7 @@ impl ReputationContract {
         user: Address,
         user_type: UserType,
     ) -> Result<(), ReputationError> {
-        user.require_auth();
+        user.require_auth_for_args(&[&user_type]);
 
         if env
             .storage()
@@ -178,7 +179,7 @@ impl ReputationContract {
         rated: Address,
         score: u32,
     ) -> Result<u64, ReputationError> {
-        rater.require_auth();
+        rater.require_auth_for_args(&[&shipment_id, &rated, &score]);
 
         if !(1..=5).contains(&score) {
             return Err(ReputationError::InvalidScore);
@@ -274,7 +275,7 @@ impl ReputationContract {
         was_on_time: bool,
         was_successful: bool,
     ) -> Result<(), ReputationError> {
-        caller.require_auth();
+        caller.require_auth_for_args(&[&user, &was_on_time, &was_successful]);
 
         // Only the authorised contract or the admin may call this.
         let auth_contract: Address = env
@@ -445,6 +446,53 @@ mod tests {
         client.initialize(&admin, &auth_contract);
 
         (env, admin, auth_contract, client)
+    }
+
+    #[test]
+    fn test_initialize_requires_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let auth_contract = Address::generate(&env);
+        let contract_id = env.register(ReputationContract {}, ());
+        let client = ReputationContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&admin, &auth_contract);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_register_user_requires_auth() {
+        let env = Env::default();
+        let user = Address::generate(&env);
+        let contract_id = env.register(ReputationContract {}, ());
+        let client = ReputationContractClient::new(&env, &contract_id);
+
+        let result = client.try_register_user(&user, &UserType::Carrier);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_submit_rating_requires_auth() {
+        let env = Env::default();
+        let rater = Address::generate(&env);
+        let rated = Address::generate(&env);
+        let contract_id = env.register(ReputationContract {}, ());
+        let client = ReputationContractClient::new(&env, &contract_id);
+
+        let result = client.try_submit_rating(&rater, &1u64, &rated, &5u32);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_update_stats_requires_auth() {
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let user = Address::generate(&env);
+        let contract_id = env.register(ReputationContract {}, ());
+        let client = ReputationContractClient::new(&env, &contract_id);
+
+        let result = client.try_update_stats(&caller, &user, &true, &false);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/contracts/shipment/src/lib.rs
+++ b/contracts/shipment/src/lib.rs
@@ -74,6 +74,7 @@ impl ShipmentContract {
         if env.storage().instance().has(&DataKey::Admin) {
             return Err(ShipmentError::AlreadyInitialized);
         }
+        admin.require_auth();
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().persistent().set(&DataKey::Counter, &0u64);
         Ok(())
@@ -91,7 +92,7 @@ impl ShipmentContract {
         weight_kg: u32,
         price: i128,
     ) -> Result<u64, ShipmentError> {
-        shipper.require_auth();
+        shipper.require_auth_for_args(&[&origin, &destination, &cargo_description, &weight_kg, &price]);
 
         if weight_kg == 0 || price <= 0 {
             return Err(ShipmentError::InvalidInput);
@@ -257,7 +258,7 @@ impl ShipmentContract {
 
     /// Either party can raise a dispute when the shipment is InTransit or Delivered.
     pub fn raise_dispute(env: Env, caller: Address, shipment_id: u64) -> Result<(), ShipmentError> {
-        caller.require_auth();
+        caller.require_auth_for_args(&[&shipment_id]);
 
         let mut shipment = Self::load(&env, shipment_id)?;
 
@@ -290,7 +291,7 @@ impl ShipmentContract {
             .instance()
             .get(&DataKey::Admin)
             .ok_or(ShipmentError::NotInitialized)?;
-        admin.require_auth();
+        admin.require_auth_for_args(&[&shipment_id, &resolve_as_completed]);
 
         let mut shipment = Self::load(&env, shipment_id)?;
 
@@ -412,6 +413,111 @@ mod tests {
             &120,
             &5_000_000_000i128, // 500 XLM
         )
+    }
+
+    #[test]
+    fn test_initialize_requires_auth() {
+        let env = Env::default();
+        let admin = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_initialize(&admin);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_shipment_requires_auth() {
+        let env = Env::default();
+        let shipper = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_create_shipment(
+            &shipper,
+            &str(&env, "Lagos"),
+            &str(&env, "Nairobi"),
+            &str(&env, "Electronics"),
+            &120u32,
+            &5_000_000_000i128,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_confirm_delivery_requires_auth() {
+        let env = Env::default();
+        let shipper = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_confirm_delivery(&shipper, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_cancel_shipment_requires_auth() {
+        let env = Env::default();
+        let shipper = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_cancel_shipment(&shipper, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_accept_shipment_requires_auth() {
+        let env = Env::default();
+        let carrier = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_accept_shipment(&carrier, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mark_in_transit_requires_auth() {
+        let env = Env::default();
+        let carrier = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_mark_in_transit(&carrier, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_mark_delivered_requires_auth() {
+        let env = Env::default();
+        let carrier = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_mark_delivered(&carrier, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_raise_dispute_requires_auth() {
+        let env = Env::default();
+        let caller = Address::generate(&env);
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_raise_dispute(&caller, &1u64);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_dispute_requires_auth() {
+        let env = Env::default();
+        let contract_id = env.register(ShipmentContract {}, ());
+        let client = ShipmentContractClient::new(&env, &contract_id);
+
+        let result = client.try_resolve_dispute(&1u64, &true);
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
Authorization-audit—require_auth-coverage-on-every-sensitive-entrypoint
Closes #1237 
Closes #1238 
Closes #1242
Closes #1244 