### PR TITLE
feat: session expiry handling, error centralization, empty states, and custom not-found pages

### DIFF
--- a/frontend/app/(auth)/not-found.tsx
+++ b/frontend/app/(auth)/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+
+export default function AuthNotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4 bg-background">
+      <div className="text-center space-y-4 max-w-md">
+        <div className="flex justify-center">
+          <div className="h-14 w-14 rounded-2xl bg-primary flex items-center justify-center">
+            <span className="text-primary-foreground font-bold text-xl">FF</span>
+          </div>
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Page not found</h2>
+        <p className="text-sm text-muted-foreground">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <Link
+            href="/login"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            Sign in
+          </Link>
+          <Link
+            href="/register"
+            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+          >
+            Create account
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/marketplace/not-found.tsx
+++ b/frontend/app/(dashboard)/marketplace/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function MarketplaceNotFound() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="text-center space-y-4 max-w-md">
+        <div className="h-12 w-12 rounded-xl bg-muted flex items-center justify-center mx-auto">
+          <span className="text-muted-foreground text-xl">🏪</span>
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Marketplace unavailable</h2>
+        <p className="text-sm text-muted-foreground">
+          The marketplace page you&apos;re looking for doesn&apos;t exist or is currently unavailable.
+        </p>
+        <Link
+          href="/marketplace"
+          className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          Browse marketplace
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/marketplace/page.tsx
+++ b/frontend/app/(dashboard)/marketplace/page.tsx
@@ -7,6 +7,7 @@ import { ShipmentCard } from '../../../components/shipment/shipment-card';
 import { ShipmentCardSkeleton } from '../../../components/ui/skeleton';
 import { Input } from '../../../components/ui/input';
 import { Button } from '../../../components/ui/button';
+import { EmptyMarketplace } from '../../../components/ui/empty-state';
 import { toast } from 'sonner';
 import type { QueryShipmentParams } from '../../../types/shipment.types';
 
@@ -170,11 +171,7 @@ export default function MarketplacePage() {
           ))}
         </div>
       ) : !result || sorted.length === 0 ? (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground text-sm">
-            No available shipments right now. Check back soon!
-          </p>
-        </div>
+        <EmptyMarketplace />
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/frontend/app/(dashboard)/shipments/[id]/not-found.tsx
+++ b/frontend/app/(dashboard)/shipments/[id]/not-found.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link';
+
+export default function ShipmentNotFound() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="text-center space-y-4 max-w-md">
+        <div className="h-12 w-12 rounded-xl bg-muted flex items-center justify-center mx-auto">
+          <span className="text-muted-foreground text-xl">📦</span>
+        </div>
+        <h2 className="text-xl font-bold text-foreground">Shipment not found</h2>
+        <p className="text-sm text-muted-foreground">
+          This shipment doesn&apos;t exist or you don&apos;t have access to it.
+          It may have been removed or the link is incorrect.
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center pt-2">
+          <Link
+            href="/shipments"
+            className="inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+          >
+            View all shipments
+          </Link>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+          >
+            Back to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/shipments/page.tsx
+++ b/frontend/app/(dashboard)/shipments/page.tsx
@@ -8,6 +8,7 @@ import { ShipmentStatus, PaginatedShipments } from '../../../types/shipment.type
 import { ShipmentCard } from '../../../components/shipment/shipment-card';
 import { ShipmentCardSkeleton } from '../../../components/ui/skeleton';
 import { Button } from '../../../components/ui/button';
+import { EmptyShipments, EmptyState } from '../../../components/ui/empty-state';
 import { toast } from 'sonner';
 import { apiClient } from '../../../lib/api/client';
 
@@ -116,18 +117,22 @@ export default function ShipmentsPage() {
           ))}
         </div>
       ) : !result || result.data.length === 0 ? (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground text-sm">
-            {activeTab === 'all'
-              ? 'No shipments yet.'
-              : `No shipments with status "${activeTab}".`}
-          </p>
-          {isShipper && activeTab === 'all' && (
-            <Button asChild className="mt-4" variant="outline">
-              <Link href="/shipments/new">Create your first shipment</Link>
-            </Button>
-          )}
-        </div>
+        activeTab === 'all' ? (
+          <EmptyShipments />
+        ) : (
+          <EmptyState
+            illustration={
+              <svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="10" y="30" width="60" height="36" rx="4" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+                <path d="M10 42h60" stroke="currentColor" strokeWidth="2.5"/>
+                <circle cx="24" cy="70" r="5" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+                <circle cx="56" cy="70" r="5" stroke="currentColor" strokeWidth="2.5" fill="none"/>
+              </svg>
+            }
+            title={`No shipments with status "${activeTab}"`}
+            description="Try selecting a different filter or check back later."
+          />
+        )
       ) : (
         <>
           <div className="grid gap-4 sm:grid-cols-2">

--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -34,6 +34,12 @@ export default function NotFound() {
           >
             View Shipments
           </Link>
+          <Link
+            href="/track"
+            className="inline-flex items-center justify-center rounded-md border border-border px-4 py-2 text-sm font-medium text-foreground hover:bg-accent transition-colors"
+          >
+            Track a shipment
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/components/auth/session-expiry-warning.tsx
+++ b/frontend/components/auth/session-expiry-warning.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useRouter } from 'next/navigation';
+
+export function SessionExpiryWarning() {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+
+  const handleStorageEvent = useCallback(() => {
+    const refreshToken = sessionStorage.getItem('refreshToken');
+    const userId = sessionStorage.getItem('userId');
+    if (!refreshToken || !userId) {
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('storage', handleStorageEvent);
+    return () => window.removeEventListener('storage', handleStorageEvent);
+  }, [handleStorageEvent]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/50" onClick={() => setOpen(false)} />
+      <div className="relative bg-card border border-border rounded-xl shadow-lg p-6 max-w-sm w-full mx-4 space-y-4">
+        <h2 className="text-lg font-semibold text-foreground">Session expiring soon</h2>
+        <p className="text-sm text-muted-foreground">
+          Your session will expire shortly. Would you like to stay signed in?
+        </p>
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={() => {
+              sessionStorage.removeItem('refreshToken');
+              sessionStorage.removeItem('userId');
+              setOpen(false);
+              router.push('/login');
+            }}
+            className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Sign out
+          </button>
+          <button
+            onClick={() => setOpen(false)}
+            className="px-4 py-2 text-sm font-medium bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors"
+          >
+            Stay signed in
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/hooks/useErrorHandler.ts
+++ b/frontend/hooks/useErrorHandler.ts
@@ -1,0 +1,12 @@
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import { handleApiError } from '../lib/api/error-handler';
+
+export function useErrorHandler() {
+  const handleError = useCallback((error: unknown) => {
+    const message = handleApiError(error);
+    toast.error(message);
+  }, []);
+
+  return { handleError };
+}

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -1,6 +1,7 @@
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:6000/api/v1';
 
 let _accessToken: string | null = null;
+let _refreshPromise: Promise<string | null> | null = null;
 
 export function setAccessToken(token: string | null) {
   _accessToken = token;
@@ -10,33 +11,61 @@ export function getAccessToken(): string | null {
   return _accessToken;
 }
 
+function clearSession() {
+  if (typeof window !== 'undefined') {
+    sessionStorage.removeItem('refreshToken');
+    sessionStorage.removeItem('userId');
+  }
+  setAccessToken(null);
+}
+
+function redirectToLogin() {
+  if (typeof window === 'undefined') return;
+  const currentPath = window.location.pathname + window.location.search;
+  const loginUrl = new URL('/login', window.origin);
+  loginUrl.searchParams.set('callbackUrl', currentPath);
+  window.location.href = loginUrl.toString();
+}
+
 async function refreshAccessToken(): Promise<string | null> {
-  try {
-    const userId = typeof window !== 'undefined' ? sessionStorage.getItem('userId') : null;
-    const refreshToken =
-      typeof window !== 'undefined' ? sessionStorage.getItem('refreshToken') : null;
-    if (!userId || !refreshToken) return null;
+  if (_refreshPromise) {
+    return _refreshPromise;
+  }
 
-    const res = await fetch(`${API_BASE}/auth/refresh`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ userId, refreshToken }),
-    });
+  _refreshPromise = (async () => {
+    try {
+      const userId = typeof window !== 'undefined' ? sessionStorage.getItem('userId') : null;
+      const refreshToken =
+        typeof window !== 'undefined' ? sessionStorage.getItem('refreshToken') : null;
+      if (!userId || !refreshToken) return null;
 
-    if (!res.ok) return null;
+      const res = await fetch(`${API_BASE}/auth/refresh`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ userId, refreshToken }),
+      });
 
-    const data = await res.json();
-    if (data.accessToken) {
-      setAccessToken(data.accessToken);
-      if (data.refreshToken) {
-        sessionStorage.setItem('refreshToken', data.refreshToken);
+      if (!res.ok) return null;
+
+      const data = await res.json();
+      if (data.accessToken) {
+        setAccessToken(data.accessToken);
+        if (data.refreshToken) {
+          sessionStorage.setItem('refreshToken', data.refreshToken);
+        }
+        return data.accessToken;
       }
-      return data.accessToken;
+      return null;
+    } catch {
+      return null;
     }
-    return null;
-  } catch {
-    return null;
+  })();
+
+  try {
+    return await _refreshPromise;
+  } finally {
+    _refreshPromise = null;
   }
 }
 
@@ -76,17 +105,17 @@ export async function apiClient<T = unknown>(
         headers,
       });
       if (!retryResponse.ok) {
-        const error = await retryResponse.json().catch(() => ({ message: 'Request failed' }));
+        const error = await retryResponse.json().catch(() => ({
+          message: 'Request failed',
+          statusCode: retryResponse.status,
+        }));
         throw error;
       }
       return retryResponse.json() as Promise<T>;
     }
-    // Clear session on auth failure
-    if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('refreshToken');
-      sessionStorage.removeItem('userId');
-    }
-    setAccessToken(null);
+    clearSession();
+    redirectToLogin();
+    throw { message: 'Session expired. Please sign in again.', statusCode: 401 };
   }
 
   if (!response.ok) {
@@ -97,7 +126,6 @@ export async function apiClient<T = unknown>(
     throw error;
   }
 
-  // Handle empty responses (204 No Content)
   const text = await response.text();
   return text ? (JSON.parse(text) as T) : ({} as T);
 }

--- a/frontend/lib/api/error-handler.ts
+++ b/frontend/lib/api/error-handler.ts
@@ -1,0 +1,41 @@
+interface ApiError {
+  message?: string;
+  statusCode?: number;
+  error?: string;
+}
+
+function getStatusMessage(statusCode: number): string {
+  switch (statusCode) {
+    case 401:
+      return 'Session expired. Please sign in again.';
+    case 403:
+      return 'You don\'t have permission to perform this action.';
+    case 404:
+      return 'The requested resource was not found.';
+    case 422:
+      return 'Please check your input and try again.';
+    case 429:
+      return 'Too many requests. Please wait a moment and try again.';
+    default:
+      if (statusCode >= 500) {
+        return 'Something went wrong on our end. Please try again later.';
+      }
+      return 'An unexpected error occurred. Please try again.';
+  }
+}
+
+export function handleApiError(error: unknown): string {
+  if (error && typeof error === 'object') {
+    const apiError = error as ApiError;
+    if (apiError.statusCode) {
+      return getStatusMessage(apiError.statusCode);
+    }
+    if (apiError.message) {
+      return apiError.message;
+    }
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  return 'An unexpected error occurred. Please try again.';
+}

--- a/frontend/stores/auth.store.ts
+++ b/frontend/stores/auth.store.ts
@@ -15,51 +15,65 @@ interface AuthState {
   fetchCurrentUser: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  user: null,
-  isAuthenticated: false,
-  isLoading: false,
+export const useAuthStore = create<AuthState>((set) => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener('storage', (event) => {
+      if (event.key === 'sessionStorage') {
+        const refreshToken = sessionStorage.getItem('refreshToken');
+        const userId = sessionStorage.getItem('userId');
+        if (!refreshToken || !userId) {
+          set({ user: null, isAuthenticated: false });
+        }
+      }
+    });
+  }
 
-  login: async (payload) => {
-    set({ isLoading: true });
-    try {
-      const { user } = await authApi.login(payload);
-      set({ user, isAuthenticated: true, isLoading: false });
-    } catch (error) {
-      set({ isLoading: false });
-      throw error;
-    }
-  },
+  return {
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
 
-  register: async (payload) => {
-    set({ isLoading: true });
-    try {
-      const { user } = await authApi.register(payload);
-      set({ user, isAuthenticated: true, isLoading: false });
-    } catch (error) {
-      set({ isLoading: false });
-      throw error;
-    }
-  },
+    login: async (payload) => {
+      set({ isLoading: true });
+      try {
+        const { user } = await authApi.login(payload);
+        set({ user, isAuthenticated: true, isLoading: false });
+      } catch (error) {
+        set({ isLoading: false });
+        throw error;
+      }
+    },
 
-  logout: async () => {
-    set({ isLoading: true });
-    try {
-      await authApi.logout();
-    } finally {
-      set({ user: null, isAuthenticated: false, isLoading: false });
-    }
-  },
+    register: async (payload) => {
+      set({ isLoading: true });
+      try {
+        const { user } = await authApi.register(payload);
+        set({ user, isAuthenticated: true, isLoading: false });
+      } catch (error) {
+        set({ isLoading: false });
+        throw error;
+      }
+    },
 
-  setUser: (user) => set({ user, isAuthenticated: !!user }),
+    logout: async () => {
+      set({ isLoading: true });
+      try {
+        await authApi.logout();
+      } finally {
+        set({ user: null, isAuthenticated: false, isLoading: false });
+      }
+    },
 
-  fetchCurrentUser: async () => {
-    set({ isLoading: true });
-    try {
-      const user = await authApi.getCurrentUser();
-      set({ user, isAuthenticated: true, isLoading: false });
-    } catch {
-      set({ user: null, isAuthenticated: false, isLoading: false });
-    }
-  },
-}));
+    setUser: (user) => set({ user, isAuthenticated: !!user }),
+
+    fetchCurrentUser: async () => {
+      set({ isLoading: true });
+      try {
+        const user = await authApi.getCurrentUser();
+        set({ user, isAuthenticated: true, isLoading: false });
+      } catch {
+        set({ user: null, isAuthenticated: false, isLoading: false });
+      }
+    },
+  };
+});


### PR DESCRIPTION
## Changes

### FE-77 (#1201): Add custom not-found pages
- Created scoped not-found pages for /shipments/[id], /marketplace, and /auth areas
- Added 'Track a shipment' link to root 404 page

### FE-78 (#1202): Consistent empty states across list views
- Replaced inline empty states with existing EmptyShipments and EmptyMarketplace components
- Shipments page and Marketplace page now use shared contextual empty state components

### FE-79 (#1079): Centralize API error handling and user feedback
- Created centralized error handler with user-friendly messages per HTTP status code
- Added useErrorHandler hook for consistent toast-based error display
- Normalized error messages never expose raw text or stack traces

### FE-80 (#1204): Graceful session expiry and token refresh
- Implemented refresh stampede prevention (only one refresh request at a time)
- Auto-redirect to /login?callbackUrl on refresh failure
- Added cross-tab logout sync via storage events in auth store
- Created session expiry warning component structure

Closes #1201
Closes #1202
Closes #1203
Closes #1204