### PR TITLE
Add structured

### DIFF
--- a/backend/src/shipments/structure.ts
+++ b/backend/src/shipments/structure.ts
@@ -1,0 +1,70 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Shipment } from './entities/shipment.entity';
+import { ShipmentStatus } from '../common/enums/shipment-status.enum';
+
+const FEE_TIERS: Partial<Record<ShipmentStatus, number>> = {
+  [ShipmentStatus.PENDING]: 0,
+  [ShipmentStatus.ACCEPTED]: 0.1,
+  [ShipmentStatus.IN_TRANSIT]: 0.25,
+};
+
+const CANCELLABLE = new Set<ShipmentStatus>([
+  ShipmentStatus.PENDING,
+  ShipmentStatus.ACCEPTED,
+  ShipmentStatus.IN_TRANSIT,
+]);
+
+export interface CancellationResult {
+  shipmentId: string;
+  cancellationFee: number;
+  currency: string;
+  status: ShipmentStatus.CANCELLED;
+}
+
+@Injectable()
+export class StructureService {
+  constructor(
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  calculateFee(price: number, status: ShipmentStatus): number {
+    const rate = FEE_TIERS[status] ?? null;
+    if (rate === null)
+      throw new BadRequestException(
+        `Shipment in status "${status}" cannot be cancelled`,
+      );
+    return Math.round(price * rate * 100) / 100;
+  }
+
+  async cancelShipment(shipmentId: string): Promise<CancellationResult> {
+    const shipment = await this.shipmentRepo.findOneOrFail({
+      where: { id: shipmentId },
+    });
+
+    if (!CANCELLABLE.has(shipment.status)) {
+      throw new BadRequestException(
+        `Cannot cancel a shipment with status "${shipment.status}"`,
+      );
+    }
+
+    const cancellationFee = this.calculateFee(
+      Number(shipment.price),
+      shipment.status,
+    );
+
+    await this.shipmentRepo.update(shipmentId, {
+      status: ShipmentStatus.CANCELLED,
+      notes: `Cancellation fee: ${cancellationFee} ${shipment.currency}`,
+    });
+
+    return {
+      shipmentId,
+      cancellationFee,
+      currency: shipment.currency,
+      status: ShipmentStatus.CANCELLED,
+    };
+  }
+}


### PR DESCRIPTION
 [FE-75] Add error boundaries — only 2 exist across 28 pages
Overview
frontend/app/ contains 28 pages but only 2 error.tsx/loading.tsx/not-found.tsx files in total. A thrown render error in most routes escapes to Next's default screen — in production, a blank page with no recovery path.

Tasks
 Add error.tsx to each route group: (auth), (dashboard), (dashboard)/admin, (dashboard)/shipments, plus the root.
 Add a root global-error.tsx for layout-level failures.
 Each boundary shows a friendly message, a "Try again" button calling reset(), and a link home — never a raw stack trace in production.
 Log caught errors in development with enough context to debug.
closes #1199
closes #1198 