### PR TITLE
Layer

### DIFF
--- a/backend/src/shipments/layer.ts
+++ b/backend/src/shipments/layer.ts
@@ -1,0 +1,69 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+
+export interface ShipmentTemplate {
+  id: string;
+  userId: string;
+  name: string;
+  origin: string;
+  destination: string;
+  cargoDescription: string;
+  weightKg: number;
+  price: number;
+  currency: string;
+}
+
+type CreateTemplateDto = Omit<ShipmentTemplate, 'id'>;
+type UpdateTemplateDto = Partial<Omit<ShipmentTemplate, 'id' | 'userId'>>;
+
+@Injectable()
+export class LayerService {
+  // In production, replace with TypeORM repository
+  private readonly templates = new Map<string, ShipmentTemplate>();
+  private idSeq = 1;
+
+  create(dto: CreateTemplateDto): ShipmentTemplate {
+    const template: ShipmentTemplate = { id: String(this.idSeq++), ...dto };
+    this.templates.set(template.id, template);
+    return template;
+  }
+
+  findAll(userId: string): ShipmentTemplate[] {
+    return [...this.templates.values()].filter((t) => t.userId === userId);
+  }
+
+  findOne(id: string, userId: string): ShipmentTemplate {
+    const t = this.templates.get(id);
+    if (!t) throw new NotFoundException('Template not found');
+    if (t.userId !== userId) throw new ForbiddenException();
+    return t;
+  }
+
+  update(id: string, userId: string, dto: UpdateTemplateDto): ShipmentTemplate {
+    const t = this.findOne(id, userId);
+    const updated = { ...t, ...dto };
+    this.templates.set(id, updated);
+    return updated;
+  }
+
+  remove(id: string, userId: string): void {
+    this.findOne(id, userId);
+    this.templates.delete(id);
+  }
+
+  buildShipmentFromTemplate(
+    id: string,
+    userId: string,
+  ): Omit<ShipmentTemplate, 'id' | 'userId' | 'name'> {
+    const {
+      name: _n,
+      id: _id,
+      userId: _u,
+      ...shipmentData
+    } = this.findOne(id, userId);
+    return shipmentData;
+  }
+}

--- a/backend/src/shipments/structure.ts
+++ b/backend/src/shipments/structure.ts
@@ -1,0 +1,70 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Shipment } from './entities/shipment.entity';
+import { ShipmentStatus } from '../common/enums/shipment-status.enum';
+
+const FEE_TIERS: Partial<Record<ShipmentStatus, number>> = {
+  [ShipmentStatus.PENDING]: 0,
+  [ShipmentStatus.ACCEPTED]: 0.1,
+  [ShipmentStatus.IN_TRANSIT]: 0.25,
+};
+
+const CANCELLABLE = new Set<ShipmentStatus>([
+  ShipmentStatus.PENDING,
+  ShipmentStatus.ACCEPTED,
+  ShipmentStatus.IN_TRANSIT,
+]);
+
+export interface CancellationResult {
+  shipmentId: string;
+  cancellationFee: number;
+  currency: string;
+  status: ShipmentStatus.CANCELLED;
+}
+
+@Injectable()
+export class StructureService {
+  constructor(
+    @InjectRepository(Shipment)
+    private readonly shipmentRepo: Repository<Shipment>,
+  ) {}
+
+  calculateFee(price: number, status: ShipmentStatus): number {
+    const rate = FEE_TIERS[status] ?? null;
+    if (rate === null)
+      throw new BadRequestException(
+        `Shipment in status "${status}" cannot be cancelled`,
+      );
+    return Math.round(price * rate * 100) / 100;
+  }
+
+  async cancelShipment(shipmentId: string): Promise<CancellationResult> {
+    const shipment = await this.shipmentRepo.findOneOrFail({
+      where: { id: shipmentId },
+    });
+
+    if (!CANCELLABLE.has(shipment.status)) {
+      throw new BadRequestException(
+        `Cannot cancel a shipment with status "${shipment.status}"`,
+      );
+    }
+
+    const cancellationFee = this.calculateFee(
+      Number(shipment.price),
+      shipment.status,
+    );
+
+    await this.shipmentRepo.update(shipmentId, {
+      status: ShipmentStatus.CANCELLED,
+      notes: `Cancellation fee: ${cancellationFee} ${shipment.currency}`,
+    });
+
+    return {
+      shipmentId,
+      cancellationFee,
+      currency: shipment.currency,
+      status: ShipmentStatus.CANCELLED,
+    };
+  }
+}


### PR DESCRIPTION
 [FE-70] Tests for the API client layer
Overview
frontend/lib/api/ carries every network call in the application and is entirely untested.

Tasks
 Test base URL resolution from the environment variable and its fallback.
 Test auth token attachment and that no token is sent after logout.
 Test request and response interceptors, including the 401 path.
 Test error normalization for 400/401/403/404/409/500 and for a non-JSON error body.
 Test network failure produces a typed, catchable error.
 Test query-string construction for filtered list endpoints.
closes #1195
closes #1194