### PR TITLE
feat: add UsersController, cost calculator, Stripe payments, and loading skeletons

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "class-validator": "^0.14.3",
         "cloudinary": "^2.7.0",
         "dotenv": "^16.4.7",
+        "helmet": "^8.0.0",
         "joi": "^17.13.3",
         "nestjs-pino": "^4.4.0",
         "nodemailer": "^6.10.1",
@@ -44,6 +45,7 @@
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
         "socket.io": "^4.8.3",
+        "stripe": "^22.3.2",
         "typeorm": "^0.3.27",
         "uuid": "^11.1.0"
       },
@@ -990,7 +992,6 @@
       "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -3330,7 +3331,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
       "integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "axios": "^1.3.1",
@@ -3388,7 +3388,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
       "integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.0.0",
         "iterare": "1.2.1",
@@ -3467,7 +3466,6 @@
       "integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3564,7 +3562,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.0.10.tgz",
       "integrity": "sha512-UVSf0yaWFBC2Zn2FOWABXxCnyG8XNIXrNnvTFpbUFqaJu1YDdwJ7wQBBqxq9CtJT7ILqSmfhOU7HS0d/0EAxpw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.0.1",
@@ -3586,7 +3583,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.1.12.tgz",
       "integrity": "sha512-1itTTYsAZecrq2NbJOkch32y8buLwN7UpcNRdJrhlS+ovJ5GxLx3RyJ3KylwBhbYnO5AeYyL1U/i4W5mg/4qDA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.3",
         "tslib": "2.8.1"
@@ -3759,7 +3755,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
       "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3773,7 +3768,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.1.12.tgz",
       "integrity": "sha512-ulSOYcgosx1TqY425cRC5oXtAu1R10+OSmVfgyR9ueR25k4luekURt8dzAZxhxSCI0OsDj9WKCFLTkEuAwg0wg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -4687,7 +4681,6 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -4759,7 +4752,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.17"
@@ -5146,7 +5138,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5325,7 +5316,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
       "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.20.0"
       }
@@ -5514,7 +5504,6 @@
       "integrity": "sha512-Tqoa05bu+t5s8CTZFaGpCH2ub3QeT9YDkXbPd3uQ4SfsLoh1/vv2GEYAioPoxCWJJNsenXlC88tRjwoHNts1oQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.24.1",
         "@typescript-eslint/types": "8.24.1",
@@ -6053,7 +6042,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6101,7 +6089,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6431,7 +6418,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
       "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6660,6 +6646,16 @@
       "integrity": "sha512-UtggzHLiTrmFOC/ogQ+Hy7VfoKoIwrP1UFcYtTxoCUdLtsIErT8+SWtOC2DH/snT9h+xDrcBEPcwKei1mzemgg==",
       "license": "Apache-2.0",
       "optional": true
+    },
+    "node_modules/bare-url": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
+      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base32.js": {
       "version": "0.1.0",
@@ -6969,7 +6965,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -7331,7 +7326,6 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7387,15 +7381,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8559,7 +8551,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8621,7 +8612,6 @@
       "integrity": "sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "build/bin/cli.js"
       },
@@ -10073,6 +10063,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
+      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -10709,7 +10705,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -13046,7 +13041,6 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
       "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -13469,7 +13463,6 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13633,7 +13626,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -13740,7 +13732,6 @@
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.6.0.tgz",
       "integrity": "sha512-i85pKRCt4qMjZ1+L7sy2Ag4t1atFcdbEt76+7iRJn1g2BvsnRMGu9p8pivl9fs63M2kF/A0OacFZhTub+m/qMg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -13772,7 +13763,6 @@
       "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-10.4.0.tgz",
       "integrity": "sha512-vjQsKBE+VN1LVchjbfLE7B6nBeGASZNRNKsR68VS0DolTm5R3zo+47JX1wjm0O96dcbvA7vnqt8YqOWlG5nN0w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "get-caller-file": "^2.0.5",
         "pino": "^9.0.0",
@@ -13935,7 +13925,6 @@
       "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14049,7 +14038,6 @@
       "version": "15.1.3",
       "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
       "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
@@ -14455,8 +14443,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/regenerator-runtime": {
       "version": "0.14.1",
@@ -14836,7 +14823,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15687,6 +15673,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stripe": {
+      "version": "22.3.2",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.3.2.tgz",
+      "integrity": "sha512-O13QOvgEIQvDlTy6Ubb5kB980wpbhmoZNsgCXKILjCMZS67f+bW+6w99k3gnSi/N1lkryoj1WYdpGT5Wc5edjg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/strnum": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
@@ -15943,7 +15946,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -16318,7 +16320,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16485,7 +16486,6 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.27.tgz",
       "integrity": "sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^3.17.0",
@@ -16696,7 +16696,6 @@
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17117,7 +17116,6 @@
       "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -17185,7 +17183,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -17623,23 +17620,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/bare-url": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-      "integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/helmet": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.3.0.tgz",
-      "integrity": "sha512-Qgpiaws3Sm30Av8Eah6sjMCZZwjlBu+E68rhpCWBshY1lb09HtLwj5GviX0OyQIn+ulUS0iX0AxN5n3tLZzz1w==",
-      "license": "MIT",
-      "dependencies": {}
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,6 +60,7 @@
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
     "socket.io": "^4.8.3",
+    "stripe": "^22.3.2",
     "typeorm": "^0.3.27",
     "uuid": "^11.1.0"
   },

--- a/backend/src/addresses/addresses.service.spec.ts
+++ b/backend/src/addresses/addresses.service.spec.ts
@@ -31,7 +31,12 @@ describe('AddressesService', () => {
 
   describe('create', () => {
     it('creates an address', async () => {
-      const dto = { label: 'HQ', address: '1 Main St', city: 'Lagos', country: 'Nigeria' };
+      const dto = {
+        label: 'HQ',
+        address: '1 Main St',
+        city: 'Lagos',
+        country: 'Nigeria',
+      };
       const saved = { id: 'uuid', userId: 'user1', ...dto, isDefault: false };
       repo.create.mockReturnValue(saved);
       repo.save.mockResolvedValue(saved);
@@ -42,13 +47,22 @@ describe('AddressesService', () => {
     });
 
     it('clears other defaults when isDefault=true', async () => {
-      const dto = { label: 'HQ', address: '1 Main St', city: 'Lagos', country: 'Nigeria', isDefault: true };
+      const dto = {
+        label: 'HQ',
+        address: '1 Main St',
+        city: 'Lagos',
+        country: 'Nigeria',
+        isDefault: true,
+      };
       const saved = { id: 'uuid', userId: 'user1', ...dto };
       repo.create.mockReturnValue(saved);
       repo.save.mockResolvedValue(saved);
 
       await service.create('user1', dto);
-      expect(repo.update).toHaveBeenCalledWith({ userId: 'user1' }, { isDefault: false });
+      expect(repo.update).toHaveBeenCalledWith(
+        { userId: 'user1' },
+        { isDefault: false },
+      );
     });
   });
 
@@ -56,19 +70,25 @@ describe('AddressesService', () => {
     it('returns addresses for user', async () => {
       repo.find.mockResolvedValue([]);
       await service.findAll('user1');
-      expect(repo.find).toHaveBeenCalledWith(expect.objectContaining({ where: { userId: 'user1' } }));
+      expect(repo.find).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { userId: 'user1' } }),
+      );
     });
   });
 
   describe('findOne', () => {
     it('throws NotFoundException when not found', async () => {
       repo.findOne.mockResolvedValue(null);
-      await expect(service.findOne('id', 'user1')).rejects.toThrow(NotFoundException);
+      await expect(service.findOne('id', 'user1')).rejects.toThrow(
+        NotFoundException,
+      );
     });
 
     it('throws ForbiddenException when wrong owner', async () => {
       repo.findOne.mockResolvedValue({ id: 'id', userId: 'other' });
-      await expect(service.findOne('id', 'user1')).rejects.toThrow(ForbiddenException);
+      await expect(service.findOne('id', 'user1')).rejects.toThrow(
+        ForbiddenException,
+      );
     });
   });
 

--- a/backend/src/admin/admin.controller.ts
+++ b/backend/src/admin/admin.controller.ts
@@ -119,7 +119,10 @@ export class AdminController {
   @Patch('certifications/:id/verify')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Verify or unverify a carrier certification' })
-  @ApiResponse({ status: 200, description: 'Certification verification updated' })
+  @ApiResponse({
+    status: 200,
+    description: 'Certification verification updated',
+  })
   @ApiResponse({ status: 404, description: 'Certification not found' })
   verifyCertification(
     @Param('id', ParseUUIDPipe) id: string,

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -24,6 +24,7 @@ import { AdminAuditInterceptor } from './audit-log/admin-audit.interceptor';
 import { CarriersModule } from './carriers/carriers.module';
 import { ReviewsModule } from './reviews/reviews.module';
 import { MessagingModule } from './messaging/messaging.module';
+import { PaymentsModule } from './payments/payments.module';
 
 const shipmentCreateTracker = (context: ExecutionContext): string => {
   const request = context.switchToHttp().getRequest<{
@@ -75,6 +76,8 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
         MAIL_PASS: Joi.string().required(),
         MAIL_FROM: Joi.string().default('noreply@freightflow.io'),
         UPLOAD_DIR: Joi.string().default('./uploads'),
+        STRIPE_SECRET_KEY: Joi.string().optional(),
+        STRIPE_WEBHOOK_SECRET: Joi.string().optional(),
       }),
       validationOptions: {
         allowUnknown: true,
@@ -131,6 +134,7 @@ const throttlerErrorMessage = (context: ExecutionContext): string => {
     CarriersModule,
     ReviewsModule,
     MessagingModule,
+    PaymentsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/backend/src/audit-log/audit-log.controller.ts
+++ b/backend/src/audit-log/audit-log.controller.ts
@@ -15,7 +15,9 @@ export class AuditLogController {
   constructor(private readonly auditLogService: AuditLogService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get paginated admin audit logs (filterable by action)' })
+  @ApiOperation({
+    summary: 'Get paginated admin audit logs (filterable by action)',
+  })
   findAll(@Query() query: QueryAuditLogDto) {
     return this.auditLogService.findAll(query);
   }

--- a/backend/src/auth/two-factor.service.ts
+++ b/backend/src/auth/two-factor.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, UnauthorizedException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  UnauthorizedException,
+  BadRequestException,
+} from '@nestjs/common';
 
 interface OtpRecord {
   code: string;

--- a/backend/src/bids/bids.controller.ts
+++ b/backend/src/bids/bids.controller.ts
@@ -61,7 +61,9 @@ export class BidsController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(RolesGuard)
   @Roles(UserRole.SHIPPER)
-  @ApiOperation({ summary: 'Shipper accepts a bid — assigns carrier, rejects others' })
+  @ApiOperation({
+    summary: 'Shipper accepts a bid — assigns carrier, rejects others',
+  })
   @ApiParam({ name: 'id', description: 'Shipment ID' })
   @ApiParam({ name: 'bidId', description: 'Bid ID' })
   acceptBid(

--- a/backend/src/bids/bids.service.spec.ts
+++ b/backend/src/bids/bids.service.spec.ts
@@ -53,30 +53,47 @@ describe('BidsService', () => {
     it('creates a bid on a PENDING shipment', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
       bidRepo.findOne.mockResolvedValue(null);
-      const bid = { id: 'bid1', shipmentId: 'ship1', carrierId: 'carrier1', proposedPrice: 100 };
+      const bid = {
+        id: 'bid1',
+        shipmentId: 'ship1',
+        carrierId: 'carrier1',
+        proposedPrice: 100,
+      };
       bidRepo.create.mockReturnValue(bid);
       bidRepo.save.mockResolvedValue(bid);
 
-      const result = await service.submitBid('ship1', 'carrier1', { proposedPrice: 100 });
+      const result = await service.submitBid('ship1', 'carrier1', {
+        proposedPrice: 100,
+      });
       expect(result).toEqual(bid);
     });
 
     it('throws if shipment not PENDING', async () => {
-      shipmentRepo.findOne.mockResolvedValue(pendingShipment({ status: ShipmentStatus.ACCEPTED }));
-      await expect(service.submitBid('ship1', 'carrier1', { proposedPrice: 100 })).rejects.toThrow(BadRequestException);
+      shipmentRepo.findOne.mockResolvedValue(
+        pendingShipment({ status: ShipmentStatus.ACCEPTED }),
+      );
+      await expect(
+        service.submitBid('ship1', 'carrier1', { proposedPrice: 100 }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('throws if carrier already has a pending bid', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
       bidRepo.findOne.mockResolvedValue({ id: 'existing' });
-      await expect(service.submitBid('ship1', 'carrier1', { proposedPrice: 100 })).rejects.toThrow(BadRequestException);
+      await expect(
+        service.submitBid('ship1', 'carrier1', { proposedPrice: 100 }),
+      ).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('getBids', () => {
     it('throws ForbiddenException if requester is not the shipper', async () => {
-      shipmentRepo.findOne.mockResolvedValue(pendingShipment({ shipperId: 'other' }));
-      await expect(service.getBids('ship1', 'shipper1')).rejects.toThrow(ForbiddenException);
+      shipmentRepo.findOne.mockResolvedValue(
+        pendingShipment({ shipperId: 'other' }),
+      );
+      await expect(service.getBids('ship1', 'shipper1')).rejects.toThrow(
+        ForbiddenException,
+      );
     });
 
     it('returns bids for the shipment owner', async () => {
@@ -90,7 +107,12 @@ describe('BidsService', () => {
   describe('acceptBid', () => {
     it('accepts bid and rejects others', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
-      const bid = { id: 'bid1', shipmentId: 'ship1', carrierId: 'carrier1', status: BidStatus.PENDING };
+      const bid = {
+        id: 'bid1',
+        shipmentId: 'ship1',
+        carrierId: 'carrier1',
+        status: BidStatus.PENDING,
+      };
       bidRepo.findOne.mockResolvedValue(bid);
       bidRepo.save.mockResolvedValue({ ...bid, status: BidStatus.ACCEPTED });
       bidRepo.update.mockResolvedValue(undefined);
@@ -99,18 +121,27 @@ describe('BidsService', () => {
       const result = await service.acceptBid('ship1', 'bid1', 'shipper1');
       expect(result.status).toBe(BidStatus.ACCEPTED);
       expect(bidRepo.update).toHaveBeenCalled();
-      expect(shipmentRepo.update).toHaveBeenCalledWith('ship1', expect.objectContaining({ carrierId: 'carrier1' }));
+      expect(shipmentRepo.update).toHaveBeenCalledWith(
+        'ship1',
+        expect.objectContaining({ carrierId: 'carrier1' }),
+      );
     });
 
     it('throws ForbiddenException if not the shipper', async () => {
-      shipmentRepo.findOne.mockResolvedValue(pendingShipment({ shipperId: 'other' }));
-      await expect(service.acceptBid('ship1', 'bid1', 'shipper1')).rejects.toThrow(ForbiddenException);
+      shipmentRepo.findOne.mockResolvedValue(
+        pendingShipment({ shipperId: 'other' }),
+      );
+      await expect(
+        service.acceptBid('ship1', 'bid1', 'shipper1'),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('throws NotFoundException if bid not found', async () => {
       shipmentRepo.findOne.mockResolvedValue(pendingShipment());
       bidRepo.findOne.mockResolvedValue(null);
-      await expect(service.acceptBid('ship1', 'bid1', 'shipper1')).rejects.toThrow(NotFoundException);
+      await expect(
+        service.acceptBid('ship1', 'bid1', 'shipper1'),
+      ).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/backend/src/bids/bids.service.ts
+++ b/backend/src/bids/bids.service.ts
@@ -24,7 +24,8 @@ export class BidsService {
     const shipment = await this.shipmentRepo.findOne({
       where: { id: shipmentId },
     });
-    if (!shipment) throw new NotFoundException(`Shipment ${shipmentId} not found`);
+    if (!shipment)
+      throw new NotFoundException(`Shipment ${shipmentId} not found`);
     return shipment;
   }
 
@@ -35,14 +36,18 @@ export class BidsService {
   ): Promise<Bid> {
     const shipment = await this.getShipment(shipmentId);
     if (shipment.status !== ShipmentStatus.PENDING) {
-      throw new BadRequestException('Bids can only be placed on PENDING shipments');
+      throw new BadRequestException(
+        'Bids can only be placed on PENDING shipments',
+      );
     }
 
     const existing = await this.bidRepo.findOne({
       where: { shipmentId, carrierId, status: BidStatus.PENDING },
     });
     if (existing) {
-      throw new BadRequestException('You already have a pending bid on this shipment');
+      throw new BadRequestException(
+        'You already have a pending bid on this shipment',
+      );
     }
 
     const bid = this.bidRepo.create({
@@ -79,7 +84,9 @@ export class BidsService {
       throw new BadRequestException('Shipment is no longer accepting bids');
     }
 
-    const bid = await this.bidRepo.findOne({ where: { id: bidId, shipmentId } });
+    const bid = await this.bidRepo.findOne({
+      where: { id: bidId, shipmentId },
+    });
     if (!bid) throw new NotFoundException(`Bid ${bidId} not found`);
     if (bid.status !== BidStatus.PENDING) {
       throw new BadRequestException('Bid is no longer pending');

--- a/backend/src/bids/entities/bid.entity.ts
+++ b/backend/src/bids/entities/bid.entity.ts
@@ -22,7 +22,11 @@ export class Bid {
   id: string;
 
   @Index()
-  @ManyToOne(() => Shipment, { eager: false, nullable: false, onDelete: 'CASCADE' })
+  @ManyToOne(() => Shipment, {
+    eager: false,
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'shipment_id' })
   shipment: Shipment;
 

--- a/backend/src/carriers/carrier-certifications.service.spec.ts
+++ b/backend/src/carriers/carrier-certifications.service.spec.ts
@@ -2,7 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { CarrierCertificationsService } from './carrier-certifications.service';
-import { CarrierCertification, CertificationType } from './entities/carrier-certification.entity';
+import {
+  CarrierCertification,
+  CertificationType,
+} from './entities/carrier-certification.entity';
 import {
   CreateCarrierCertificationDto,
   UpdateCertificationVerificationDto,

--- a/backend/src/carriers/carrier-earnings.service.ts
+++ b/backend/src/carriers/carrier-earnings.service.ts
@@ -29,7 +29,10 @@ export class CarrierEarningsService {
       select: ['id', 'price', 'actualDeliveryDate'],
     });
 
-    const lifetimeEarnings = completed.reduce((sum, s) => sum + Number(s.price), 0);
+    const lifetimeEarnings = completed.reduce(
+      (sum, s) => sum + Number(s.price),
+      0,
+    );
 
     const now = new Date();
     const currentMonthKey = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
@@ -54,9 +57,13 @@ export class CarrierEarningsService {
       }
     }
 
-    const monthlyBreakdown: MonthlyBreakdown[] = Array.from(buckets.entries()).map(
-      ([month, { earnings, count }]) => ({ month, earnings, completedShipments: count }),
-    );
+    const monthlyBreakdown: MonthlyBreakdown[] = Array.from(
+      buckets.entries(),
+    ).map(([month, { earnings, count }]) => ({
+      month,
+      earnings,
+      completedShipments: count,
+    }));
 
     const currentMonthEarnings = buckets.get(currentMonthKey)?.earnings ?? 0;
 

--- a/backend/src/carriers/carriers.controller.ts
+++ b/backend/src/carriers/carriers.controller.ts
@@ -30,7 +30,9 @@ export class CarriersController {
   @Get('me/metrics')
   @UseGuards(RolesGuard)
   @Roles(UserRole.CARRIER)
-  @ApiOperation({ summary: 'Get performance metrics for the authenticated carrier' })
+  @ApiOperation({
+    summary: 'Get performance metrics for the authenticated carrier',
+  })
   getMyMetrics(@CurrentUser() user: User) {
     return this.carriersService.getMyMetrics(user.id);
   }
@@ -58,7 +60,10 @@ export class CarriersController {
 
   @Get(':id/certifications')
   @UseGuards(RolesGuard)
-  @ApiOperation({ summary: 'Get certifications for a carrier (visible to all authenticated users)' })
+  @ApiOperation({
+    summary:
+      'Get certifications for a carrier (visible to all authenticated users)',
+  })
   getCarrierCertifications(@Param('id', ParseUUIDPipe) id: string) {
     return this.certificationsService.findByCarrierId(id);
   }

--- a/backend/src/carriers/carriers.service.ts
+++ b/backend/src/carriers/carriers.service.ts
@@ -14,14 +14,27 @@ export class CarriersService {
   async getMyMetrics(carrierId: string) {
     const shipments = await this.shipmentRepo.find({
       where: { carrierId },
-      select: ['id', 'status', 'price', 'currency', 'estimatedDeliveryDate', 'actualDeliveryDate'],
+      select: [
+        'id',
+        'status',
+        'price',
+        'currency',
+        'estimatedDeliveryDate',
+        'actualDeliveryDate',
+      ],
     });
 
-    const completed = shipments.filter((s) => s.status === ShipmentStatus.COMPLETED);
-    const delivered = shipments.filter(
-      (s) => s.status === ShipmentStatus.DELIVERED || s.status === ShipmentStatus.COMPLETED,
+    const completed = shipments.filter(
+      (s) => s.status === ShipmentStatus.COMPLETED,
     );
-    const cancelled = shipments.filter((s) => s.status === ShipmentStatus.CANCELLED);
+    const delivered = shipments.filter(
+      (s) =>
+        s.status === ShipmentStatus.DELIVERED ||
+        s.status === ShipmentStatus.COMPLETED,
+    );
+    const cancelled = shipments.filter(
+      (s) => s.status === ShipmentStatus.CANCELLED,
+    );
 
     const totalAccepted = shipments.filter(
       (s) => s.status !== ShipmentStatus.PENDING,
@@ -34,11 +47,16 @@ export class CarriersService {
         new Date(s.actualDeliveryDate) <= new Date(s.estimatedDeliveryDate),
     ).length;
 
-    const onTimeRate = delivered.length > 0 ? onTimeDeliveries / delivered.length : 0;
+    const onTimeRate =
+      delivered.length > 0 ? onTimeDeliveries / delivered.length : 0;
 
-    const totalEarnings = completed.reduce((sum, s) => sum + Number(s.price), 0);
+    const totalEarnings = completed.reduce(
+      (sum, s) => sum + Number(s.price),
+      0,
+    );
 
-    const cancellationRate = totalAccepted > 0 ? cancelled.length / totalAccepted : 0;
+    const cancellationRate =
+      totalAccepted > 0 ? cancelled.length / totalAccepted : 0;
 
     return {
       totalAccepted,

--- a/backend/src/common/cursor-pagination.util.ts
+++ b/backend/src/common/cursor-pagination.util.ts
@@ -1,7 +1,7 @@
 import { Repository, FindOptionsWhere, LessThan } from 'typeorm';
 
 export interface CursorPageOptions {
-  cursor?: string;   // opaque base64 cursor from previous response
+  cursor?: string; // opaque base64 cursor from previous response
   limit?: number;
   // Legacy offset fallback
   page?: number;
@@ -26,7 +26,9 @@ export function encodeCursor(createdAt: Date, id: string): string {
 
 export function decodeCursor(cursor: string): CursorPayload {
   try {
-    return JSON.parse(Buffer.from(cursor, 'base64url').toString('utf8')) as CursorPayload;
+    return JSON.parse(
+      Buffer.from(cursor, 'base64url').toString('utf8'),
+    ) as CursorPayload;
   } catch {
     throw new Error('Invalid pagination cursor');
   }
@@ -40,7 +42,10 @@ export async function cursorPaginate<T extends { id: string; createdAt: Date }>(
   const limit = Math.min(options.limit ?? 20, 100);
 
   // Offset fallback for backwards compatibility
-  if (!options.cursor && (options.page !== undefined || options.pageSize !== undefined)) {
+  if (
+    !options.cursor &&
+    (options.page !== undefined || options.pageSize !== undefined)
+  ) {
     const page = options.page ?? 1;
     const pageSize = options.pageSize ?? limit;
     const [data, total] = await repo.findAndCount({

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,13 +7,12 @@ async function bootstrap() {
   const logger = new Logger('Bootstrap');
 
   try {
-    // Start NestJS application
-    const app = await NestFactory.create(AppModule);
+    const app = await NestFactory.create(AppModule, {
+      rawBody: true,
+    });
 
-    // GLOBAL PREFIX (optional, keeps API versioned/clean)
     app.setGlobalPrefix('api/v1');
 
-    // GLOBAL VALIDATION PIPES
     app.useGlobalPipes(
       new ValidationPipe({
         whitelist: true,
@@ -22,13 +21,11 @@ async function bootstrap() {
       }),
     );
 
-    // ENABLE CORS
     app.enableCors({
       origin: process.env.FRONTEND_URL?.split(',') || ['http://localhost:3000'],
       credentials: true,
     });
 
-    // SWAGGER DOCUMENTATION
     const config = new DocumentBuilder()
       .setTitle('FreightFlow')
       .setDescription('API Documentation for FreightFlow Project')
@@ -36,7 +33,7 @@ async function bootstrap() {
       .setTermsOfService('terms-of-service')
       .setLicense('MIT License', 'mit')
       .addServer('http://localhost:6006')
-      .addBearerAuth() // 🚀 for future auth-secured endpoints
+      .addBearerAuth()
       .build();
 
     const document = SwaggerModule.createDocument(app, config);

--- a/backend/src/notification-preferences/notification-preferences.controller.ts
+++ b/backend/src/notification-preferences/notification-preferences.controller.ts
@@ -12,14 +12,19 @@ export class NotificationPreferencesController {
   constructor(private readonly prefsService: NotificationPreferencesService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get notification preferences for the current user' })
+  @ApiOperation({
+    summary: 'Get notification preferences for the current user',
+  })
   get(@CurrentUser() user: User) {
     return this.prefsService.getOrCreate(user.id);
   }
 
   @Patch()
   @ApiOperation({ summary: 'Update notification preferences' })
-  update(@CurrentUser() user: User, @Body() dto: UpdateNotificationPreferencesDto) {
+  update(
+    @CurrentUser() user: User,
+    @Body() dto: UpdateNotificationPreferencesDto,
+  ) {
     return this.prefsService.update(user.id, dto);
   }
 }

--- a/backend/src/notification-preferences/notification-preferences.service.spec.ts
+++ b/backend/src/notification-preferences/notification-preferences.service.spec.ts
@@ -79,7 +79,10 @@ describe('NotificationPreferencesService', () => {
     });
 
     it('returns false for disabled preference', async () => {
-      repo.findOne.mockResolvedValue({ ...defaultPrefs(), shipmentDisputed: false });
+      repo.findOne.mockResolvedValue({
+        ...defaultPrefs(),
+        shipmentDisputed: false,
+      });
       const result = await service.isEnabled('user1', 'shipmentDisputed');
       expect(result).toBe(false);
     });

--- a/backend/src/notification-preferences/notification-preferences.service.ts
+++ b/backend/src/notification-preferences/notification-preferences.service.ts
@@ -31,9 +31,12 @@ export class NotificationPreferencesService {
 
   async isEnabled(
     userId: string,
-    key: keyof Omit<NotificationPreferences, 'id' | 'userId' | 'user' | 'updatedAt'>,
+    key: keyof Omit<
+      NotificationPreferences,
+      'id' | 'userId' | 'user' | 'updatedAt'
+    >,
   ): Promise<boolean> {
     const prefs = await this.getOrCreate(userId);
-    return prefs[key] as boolean;
+    return prefs[key];
   }
 }

--- a/backend/src/payments/dto/create-checkout.dto.ts
+++ b/backend/src/payments/dto/create-checkout.dto.ts
@@ -1,0 +1,9 @@
+import { IsUUID, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateCheckoutDto {
+  @ApiProperty({ example: 'b2a1c3d4-e5f6-7890-abcd-ef1234567890' })
+  @IsUUID()
+  @IsNotEmpty()
+  shipmentId: string;
+}

--- a/backend/src/payments/entities/invoice.entity.ts
+++ b/backend/src/payments/entities/invoice.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export enum InvoiceStatus {
+  PENDING = 'pending',
+  PAID = 'paid',
+  FAILED = 'failed',
+}
+
+@Entity('invoices')
+export class Invoice {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'shipment_id' })
+  shipmentId: string;
+
+  @Column({ type: 'decimal', precision: 14, scale: 2 })
+  amount: number;
+
+  @Column({
+    type: 'enum',
+    enum: InvoiceStatus,
+    default: InvoiceStatus.PENDING,
+  })
+  status: InvoiceStatus;
+
+  @Column({ name: 'stripe_payment_intent_id', nullable: true, type: 'varchar' })
+  stripePaymentIntentId: string | null;
+
+  @Column({ name: 'stripe_session_id', nullable: true, type: 'varchar' })
+  stripeSessionId: string | null;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -1,0 +1,70 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Headers,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Post,
+  RawBodyRequest,
+  Req,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiParam,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Request } from 'express';
+import { Public } from '../auth/decorators/public.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+import { CreateCheckoutDto } from './dto/create-checkout.dto';
+import { PaymentsService } from './payments.service';
+
+@ApiTags('payments')
+@Controller('payments')
+export class PaymentsController {
+  constructor(private readonly paymentsService: PaymentsService) {}
+
+  @Post('checkout')
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a Stripe Checkout session for a shipment' })
+  @ApiResponse({ status: 201, description: 'Checkout session created' })
+  createCheckout(@CurrentUser() user: User, @Body() dto: CreateCheckoutDto) {
+    return this.paymentsService.createCheckoutSession(dto.shipmentId, user.id);
+  }
+
+  @Public()
+  @Post('webhook')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Stripe webhook receiver (raw body)' })
+  @ApiResponse({ status: 200, description: 'Webhook acknowledged' })
+  async handleWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Headers('stripe-signature') signature: string,
+  ) {
+    const event = this.paymentsService.constructWebhookEvent(
+      req.rawBody!,
+      signature,
+    );
+    return this.paymentsService.handleWebhook(event);
+  }
+
+  @Get('invoice/:shipmentId')
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get invoice for a shipment' })
+  @ApiParam({
+    name: 'shipmentId',
+    example: 'b2a1c3d4-e5f6-7890-abcd-ef1234567890',
+  })
+  @ApiResponse({ status: 200, description: 'Invoice returned' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  getInvoice(@Param('shipmentId', ParseUUIDPipe) shipmentId: string) {
+    return this.paymentsService.getInvoice(shipmentId);
+  }
+}

--- a/backend/src/payments/payments.module.ts
+++ b/backend/src/payments/payments.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Invoice } from './entities/invoice.entity';
+import { PaymentsService } from './payments.service';
+import { PaymentsController } from './payments.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Invoice])],
+  controllers: [PaymentsController],
+  providers: [PaymentsService],
+  exports: [PaymentsService],
+})
+export class PaymentsModule {}

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -1,0 +1,150 @@
+import {
+  Injectable,
+  NotFoundException,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import Stripe from 'stripe';
+import { ConfigService } from '@nestjs/config';
+import { Invoice, InvoiceStatus } from './entities/invoice.entity';
+
+@Injectable()
+export class PaymentsService {
+  private readonly logger = new Logger(PaymentsService.name);
+  private readonly stripe: Stripe;
+
+  constructor(
+    @InjectRepository(Invoice)
+    private readonly invoiceRepo: Repository<Invoice>,
+    private readonly configService: ConfigService,
+  ) {
+    this.stripe = new Stripe(
+      this.configService.get<string>('STRIPE_SECRET_KEY', ''),
+      { apiVersion: '2025-06-30.basil' as Stripe.LatestApiVersion },
+    );
+  }
+
+  async createCheckoutSession(
+    shipmentId: string,
+    userId: string,
+  ): Promise<{ sessionId: string; url: string }> {
+    const invoice = await this.invoiceRepo.findOne({
+      where: { shipmentId, status: InvoiceStatus.PAID },
+    });
+    if (invoice) {
+      throw new BadRequestException('Shipment already paid');
+    }
+
+    const frontendUrl = this.configService.get<string>(
+      'FRONTEND_URL',
+      'http://localhost:3000',
+    );
+
+    const session = await this.stripe.checkout.sessions.create({
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: `FreightFlow Shipment — ${shipmentId}`,
+            },
+            unit_amount: 5000,
+          },
+          quantity: 1,
+        },
+      ],
+      mode: 'payment',
+      success_url: `${frontendUrl}/payments/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${frontendUrl}/payments/cancel?session_id={CHECKOUT_SESSION_ID}`,
+      metadata: {
+        shipmentId,
+        userId,
+      },
+    });
+
+    let existingInvoice = await this.invoiceRepo.findOne({
+      where: { shipmentId },
+    });
+    if (!existingInvoice) {
+      existingInvoice = this.invoiceRepo.create({
+        shipmentId,
+        amount: 50,
+        status: InvoiceStatus.PENDING,
+        stripeSessionId: session.id,
+      });
+    } else {
+      existingInvoice.stripeSessionId = session.id;
+    }
+    await this.invoiceRepo.save(existingInvoice);
+
+    return { sessionId: session.id, url: session.url! };
+  }
+
+  async handleWebhook(event: Stripe.Event): Promise<{ received: boolean }> {
+    switch (event.type) {
+      case 'checkout.session.completed': {
+        const session = event.data.object;
+        const shipmentId = session.metadata?.shipmentId;
+        if (!shipmentId) {
+          this.logger.warn('Webhook missing shipmentId metadata');
+          break;
+        }
+
+        const invoice = await this.invoiceRepo.findOne({
+          where: { shipmentId },
+        });
+        if (invoice) {
+          invoice.status = InvoiceStatus.PAID;
+          invoice.stripePaymentIntentId =
+            typeof session.payment_intent === 'string'
+              ? session.payment_intent
+              : null;
+          await this.invoiceRepo.save(invoice);
+        }
+        break;
+      }
+      case 'checkout.session.expired': {
+        const session = event.data.object;
+        const shipmentId = session.metadata?.shipmentId;
+        if (shipmentId) {
+          const invoice = await this.invoiceRepo.findOne({
+            where: { shipmentId },
+          });
+          if (invoice && invoice.status === InvoiceStatus.PENDING) {
+            invoice.status = InvoiceStatus.FAILED;
+            await this.invoiceRepo.save(invoice);
+          }
+        }
+        break;
+      }
+    }
+
+    return { received: true };
+  }
+
+  async getInvoice(shipmentId: string): Promise<Invoice> {
+    const invoice = await this.invoiceRepo.findOne({
+      where: { shipmentId },
+    });
+    if (!invoice) {
+      throw new NotFoundException(
+        `Invoice for shipment ${shipmentId} not found`,
+      );
+    }
+    return invoice;
+  }
+
+  constructWebhookEvent(payload: Buffer, signature: string): Stripe.Event {
+    const webhookSecret = this.configService.get<string>(
+      'STRIPE_WEBHOOK_SECRET',
+    )!;
+    return this.stripe.webhooks.constructEvent(
+      payload,
+      signature,
+      webhookSecret,
+    );
+  }
+}

--- a/backend/src/reviews/reviews.controller.ts
+++ b/backend/src/reviews/reviews.controller.ts
@@ -1,4 +1,11 @@
-import { Body, Controller, Get, Param, ParseUUIDPipe, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseUUIDPipe,
+  Post,
+} from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { ReviewsService } from './reviews.service';
 import { CreateReviewDto } from './dto/create-review.dto';
@@ -34,4 +41,3 @@ export class UserRatingController {
     return this.reviewsService.getAverageRating(id);
   }
 }
-

--- a/backend/src/reviews/reviews.service.spec.ts
+++ b/backend/src/reviews/reviews.service.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { BadRequestException, ConflictException, ForbiddenException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import { ReviewsService } from './reviews.service';
 import { Review } from './entities/review.entity';
 import { Shipment } from '../shipments/entities/shipment.entity';
@@ -63,7 +67,12 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
 
 describe('ReviewsService', () => {
   let service: ReviewsService;
-  let reviewRepo: { findOne: jest.Mock; create: jest.Mock; save: jest.Mock; createQueryBuilder: jest.Mock };
+  let reviewRepo: {
+    findOne: jest.Mock;
+    create: jest.Mock;
+    save: jest.Mock;
+    createQueryBuilder: jest.Mock;
+  };
   let shipmentRepo: { findOne: jest.Mock };
 
   beforeEach(async () => {
@@ -101,28 +110,40 @@ describe('ReviewsService', () => {
 
       expect(result).toBe(review);
       expect(reviewRepo.create).toHaveBeenCalledWith(
-        expect.objectContaining({ reviewerId: 'shipper-1', revieweeId: 'carrier-1', rating: 5 }),
+        expect.objectContaining({
+          reviewerId: 'shipper-1',
+          revieweeId: 'carrier-1',
+          rating: 5,
+        }),
       );
     });
 
     it('throws BadRequestException if shipment not COMPLETED', async () => {
-      shipmentRepo.findOne.mockResolvedValue(makeShipment({ status: ShipmentStatus.DELIVERED }));
+      shipmentRepo.findOne.mockResolvedValue(
+        makeShipment({ status: ShipmentStatus.DELIVERED }),
+      );
 
-      await expect(service.create('ship-1', makeUser(), { rating: 4 })).rejects.toThrow(BadRequestException);
+      await expect(
+        service.create('ship-1', makeUser(), { rating: 4 }),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('throws ForbiddenException if reviewer is not a party', async () => {
       shipmentRepo.findOne.mockResolvedValue(makeShipment());
       const outsider = makeUser({ id: 'outsider-1' });
 
-      await expect(service.create('ship-1', outsider, { rating: 3 })).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.create('ship-1', outsider, { rating: 3 }),
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('throws ConflictException on duplicate review', async () => {
       shipmentRepo.findOne.mockResolvedValue(makeShipment());
       reviewRepo.findOne.mockResolvedValue({ id: 'existing-review' });
 
-      await expect(service.create('ship-1', makeUser(), { rating: 5 })).rejects.toThrow(ConflictException);
+      await expect(
+        service.create('ship-1', makeUser(), { rating: 5 }),
+      ).rejects.toThrow(ConflictException);
     });
   });
 

--- a/backend/src/reviews/reviews.service.ts
+++ b/backend/src/reviews/reviews.service.ts
@@ -21,24 +21,35 @@ export class ReviewsService {
     private readonly shipmentRepo: Repository<Shipment>,
   ) {}
 
-  async create(shipmentId: string, reviewer: User, dto: CreateReviewDto): Promise<Review> {
-    const shipment = await this.shipmentRepo.findOne({ where: { id: shipmentId } });
+  async create(
+    shipmentId: string,
+    reviewer: User,
+    dto: CreateReviewDto,
+  ): Promise<Review> {
+    const shipment = await this.shipmentRepo.findOne({
+      where: { id: shipmentId },
+    });
     if (!shipment) throw new BadRequestException('Shipment not found');
 
     if (shipment.status !== ShipmentStatus.COMPLETED) {
-      throw new BadRequestException('Reviews can only be left for completed shipments');
+      throw new BadRequestException(
+        'Reviews can only be left for completed shipments',
+      );
     }
 
     const isShipper = shipment.shipperId === reviewer.id;
     const isCarrier = shipment.carrierId === reviewer.id;
     if (!isShipper && !isCarrier) {
-      throw new ForbiddenException('Only parties to the shipment can leave a review');
+      throw new ForbiddenException(
+        'Only parties to the shipment can leave a review',
+      );
     }
 
     const existing = await this.reviewRepo.findOne({
       where: { shipmentId, reviewerId: reviewer.id },
     });
-    if (existing) throw new ConflictException('You have already reviewed this shipment');
+    if (existing)
+      throw new ConflictException('You have already reviewed this shipment');
 
     // Shipper reviews carrier, carrier reviews shipper
     const revieweeId = isShipper ? shipment.carrierId! : shipment.shipperId;
@@ -54,7 +65,9 @@ export class ReviewsService {
     return this.reviewRepo.save(review);
   }
 
-  async getAverageRating(userId: string): Promise<{ averageRating: number; totalReviews: number }> {
+  async getAverageRating(
+    userId: string,
+  ): Promise<{ averageRating: number; totalReviews: number }> {
     const result = await this.reviewRepo
       .createQueryBuilder('r')
       .where('r.reviewee_id = :userId', { userId })
@@ -63,7 +76,9 @@ export class ReviewsService {
       .getRawOne<{ avg: string | null; count: string }>();
 
     return {
-      averageRating: result?.avg ? Math.round(Number(result.avg) * 100) / 100 : 0,
+      averageRating: result?.avg
+        ? Math.round(Number(result.avg) * 100) / 100
+        : 0,
       totalReviews: Number(result?.count ?? 0),
     };
   }

--- a/backend/src/shipments/cancellation-fee.service.ts
+++ b/backend/src/shipments/cancellation-fee.service.ts
@@ -32,18 +32,28 @@ export class CancellationFeeService {
 
   calculateFee(price: number, status: ShipmentStatus): number {
     const rate = FEE_TIERS[status] ?? null;
-    if (rate === null) throw new BadRequestException(`Shipment in status "${status}" cannot be cancelled`);
+    if (rate === null)
+      throw new BadRequestException(
+        `Shipment in status "${status}" cannot be cancelled`,
+      );
     return Math.round(price * rate * 100) / 100;
   }
 
   async cancelShipment(shipmentId: string): Promise<CancellationResult> {
-    const shipment = await this.shipmentRepo.findOneOrFail({ where: { id: shipmentId } });
+    const shipment = await this.shipmentRepo.findOneOrFail({
+      where: { id: shipmentId },
+    });
 
     if (!CANCELLABLE.has(shipment.status)) {
-      throw new BadRequestException(`Cannot cancel a shipment with status "${shipment.status}"`);
+      throw new BadRequestException(
+        `Cannot cancel a shipment with status "${shipment.status}"`,
+      );
     }
 
-    const cancellationFee = this.calculateFee(Number(shipment.price), shipment.status);
+    const cancellationFee = this.calculateFee(
+      Number(shipment.price),
+      shipment.status,
+    );
 
     await this.shipmentRepo.update(shipmentId, {
       status: ShipmentStatus.CANCELLED,

--- a/backend/src/shipments/dispute-evidence.service.ts
+++ b/backend/src/shipments/dispute-evidence.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 
 export interface DisputeEvidence {
   id: string;
@@ -38,7 +42,11 @@ export class DisputeEvidenceService {
     }
   }
 
-  submit(shipmentId: string, userId: string, dto: SubmitEvidenceDto): DisputeEvidence {
+  submit(
+    shipmentId: string,
+    userId: string,
+    dto: SubmitEvidenceDto,
+  ): DisputeEvidence {
     const shipment = this.getShipment(shipmentId);
     this.assertAccess(shipment, userId);
 
@@ -56,7 +64,11 @@ export class DisputeEvidenceService {
     return record;
   }
 
-  findAll(shipmentId: string, userId: string, isAdmin: boolean): DisputeEvidence[] {
+  findAll(
+    shipmentId: string,
+    userId: string,
+    isAdmin: boolean,
+  ): DisputeEvidence[] {
     const shipment = this.getShipment(shipmentId);
     if (!isAdmin) this.assertAccess(shipment, userId);
     return this.evidence.get(shipmentId) ?? [];

--- a/backend/src/shipments/dto/analytics-query.dto.ts
+++ b/backend/src/shipments/dto/analytics-query.dto.ts
@@ -2,12 +2,18 @@ import { IsOptional, IsDateString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AnalyticsQueryDto {
-  @ApiPropertyOptional({ description: 'Start date (ISO 8601)', example: '2024-01-01' })
+  @ApiPropertyOptional({
+    description: 'Start date (ISO 8601)',
+    example: '2024-01-01',
+  })
   @IsOptional()
   @IsDateString()
   from?: string;
 
-  @ApiPropertyOptional({ description: 'End date (ISO 8601)', example: '2024-12-31' })
+  @ApiPropertyOptional({
+    description: 'End date (ISO 8601)',
+    example: '2024-12-31',
+  })
   @IsOptional()
   @IsDateString()
   to?: string;

--- a/backend/src/shipments/dto/batch-create-shipments.dto.ts
+++ b/backend/src/shipments/dto/batch-create-shipments.dto.ts
@@ -1,4 +1,9 @@
-import { IsArray, ArrayMinSize, ArrayMaxSize, ValidateNested } from 'class-validator';
+import {
+  IsArray,
+  ArrayMinSize,
+  ArrayMaxSize,
+  ValidateNested,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
 import { CreateShipmentDto } from './create-shipment.dto';

--- a/backend/src/shipments/dto/calculate-cost.dto.ts
+++ b/backend/src/shipments/dto/calculate-cost.dto.ts
@@ -1,0 +1,40 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsPositive,
+  IsOptional,
+  IsEnum,
+  MaxLength,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { CargoCategory } from '../../common/enums/cargo-category.enum';
+
+export class CalculateCostDto {
+  @ApiProperty({ example: 'Lagos, Nigeria' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  origin: string;
+
+  @ApiProperty({ example: 'Abuja, Nigeria' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(255)
+  destination: string;
+
+  @ApiProperty({ example: 500.5, description: 'Weight in kilograms' })
+  @Type(() => Number)
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @IsPositive()
+  weight: number;
+
+  @ApiPropertyOptional({
+    enum: CargoCategory,
+    example: CargoCategory.ELECTRONICS,
+  })
+  @IsOptional()
+  @IsEnum(CargoCategory)
+  cargoCategory?: CargoCategory;
+}

--- a/backend/src/shipments/dto/query-shipment.dto.ts
+++ b/backend/src/shipments/dto/query-shipment.dto.ts
@@ -1,4 +1,12 @@
-import { IsOptional, IsEnum, IsString, IsInt, IsNumber, Min, Max } from 'class-validator';
+import {
+  IsOptional,
+  IsEnum,
+  IsString,
+  IsInt,
+  IsNumber,
+  Min,
+  Max,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { ShipmentStatus } from '../../common/enums/shipment-status.enum';

--- a/backend/src/shipments/eta.service.ts
+++ b/backend/src/shipments/eta.service.ts
@@ -24,7 +24,8 @@ const ZONE_MAP: Record<string, number> = {
 
 function resolveZone(location: string): string {
   const l = location.toUpperCase();
-  if (/\b(US|CA|MX|BR|AR)\b/.test(l)) return l.includes('CA') ? 'CA' : l.includes('MX') ? 'MX' : 'US';
+  if (/\b(US|CA|MX|BR|AR)\b/.test(l))
+    return l.includes('CA') ? 'CA' : l.includes('MX') ? 'MX' : 'US';
   if (/\b(UK|DE|FR|IT|ES|NL|PL|SE)\b/.test(l)) return 'EU';
   if (/\b(CN|JP|KR|IN|SG|TH|VN)\b/.test(l)) return 'AS';
   return 'US';

--- a/backend/src/shipments/shipment-template.service.ts
+++ b/backend/src/shipments/shipment-template.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
 
 export interface ShipmentTemplate {
   id: string;
@@ -50,8 +54,16 @@ export class ShipmentTemplateService {
     this.templates.delete(id);
   }
 
-  buildShipmentFromTemplate(id: string, userId: string): Omit<ShipmentTemplate, 'id' | 'userId' | 'name'> {
-    const { name: _n, id: _id, userId: _u, ...shipmentData } = this.findOne(id, userId);
+  buildShipmentFromTemplate(
+    id: string,
+    userId: string,
+  ): Omit<ShipmentTemplate, 'id' | 'userId' | 'name'> {
+    const {
+      name: _n,
+      id: _id,
+      userId: _u,
+      ...shipmentData
+    } = this.findOne(id, userId);
     return shipmentData;
   }
 }

--- a/backend/src/shipments/shipments.controller.ts
+++ b/backend/src/shipments/shipments.controller.ts
@@ -23,7 +23,9 @@ import { CreateShipmentDto } from './dto/create-shipment.dto';
 import { UpdateShipmentDto } from './dto/update-shipment.dto';
 import { QueryShipmentDto } from './dto/query-shipment.dto';
 import { BatchCreateShipmentsDto } from './dto/batch-create-shipments.dto';
+import { CalculateCostDto } from './dto/calculate-cost.dto';
 import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Public } from '../auth/decorators/public.decorator';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
 import { UserRole } from '../common/enums/role.enum';
@@ -64,6 +66,15 @@ class CancelBody {
 export class ShipmentsController {
   constructor(private readonly shipmentsService: ShipmentsService) {}
 
+  @Public()
+  @Post('calculate-cost')
+  @Throttle({ default: { limit: 30, ttl: 60_000 } })
+  @ApiOperation({ summary: 'Estimate shipment cost (public)' })
+  @ApiResponse({ status: 201, description: 'Cost estimate returned' })
+  calculateCost(@Body() dto: CalculateCostDto) {
+    return this.shipmentsService.calculateCost(dto);
+  }
+
   // ── Shipper actions ──────────────────────────────────────────────────────────
 
   @Post()
@@ -99,10 +110,7 @@ export class ShipmentsController {
     description: 'Batch shipments created successfully',
   })
   @ApiResponse({ status: 400, description: 'Validation error in batch data' })
-  batchCreate(
-    @CurrentUser() user: User,
-    @Body() dto: BatchCreateShipmentsDto,
-  ) {
+  batchCreate(@CurrentUser() user: User, @Body() dto: BatchCreateShipmentsDto) {
     return this.shipmentsService.batchCreate(user.id, dto);
   }
 
@@ -160,7 +168,9 @@ export class ShipmentsController {
   @Get('analytics')
   @UseGuards(RolesGuard)
   @Roles(UserRole.ADMIN, UserRole.SHIPPER)
-  @ApiOperation({ summary: 'Shipment analytics — admin sees all, shipper sees own' })
+  @ApiOperation({
+    summary: 'Shipment analytics — admin sees all, shipper sees own',
+  })
   getAnalytics(@CurrentUser() user: User, @Query() query: AnalyticsQueryDto) {
     return this.shipmentsService.getAnalytics(user, query);
   }

--- a/backend/src/shipments/shipments.service.ts
+++ b/backend/src/shipments/shipments.service.ts
@@ -16,6 +16,7 @@ import {
   LessThanOrEqual,
   SelectQueryBuilder,
 } from 'typeorm';
+import { CalculateCostDto } from './dto/calculate-cost.dto';
 import { AnalyticsQueryDto } from './dto/analytics-query.dto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { v4 as uuidv4 } from 'uuid';
@@ -27,6 +28,7 @@ import { QueryShipmentDto } from './dto/query-shipment.dto';
 import { BatchCreateShipmentsDto } from './dto/batch-create-shipments.dto';
 import { ExportShipmentsDto } from './dto/export-shipments.dto';
 import { ShipmentStatus } from '../common/enums/shipment-status.enum';
+import { CargoCategory } from '../common/enums/cargo-category.enum';
 import { UserRole } from '../common/enums/role.enum';
 import { User } from '../users/entities/user.entity';
 import {
@@ -109,6 +111,54 @@ export class ShipmentsService {
     private readonly historyRepo: Repository<ShipmentStatusHistory>,
     private readonly eventEmitter: EventEmitter2,
   ) {}
+
+  calculateCost(dto: CalculateCostDto) {
+    const BASE_RATE = 50;
+    const WEIGHT_RATE = 0.5;
+
+    const categoryMultipliers: Record<string, number> = {
+      [CargoCategory.HAZARDOUS]: 1.5,
+      [CargoCategory.PHARMACEUTICALS]: 1.4,
+      [CargoCategory.ELECTRONICS]: 1.3,
+      [CargoCategory.PERISHABLES]: 1.3,
+      [CargoCategory.AUTOMOTIVE]: 1.2,
+      [CargoCategory.MACHINERY]: 1.2,
+      [CargoCategory.FURNITURE]: 1.1,
+      [CargoCategory.TEXTILES]: 1.0,
+      [CargoCategory.FOOD_AND_BEVERAGE]: 1.1,
+      [CargoCategory.CONSTRUCTION_MATERIALS]: 1.1,
+      [CargoCategory.GENERAL_CARGO]: 1.0,
+    };
+
+    const multiplier = dto.cargoCategory
+      ? (categoryMultipliers[dto.cargoCategory] ?? 1.0)
+      : 1.0;
+
+    const originLower = dto.origin.toLowerCase();
+    const destinationLower = dto.destination.toLowerCase();
+    const sameCity = originLower === destinationLower;
+    const distance = sameCity
+      ? 1
+      : Math.max(originLower.length, destinationLower.length) * 0.5;
+
+    const weightCost = dto.weight * WEIGHT_RATE;
+    const categoryCost = BASE_RATE * (multiplier - 1);
+
+    const estimatedCost =
+      Math.round((BASE_RATE + distance + weightCost + categoryCost) * 100) /
+      100;
+
+    return {
+      estimatedCost,
+      currency: 'USD',
+      breakdown: {
+        base: BASE_RATE,
+        distance: Math.round(distance * 100) / 100,
+        weight: Math.round(weightCost * 100) / 100,
+        category: Math.round(categoryCost * 100) / 100,
+      },
+    };
+  }
 
   // ── Tracking number ──────────────────────────────────────────────────────────
 
@@ -376,7 +426,15 @@ export class ShipmentsService {
   }
 
   async findMarketplace(query: QueryShipmentDto): Promise<PaginatedShipments> {
-    const { page = 1, limit = 20, origin, destination, cargoCategory, minPrice, maxPrice } = query;
+    const {
+      page = 1,
+      limit = 20,
+      origin,
+      destination,
+      cargoCategory,
+      minPrice,
+      maxPrice,
+    } = query;
     const skip = (page - 1) * limit;
 
     const where: FindOptionsWhere<Shipment> = {
@@ -385,7 +443,8 @@ export class ShipmentsService {
     if (origin) where.origin = ILike(`%${origin}%`);
     if (destination) where.destination = ILike(`%${destination}%`);
     if (cargoCategory) where.cargoCategory = cargoCategory;
-    if (minPrice != null && maxPrice != null) where.price = Between(minPrice, maxPrice);
+    if (minPrice != null && maxPrice != null)
+      where.price = Between(minPrice, maxPrice);
     else if (minPrice != null) where.price = MoreThanOrEqual(minPrice);
     else if (maxPrice != null) where.price = LessThanOrEqual(maxPrice);
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,100 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Patch,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiProperty,
+  ApiPropertyOptional,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { User } from './entities/user.entity';
+import { UsersService } from './users.service';
+
+class UpdateMeDto {
+  @ApiPropertyOptional({ example: 'John' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  firstName?: string;
+
+  @ApiPropertyOptional({ example: 'Doe' })
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(50)
+  lastName?: string;
+
+  @ApiPropertyOptional({ example: 'GABCDE...XYZ' })
+  @IsOptional()
+  @IsString()
+  walletAddress?: string;
+}
+
+class OnboardingStatus {
+  @ApiProperty()
+  profileComplete: boolean;
+
+  @ApiProperty()
+  addressAdded: boolean;
+
+  @ApiProperty()
+  walletLinked: boolean;
+
+  @ApiProperty()
+  firstShipmentCreated: boolean;
+}
+
+@ApiTags('users')
+@ApiBearerAuth()
+@Controller('users')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get('me')
+  @ApiOperation({ summary: 'Get authenticated user profile' })
+  @ApiResponse({ status: 200, description: 'User profile returned' })
+  getMe(@CurrentUser() user: User) {
+    const { passwordHash: _ph, refreshToken: _rt, ...safeUser } = user;
+    return safeUser;
+  }
+
+  @Patch('me')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Update own profile (name, wallet — not role or email)',
+  })
+  @ApiResponse({ status: 200, description: 'Profile updated' })
+  async updateMe(@CurrentUser() user: User, @Body() dto: UpdateMeDto) {
+    const updated = await this.usersService.update(user.id, dto);
+    const { passwordHash: _ph, refreshToken: _rt, ...safeUser } = updated;
+    return safeUser;
+  }
+
+  @Get('me/onboarding')
+  @ApiOperation({ summary: 'Get computed onboarding status' })
+  @ApiResponse({ status: 200, description: 'Onboarding status' })
+  async getOnboarding(@CurrentUser() user: User): Promise<OnboardingStatus> {
+    const [hasAddress, hasWallet, hasShipment] = await Promise.all([
+      this.usersService.hasAddress(user.id),
+      Promise.resolve(!!user.walletAddress),
+      this.usersService.hasShipment(user.id),
+    ]);
+
+    return {
+      profileComplete: !!(user.firstName && user.lastName),
+      addressAdded: hasAddress,
+      walletLinked: hasWallet,
+      firstShipmentCreated: hasShipment,
+    };
+  }
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,10 +1,18 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UsersService } from './users.service';
+import { UsersController } from './users.controller';
+import { AuthModule } from '../auth/auth.module';
+import { Address } from '../addresses/entities/address.entity';
+import { Shipment } from '../shipments/entities/shipment.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [
+    TypeOrmModule.forFeature([User, Address, Shipment]),
+    forwardRef(() => AuthModule),
+  ],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -9,12 +9,18 @@ import * as bcrypt from 'bcrypt';
 import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
+import { Address } from '../addresses/entities/address.entity';
+import { Shipment } from '../shipments/entities/shipment.entity';
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(User)
     private readonly usersRepository: Repository<User>,
+    @InjectRepository(Address)
+    private readonly addressRepository: Repository<Address>,
+    @InjectRepository(Shipment)
+    private readonly shipmentRepository: Repository<Shipment>,
   ) {}
 
   async create(createUserDto: CreateUserDto): Promise<User> {
@@ -135,5 +141,19 @@ export class UsersService {
   async remove(id: string): Promise<void> {
     const user = await this.findOne(id);
     await this.usersRepository.remove(user);
+  }
+
+  async hasAddress(userId: string): Promise<boolean> {
+    const count = await this.addressRepository.count({
+      where: { userId },
+    });
+    return count > 0;
+  }
+
+  async hasShipment(userId: string): Promise<boolean> {
+    const count = await this.shipmentRepository.count({
+      where: { shipperId: userId },
+    });
+    return count > 0;
   }
 }

--- a/frontend/app/(dashboard)/admin/loading.tsx
+++ b/frontend/app/(dashboard)/admin/loading.tsx
@@ -1,0 +1,29 @@
+import { Skeleton, StatsCardSkeleton } from '../../../components/ui/skeleton';
+
+export default function AdminLoading() {
+  return (
+    <div className="p-8 space-y-8">
+      <div>
+        <Skeleton className="h-7 w-44" />
+        <Skeleton className="h-4 w-40 mt-1" />
+      </div>
+      <div className="flex gap-3">
+        <Skeleton className="h-8 w-32 rounded-md" />
+        <Skeleton className="h-8 w-32 rounded-md" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatsCardSkeleton />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/admin/shipments/loading.tsx
+++ b/frontend/app/(dashboard)/admin/shipments/loading.tsx
@@ -1,0 +1,46 @@
+import { Skeleton } from '../../../../components/ui/skeleton';
+
+export default function AdminShipmentsLoading() {
+  return (
+    <div className="p-8 space-y-6">
+      <div>
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-4 w-36 mt-1" />
+      </div>
+      <div className="flex gap-1 flex-wrap border-b border-border">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-5 w-16 rounded" />
+        ))}
+      </div>
+      <div className="rounded-xl border bg-card shadow">
+        <div className="p-6 pb-2 space-y-2">
+          <Skeleton className="h-5 w-24" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+        <div className="p-0">
+          <div className="border-b border-border bg-muted/50">
+            <div className="grid grid-cols-8 gap-4 px-4 py-3">
+              {Array.from({ length: 8 }).map((_, i) => (
+                <Skeleton key={i} className="h-3 w-16" />
+              ))}
+            </div>
+          </div>
+          <div className="divide-y divide-border">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="grid grid-cols-8 gap-4 items-center px-4 py-3">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-32" />
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-5 w-16 rounded-full" />
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-6 w-12 rounded-md ml-auto" />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/admin/users/loading.tsx
+++ b/frontend/app/(dashboard)/admin/users/loading.tsx
@@ -1,0 +1,44 @@
+import { Skeleton, UserTableRowSkeleton } from '../../../../components/ui/skeleton';
+
+export default function AdminUsersLoading() {
+  return (
+    <div className="p-8 space-y-6">
+      <div>
+        <Skeleton className="h-7 w-44" />
+        <Skeleton className="h-4 w-32 mt-1" />
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <div className="flex gap-1 border border-border rounded-md overflow-hidden">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-20 rounded-none" />
+          ))}
+        </div>
+        <div className="flex gap-1 border border-border rounded-md overflow-hidden">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-8 w-16 rounded-none" />
+          ))}
+        </div>
+      </div>
+      <div className="rounded-xl border bg-card shadow">
+        <div className="p-6 pb-2 space-y-2">
+          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-3 w-28" />
+        </div>
+        <div className="p-0">
+          <div className="border-b border-border bg-muted/50">
+            <div className="grid grid-cols-6 gap-4 px-4 py-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <Skeleton key={i} className="h-3 w-16" />
+              ))}
+            </div>
+          </div>
+          <div className="divide-y divide-border">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <UserTableRowSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/dashboard/loading.tsx
+++ b/frontend/app/(dashboard)/dashboard/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton, StatsCardSkeleton, ShipmentCardSkeleton } from '../../../components/ui/skeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+        <Skeleton className="h-9 w-32 rounded-md" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <StatsCardSkeleton key={i} />
+        ))}
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <ShipmentCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/marketplace/loading.tsx
+++ b/frontend/app/(dashboard)/marketplace/loading.tsx
@@ -1,0 +1,28 @@
+import { Skeleton, ShipmentCardSkeleton } from '../../../components/ui/skeleton';
+
+export default function MarketplaceLoading() {
+  return (
+    <div className="p-6 max-w-6xl mx-auto">
+      <div className="mb-6">
+        <Skeleton className="h-7 w-36" />
+        <Skeleton className="h-4 w-72 mt-1" />
+      </div>
+      <div className="mb-6 space-y-3">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-9 w-36 rounded-md" />
+          <Skeleton className="h-9 w-36 rounded-md" />
+          <Skeleton className="h-9 w-32 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+          <Skeleton className="h-9 w-40 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <ShipmentCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/shipments/[id]/loading.tsx
+++ b/frontend/app/(dashboard)/shipments/[id]/loading.tsx
@@ -1,0 +1,78 @@
+import { Skeleton } from '../../../../components/ui/skeleton';
+
+export default function ShipmentDetailLoading() {
+  return (
+    <div className="p-6 max-w-4xl mx-auto space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton className="h-3 w-16" />
+          <Skeleton className="h-6 w-48" />
+          <Skeleton className="h-4 w-64" />
+        </div>
+        <Skeleton className="h-5 w-20 rounded-full" />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2 space-y-4">
+          <div className="rounded-xl border bg-card shadow p-6 space-y-3">
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-3 w-full" />
+            <div className="grid grid-cols-2 gap-2">
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-16" />
+                <Skeleton className="h-4 w-20" />
+              </div>
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-4 w-16" />
+              </div>
+            </div>
+          </div>
+          <div className="rounded-xl border bg-card shadow p-6 space-y-3">
+            <Skeleton className="h-5 w-16" />
+            <div className="space-y-2">
+              <div className="flex justify-between">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+              <div className="flex justify-between">
+                <Skeleton className="h-4 w-16" />
+                <Skeleton className="h-4 w-28" />
+              </div>
+            </div>
+          </div>
+          <div className="rounded-xl border bg-card shadow p-6 space-y-3">
+            <Skeleton className="h-5 w-16" />
+            <div className="flex flex-wrap gap-2">
+              <Skeleton className="h-8 w-24 rounded-md" />
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+          </div>
+        </div>
+        <div>
+          <div className="rounded-xl border bg-card shadow p-6 space-y-3">
+            <Skeleton className="h-5 w-32" />
+            <div className="space-y-4">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div key={i} className="flex gap-3 items-start">
+                  <Skeleton className="h-3 w-3 rounded-full shrink-0 mt-1" />
+                  <div className="space-y-1 flex-1">
+                    <Skeleton className="h-3 w-24" />
+                    <Skeleton className="h-3 w-16" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/shipments/loading.tsx
+++ b/frontend/app/(dashboard)/shipments/loading.tsx
@@ -1,0 +1,25 @@
+import { Skeleton, ShipmentCardSkeleton } from '../../../components/ui/skeleton';
+
+export default function ShipmentsLoading() {
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <Skeleton className="h-7 w-40" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-24 rounded-md" />
+          <Skeleton className="h-8 w-32 rounded-md" />
+        </div>
+      </div>
+      <div className="flex gap-1 mb-6 border-b border-border">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-5 w-16 rounded" />
+        ))}
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <ShipmentCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -125,6 +125,12 @@
     font-family: var(--font-geist-mono), "Courier New", monospace;
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .animate-pulse {
+      animation: none;
+    }
+  }
+
   /* Hide all scrollbars but keep functionality */
   * {
     scrollbar-width: none; /* Firefox */

--- a/frontend/components/ui/skeleton.tsx
+++ b/frontend/components/ui/skeleton.tsx
@@ -1,15 +1,20 @@
+import * as React from 'react';
 import { cn } from '../../lib/utils';
 
-export function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return (
+const Skeleton = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
     <div
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      ref={ref}
+      className={cn(
+        'animate-pulse rounded-md bg-muted',
+        className,
+      )}
       {...props}
     />
-  );
-}
+  ),
+);
+Skeleton.displayName = 'Skeleton';
 
-/** Skeleton for a shipment card */
 export function ShipmentCardSkeleton() {
   return (
     <div className="rounded-xl border bg-card shadow p-6 space-y-3">
@@ -30,7 +35,6 @@ export function ShipmentCardSkeleton() {
   );
 }
 
-/** Skeleton for a shipment table row */
 export function ShipmentTableRowSkeleton() {
   return (
     <div className="flex items-center gap-4 px-4 py-3 border-b">
@@ -43,7 +47,6 @@ export function ShipmentTableRowSkeleton() {
   );
 }
 
-/** Skeleton for a user table row */
 export function UserTableRowSkeleton() {
   return (
     <div className="flex items-center gap-4 px-4 py-3 border-b">
@@ -58,7 +61,6 @@ export function UserTableRowSkeleton() {
   );
 }
 
-/** Skeleton for a stats card */
 export function StatsCardSkeleton() {
   return (
     <div className="rounded-xl border bg-card shadow p-6 space-y-2">
@@ -68,3 +70,5 @@ export function StatsCardSkeleton() {
     </div>
   );
 }
+
+export { Skeleton };


### PR DESCRIPTION
## Summary

- **BE-37** (#1084): Create UsersController with `GET /users/me`, `PATCH /users/me`, and `GET /users/me/onboarding` with computed onboarding status.
- **BE-36** (#1083): Add `POST /shipments/calculate-cost` with pricing formula (base + distance + weight + category multiplier).
- **BE-49** (#1096): Add Stripe payment integration with checkout session creation, webhook handler, and invoice entity.
- **FE-76** (#1200): Add loading skeletons for 7 dashboard routes with Skeleton component and prefers-reduced-motion support.

Closes #1084
Closes #1083
Closes #1096
Closes #1200